### PR TITLE
chore(libadwaita): add explicit dependency on 1.7

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -19,7 +19,7 @@ bz_sources = [
 bz_deps = [
   cc.find_library('m', required: false),
   dependency('gtk4'),
-  dependency('libadwaita-1', version: '>= 1.4'),
+  dependency('libadwaita-1', version: '>= 1.7'),
   dependency('libdex-1', version: '>= 0.9'),
   dependency('flatpak', version: '>= 1.9'),
   dependency('appstream', version : '>= 1.0'),


### PR DESCRIPTION

Tried packaging this for CentOS Stream 10, which has libadwaita 1.6.6 and the Search screen fails because of:

```
(bazaar:7579): Gtk-CRITICAL **: 13:55:43.339: Error building template class 'BzS
earchWidget' for an instance of type 'BzSearchWidget': .:0:0 Invalid property: A
dwBottomSheet.reveal-bottom-bar
```

Which is a property that got added on [Libadwaita 1.7](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1-latest/property.BottomSheet.reveal-bottom-bar.html). So lets depend on 1.7+!
