### PR TITLE
feat: Add initial devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:25.04
+
+RUN userdel -f -r ubuntu
+
+RUN apt-get update && apt-get install -y \
+    appstream \
+    bash-completion \
+    build-essential \
+    cmake \
+    gettext \
+    git \
+    libadwaita-1-dev \
+    libdex-dev \
+    libflatpak-dev \
+    libglycin-1-dev \
+    libglycin-gtk4-1-dev \
+    libgtk-4-dev \
+    liblcms2-dev \
+    libxmlb-dev \
+    meson \
+    ninja-build

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+	"name": "Bazaar devcontainer",
+
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils:2": {
+			"installZsh": "false",
+			"username": "vscode",
+			"userUid": "1000",
+			"userGid": "1000",
+			"upgradePackages": "true"
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	},
+
+	"remoteUser": "vscode",
+
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools-extension-pack"
+			]
+		}
+	},
+
+	// Wayland support
+	"containerEnv": {
+		"WAYLAND_DISPLAY": "${localEnv:WAYLAND_DISPLAY}",
+		"XDG_RUNTIME_DIR": "${localEnv:XDG_RUNTIME_DIR}",
+		"XDG_SESSION_TYPE": "${localEnv:XDG_SESSION_TYPE}"
+	},
+
+	"mounts": [
+		"source=${localEnv:XDG_RUNTIME_DIR},target=${localEnv:XDG_RUNTIME_DIR},type=bind,consistency=cached"
+	]
+}


### PR DESCRIPTION
This PR adds initial support to develop bazaar through a devcontainer. This allows easier contributions and dev environment from immutable distros like bluefin. 

The dockerfile is required because ubuntu 24.04 doesn't have all the required libs to build it. Hence, ubuntu 25.04 is used.

It needs more work around flatpak to either bind to the host flatpak or make flatpak work properly inside the container to allow testing. Since wayland passthrough is enabled it's possible to launch bazaar as expected through the README after building it.