### PR TITLE
feat: add flatpak manifest

### DIFF
--- a/build-aux/flatpak/flatpak-bwrap-wrapper.sh
+++ b/build-aux/flatpak/flatpak-bwrap-wrapper.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+echo "Running flatpak-bwrap wrapper, redirecting to host..."
+export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/flatpak/bus
+
+# Inspect which fds are currently opened, and forward them to the host side.
+echo "Open file descriptors:"
+ls -l /proc/$$/fd
+
+fds=""
+for fd in $(ls /proc/$$/fd); do
+  case "$fd" in
+    0|1|2|3|255)
+      ;;
+    *)
+      fds="${fds} --forward-fd=$fd"
+      echo "Forwarding fd $fd"
+      ;;
+  esac
+done
+
+# Test if the `bwrap` command is available
+echo "Checking if bwrap is available on host system..."
+flatpak-spawn --host bwrap --version
+retval=$?
+
+if [ $retval -eq 0 ]; then
+  echo "Using bwrap."
+  binary="bwrap"
+else
+  echo "Unable to execute bwrap, falling back to flatpak-bwrap."
+  binary="flatpak-bwrap"
+fi
+
+# The actual call on the host side
+echo "Executing actual command on host system using flatpak-spawn..."
+exec flatpak-spawn --host $fds $binary "$@"

--- a/build-aux/flatpak/fuse-2.9.2-closefrom.patch
+++ b/build-aux/flatpak/fuse-2.9.2-closefrom.patch
@@ -1,0 +1,20 @@
+--- fuse-2.9.2/util/ulockmgr_server.c.closefromfix	2019-01-04 05:33:33.000000000 -0800
++++ fuse-2.9.2/util/ulockmgr_server.c	2022-07-12 12:29:56.445402244 -0700
+@@ -124,7 +124,7 @@
+ 	return res;
+ }
+
+-static int closefrom(int minfd)
++static int _closefrom(int minfd)
+ {
+ 	DIR *dir = opendir("/proc/self/fd");
+ 	if (dir) {
+@@ -384,7 +384,7 @@
+ 		dup2(nullfd, 1);
+ 	}
+ 	close(3);
+-	closefrom(5);
++	_closefrom(5);
+ 	while (1) {
+ 		char c;
+ 		int sock;

--- a/build-aux/flatpak/fuse-2.9.2-namespace-conflict-fix.patch
+++ b/build-aux/flatpak/fuse-2.9.2-namespace-conflict-fix.patch
@@ -1,0 +1,21 @@
+diff -up fuse-2.9.2/include/fuse_kernel.h.conflictfix fuse-2.9.2/include/fuse_kernel.h
+--- fuse-2.9.2/include/fuse_kernel.h.conflictfix	2013-06-26 09:31:57.862198038 -0400
++++ fuse-2.9.2/include/fuse_kernel.h	2013-06-26 09:32:19.679198365 -0400
+@@ -88,12 +88,16 @@
+ #ifndef _LINUX_FUSE_H
+ #define _LINUX_FUSE_H
+
+-#include <sys/types.h>
++#ifdef __linux__
++#include <linux/types.h>
++#else
++#include <stdint.h>
+ #define __u64 uint64_t
+ #define __s64 int64_t
+ #define __u32 uint32_t
+ #define __s32 int32_t
+ #define __u16 uint16_t
++#endif
+
+ /*
+  * Version negotiation:

--- a/build-aux/flatpak/fuse-disable-sys-mount-under-flatpak.patch
+++ b/build-aux/flatpak/fuse-disable-sys-mount-under-flatpak.patch
@@ -1,0 +1,26 @@
+From 1ec935f4abecd08957affc7b21bae6bf5be78931 Mon Sep 17 00:00:00 2001
+From: Christian Hergert <chergert@redhat.com>
+Date: Thu, 12 Apr 2018 01:47:57 -0700
+Subject: [PATCH] libfuse: disable sys mount under flatpak
+
+---
+ lib/mount.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/mount.c b/lib/mount.c
+index 7a18c11..1667db2 100644
+--- a/lib/mount.c
++++ b/lib/mount.c
+@@ -392,6 +392,9 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
+ 	int fd;
+ 	int res;
+
++	/* disable in flatpak */
++	return -2;
++
+ 	if (!mnt) {
+ 		fprintf(stderr, "fuse: missing mountpoint parameter\n");
+ 		return -1;
+--
+2.17.0.rc2
+

--- a/build-aux/flatpak/fusermount-wrapper.sh
+++ b/build-aux/flatpak/fusermount-wrapper.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+echo "Running fusermount wrapper, redirecting to host..."
+export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/flatpak/bus
+
+# Test if the `fusermount` command is available
+echo "Checking if fusermount is available on host system..."
+flatpak-spawn --host fusermount --version
+retval=$?
+
+if [ $retval -eq 0 ]; then
+  echo "Using fusermount."
+  binary="fusermount"
+else
+  # Some distros don't ship `fusermount` anymore, but `fusermount3` like Alpine
+  echo "Unable to execute fusermount, trying to use fusermount3."
+  binary="fusermount3"
+fi
+
+# The actual call on the host side
+if [ -z "$_FUSE_COMMFD" ]; then
+    FD_ARGS=
+else
+    FD_ARGS="--env=_FUSE_COMMFD=${_FUSE_COMMFD} --forward-fd=${_FUSE_COMMFD}"
+fi
+exec flatpak-spawn --host $FD_ARGS $binary "$@"

--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.json
@@ -16,6 +16,7 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
+        "--socket=session-bus",
         "--device=dri",
         "--filesystem=host",
         /* Default Flatpak installations so Bazaar is able to access them */

--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.json
@@ -288,13 +288,13 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Dglycin-loaders=true",
-                "-Dlibglycin=false"
+                "-Dlibglycin=true"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/sophie-h/glycin.git",
-                    "tag": "1.1.0"
+                    "tag": "1.2.1"
                 }
             ]
         },

--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.json
@@ -1,0 +1,311 @@
+{
+    "id": "io.github.kolunmi.Bazaar.Devel",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "master",
+    "sdk": "org.gnome.Sdk",
+    "command": "bazaar",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.rust-stable",
+        "org.freedesktop.Sdk.Extension.llvm18"
+    ],
+    "tags": [
+        "nightly"
+    ],
+    "finish-args": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=host",
+        /* Default Flatpak installations so Bazaar is able to access them */
+        "--filesystem=/var/lib/flatpak/",
+        "--filesystem=~/.local/share/flatpak:rw",
+        "--filesystem=/var/tmp:rw",
+        "--filesystem=/var/lib/flatpak",
+        "--filesystem=/var/tmp",
+        "--filesystem=/tmp",
+        "--talk-name=org.freedesktop.Flatpak",
+        "--system-talk-name=org.freedesktop.Flatpak.SystemHelper",
+        "--system-talk-name=org.freedesktop.PolicyKit1",
+        /* Required for libflatpak for detecting system language */
+        "--system-talk-name=org.freedesktop.Accounts",
+        "--talk-name=org.gtk.vfs.*",
+        "--filesystem=xdg-run/gvfsd",
+        "--env=GOBJECT_DEBUG=instance-count",
+        "--env=WORKER_AS_SUBPROCESS=1"
+    ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin",
+        "env": {
+            "MOUNT_FUSE_PATH": "../tmp/",
+            "RUSTFLAGS": "-C force-frame-pointers=yes -C symbol-mangling-version=v0 -C linker=clang -C link-arg=-fuse-ld=/usr/lib/sdk/rust-stable/bin/mold",
+            "BASH_COMPLETIONSDIR": "/app/share/bash-completion/completions"
+        },
+        "build-args": [
+            "--share=network"
+        ]
+    },
+    "modules": [
+        "python-deps.json",
+        {
+            "name": "libfuse",
+            "config-opts": [
+                "UDEV_RULES_PATH=/app/etc/udev/rules.d",
+                "INIT_D_PATH=/app/etc/init.d"
+            ],
+            "cleanup": [
+                "/bin/ulockmgr_server"
+            ],
+            "post-install": [
+                "install -m a+rx fusermount-wrapper.sh /app/bin/fusermount"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz",
+                    "sha256": "d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5"
+                },
+                {
+                    "type": "patch",
+                    "path": "fuse-2.9.2-namespace-conflict-fix.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "fuse-disable-sys-mount-under-flatpak.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "fuse-2.9.2-closefrom.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "fusermount-wrapper.sh"
+                }
+            ]
+        },
+        {
+            "name": "ostree",
+            "config-opts": [
+                "--disable-man",
+                "--with-curl",
+                "--without-soup",
+                "--without-libsystemd"
+            ],
+            "cleanup": [
+                "/bin",
+                "/etc/grub.d",
+                "/etc/ostree",
+                "/share/ostree",
+                "/libexec"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/ostreedev/ostree.git",
+                    "tag": "v2023.5"
+                }
+            ]
+        },
+        {
+            "name": "intltool",
+            "cleanup": [
+                "*"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+                    "sha256": "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+                }
+            ]
+        },
+        {
+            "name": "libyaml",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/yaml/libyaml.git",
+                    "tag": "0.2.5"
+                }
+            ]
+        },
+        {
+            "name": "libstemmer",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/zvelo/libstemmer",
+                    "commit": "78c149a3a6f262a35c7f7351d3f77b725fc646cf"
+                }
+            ]
+        },
+        {
+            "name": "polkit",
+            "config-opts": [
+                "--disable-polkitd",
+                "--disable-man-pages",
+                "--disable-introspection",
+                "--disable-examples",
+                "--disable-gtk-doc",
+                "--disable-libelogind",
+                "--disable-libsystemd-login",
+                "--with-systemdsystemunitdir=no",
+                "--with-authdb=dummy",
+                "--with-authfw=none"
+            ],
+            "rm-configure": true,
+            "build-options": {
+                "env": {
+                    "CFLAGS": "-Wno-implicit-function-declaration"
+                }
+            },
+            "cleanup": [
+                "/bin/*",
+                "/etc/pam.d",
+                "/etc/dbus-1",
+                "/share/dbus-1/system-services/*",
+                "/share/polkit-1",
+                "/lib/polkit-1"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.freedesktop.org/software/polkit/releases/polkit-0.116.tar.gz",
+                    "sha256": "88170c9e711e8db305a12fdb8234fac5706c61969b94e084d0f117d8ec5d34b1"
+                },
+                {
+                    "type": "patch",
+                    "path": "polkit-build-Add-option-to-build-without-polkitd.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "polkit-autogen",
+                    "dest-filename": "autogen.sh"
+                }
+            ]
+        },
+        {
+            "name": "bubblewrap",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dman=disabled",
+                "-Dselinux=disabled",
+                "-Dtests=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/projectatomic/bubblewrap/archive/refs/tags/v0.11.0.tar.gz",
+                    "sha256": "cfeeb15fcc47d177d195f06fdf0847e93ee3aa6bf46f6ac0a141fa142759e2c3"
+                }
+            ]
+        },
+        {
+            "name": "xdg-dbus-proxy",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dman=disabled",
+                "-Dtests=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/flatpak/xdg-dbus-proxy/archive/refs/tags/0.1.6.tar.gz",
+                    "sha256": "ee9c1d665f4e3b025a83d522d478ff7930070f2817fc2cb446db0dca93c990b1"
+                }
+            ]
+        },
+        {
+            "name": "flatpak",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dgtkdoc=disabled",
+                "-Ddocbook_docs=disabled",
+                "-Dtests=false",
+                "-Dman=disabled",
+                "-Dseccomp=disabled",
+                "-Dselinux_module=disabled",
+                "-Dmalcontent=disabled",
+                "-Dsandboxed_triggers=false",
+                "-Dsystem_helper=enabled",
+                "-Dhttp_backend=curl",
+                "-Dsystemd=disabled",
+                "-Dsystem_install_dir=/var/lib/flatpak",
+                "-Dsystem_bubblewrap=bwrap",
+                "-Dsystem_dbus_proxy=xdg-dbus-proxy",
+                "--sysconfdir=/var/run/host/etc"
+            ],
+            "cleanup": [
+                "/bin/flatpak-bisect",
+                "/bin/flatpak-coredumpctl",
+                "/etc/profile.d",
+                "/lib/systemd",
+                "/share/dbus-1/interfaces/org.freedesktop.*",
+                "/share/dbus-1/services/org.freedesktop.*",
+                "/share/flatpak/triggers",
+                "/share/gdm",
+                "/share/zsh"
+            ],
+            "post-install": [
+                "cp /usr/bin/update-mime-database /app/bin",
+                "cp /usr/bin/update-desktop-database /app/bin",
+                "install -m a+rx ../flatpak-bwrap-wrapper.sh /app/bin/flatpak-bwrap"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/flatpak/flatpak.git",
+                    "tag": "1.16.0"
+                },
+                {
+                    "type": "file",
+                    "path": "flatpak-bwrap-wrapper.sh"
+                }
+            ]
+        },
+        {
+            "name": "libxmlb",
+            "buildsystem": "meson",
+            "config-opts": [
+                "--libdir=/app/lib",
+                "-Dgtkdoc=false",
+                "-Dtests=false",
+                "-Dcli=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/hughsie/libxmlb.git",
+                    "tag": "0.3.22"
+                }
+            ]
+        },
+        {
+            "name": "glycin-loaders",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dglycin-loaders=true",
+                "-Dlibglycin=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/sophie-h/glycin.git",
+                    "tag": "1.1.0"
+                }
+            ]
+        },
+        {
+            "name": "bazaar",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "dir",
+                    "path": "../.."
+                }
+            ]
+        }
+    ]
+}

--- a/build-aux/flatpak/polkit-autogen
+++ b/build-aux/flatpak/polkit-autogen
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+gtkdocize --flavour no-tmpl
+autoreconf -if

--- a/build-aux/flatpak/polkit-build-Add-option-to-build-without-polkitd.patch
+++ b/build-aux/flatpak/polkit-build-Add-option-to-build-without-polkitd.patch
@@ -1,0 +1,132 @@
+From 1073a44277316348d40d86ecec908f1d4812f360 Mon Sep 17 00:00:00 2001
+From: Christian Hergert <chergert@redhat.com>
+Date: Mon, 27 May 2019 11:49:09 -0700
+Subject: [PATCH] flatpak: make polkit suitable for use within flatpak
+
+This is based on patches from Patrick Griffis with additional fixes
+to allow us to disable use of PAM within Flaptak.
+---
+ configure.ac                | 20 ++++++++++++++++----
+ src/Makefile.am             |  6 +++++-
+ src/polkitagent/Makefile.am |  5 +++++
+ test/Makefile.am            |  6 +++++-
+ 4 files changed, 31 insertions(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 5cedb4e..729d78d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -79,11 +79,13 @@ PKG_CHECK_MODULES(GLIB, [gmodule-2.0 gio-unix-2.0 >= 2.30.0])
+ AC_SUBST(GLIB_CFLAGS)
+ AC_SUBST(GLIB_LIBS)
+
+-PKG_CHECK_MODULES(LIBJS, [mozjs-60])
++AS_IF([test x${enable_polkitd} = yes], [
++  PKG_CHECK_MODULES(LIBJS, [mozjs-60])
+
+-AC_SUBST(LIBJS_CFLAGS)
+-AC_SUBST(LIBJS_CXXFLAGS)
+-AC_SUBST(LIBJS_LIBS)
++  AC_SUBST(LIBJS_CFLAGS)
++  AC_SUBST(LIBJS_CXXFLAGS)
++  AC_SUBST(LIBJS_LIBS)
++])
+
+ EXPAT_LIB=""
+ AC_ARG_WITH(expat, [  --with-expat=<dir>      Use expat from here],
+@@ -236,6 +238,15 @@ if test "x$with_systemdsystemunitdir" != "xno"; then
+ fi
+ AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$systemdsystemunitdir"])
+
++dnl ---------------------------------------------------------------------------
++dnl - Disable polkitd when using library alone
++dnl ---------------------------------------------------------------------------
++
++AC_ARG_ENABLE([polkitd],
++              [AS_HELP_STRING([--disable-polkitd], [Do not build polkitd])],
++              [enable_polkitd=$enableval], [enable_polkitd=yes])
++AM_CONDITIONAL(BUILD_POLKITD, [test x${enable_polkitd} = yes])
++
+ dnl ---------------------------------------------------------------------------
+ dnl - User for running polkitd
+ dnl ---------------------------------------------------------------------------
+@@ -579,6 +590,7 @@ echo "
+         Session tracking:           ${SESSION_TRACKING}
+         PAM support:                ${have_pam}
+         systemdsystemunitdir:       ${systemdsystemunitdir}
++        polkitd:                    ${enable_polkitd}
+         polkitd user:               ${POLKITD_USER}"
+
+ if test "$have_pam" = yes ; then
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 09fc7b3..c6fe91b 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -1,5 +1,9 @@
+
+-SUBDIRS = polkit polkitbackend polkitagent programs
++SUBDIRS = polkit polkitagent programs
++
++if BUILD_POLKITD
++SUBDIRS += polkitbackend
++endif
+
+ if BUILD_EXAMPLES
+ SUBDIRS += examples
+diff --git a/src/polkitagent/Makefile.am b/src/polkitagent/Makefile.am
+index 49720db..633f9d4 100644
+--- a/src/polkitagent/Makefile.am
++++ b/src/polkitagent/Makefile.am
+@@ -79,6 +79,7 @@ libpolkit_agent_1_la_LIBADD =                               		\
+
+ libpolkit_agent_1_la_LDFLAGS = -export-symbols-regex '(^polkit_.*)'
+
++if !POLKIT_AUTHFW_NONE
+ libprivdir = $(prefix)/lib/polkit-1
+ libpriv_PROGRAMS = polkit-agent-helper-1
+
+@@ -113,6 +114,8 @@ polkit_agent_helper_1_LDFLAGS = 					\
+ 	$(AM_LDFLAGS)							\
+ 	$(NULL)
+
++endif # !POLKIT_AUTHFW_NONE
++
+ if HAVE_INTROSPECTION
+
+ girdir = $(INTROSPECTION_GIRDIR)
+@@ -142,6 +145,7 @@ include $(INTROSPECTION_MAKEFILE)
+
+ endif # HAVE_INTROSPECTION
+
++if !POLKIT_AUTHFW_NONE
+ # polkit-agent-helper-1 need to be setuid root because it's used to
+ # authenticate not only the invoking user, but possibly also root
+ # and/or other users.
+@@ -149,6 +153,7 @@ endif # HAVE_INTROSPECTION
+ install-data-hook:
+ 	-chown root $(DESTDIR)$(libprivdir)/polkit-agent-helper-1
+ 	-chmod 4755 $(DESTDIR)$(libprivdir)/polkit-agent-helper-1
++endif # !POLKIT_AUTHFW_NONE
+
+ EXTRA_DIST = polkitagentmarshal.list polkitagentenumtypes.h.template polkitagentenumtypes.c.template
+ CLEANFILES = $(gir_DATA) $(typelibs_DATA)
+diff --git a/test/Makefile.am b/test/Makefile.am
+index 59d0680..d43b0fe 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -1,7 +1,11 @@
+
+-SUBDIRS = mocklibc . polkit polkitbackend
++SUBDIRS = mocklibc . polkit
+ AM_CFLAGS = $(GLIB_CFLAGS)
+
++if BUILD_POLKITD
++SUBDIRS += polkitbackend
++endif
++
+ noinst_LTLIBRARIES = libpolkit-test-helper.la
+ libpolkit_test_helper_la_SOURCES = polkittesthelper.c polkittesthelper.h
+ libpolkit_test_helper_la_LIBADD = $(GLIB_LIBS)
+--
+2.21.0
+

--- a/build-aux/flatpak/polkit-mocklib-print-indent.patch
+++ b/build-aux/flatpak/polkit-mocklib-print-indent.patch
@@ -1,0 +1,61 @@
+From fab336d25955910f99b083c3280c0abe7007d452 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Sun, 3 Dec 2023 23:06:30 +0000
+Subject: [PATCH] test/mocklibc: fix build against
+
+polkit> ../subprojects/mocklibc-1.0/src/netgroup-debug.c: In function 'netgroup_debug_print_entry':
+polkit> ../subprojects/mocklibc-1.0/src/netgroup-debug.c:25:3: error: implicit declaration of function 'print_indent' [-Wimplicit-function-declaration]
+polkit>    25 |   print_indent(stream, indent);
+polkit>       |   ^~~~~~~~~~~~
+---
+ test/mocklibc/src/netgroup-debug.c | 11 +++++++++++
+ test/mocklibc/src/netgroup.c       | 11 -----------
+ 2 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/test/mocklibc/src/netgroup-debug.c b/test/mocklibc/src/netgroup-debug.c
+index 81d6e728..46e5b25f 100644
+--- a/test/mocklibc/src/netgroup-debug.c
++++ b/test/mocklibc/src/netgroup-debug.c
+@@ -21,6 +21,17 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ 
++/**
++ * Print a varaible indentation to the stream.
++ * @param stream Stream to print to
++ * @param indent Number of indents to use
++ */
++static void print_indent(FILE *stream, unsigned int indent) {
++  int i;
++  for (i = 0; i < indent; i++)
++    fprintf(stream, "  ");
++}
++
+ void netgroup_debug_print_entry(struct entry *entry, FILE *stream, unsigned int indent) {
+   print_indent(stream, indent);
+ 
+diff --git a/test/mocklibc/src/netgroup.c b/test/mocklibc/src/netgroup.c
+index 06a8a894..e16e4519 100644
+--- a/test/mocklibc/src/netgroup.c
++++ b/test/mocklibc/src/netgroup.c
+@@ -71,17 +71,6 @@ static char *parser_copy_word(char **cur) {
+   return result;
+ }
+ 
+-/**
+- * Print a varaible indentation to the stream.
+- * @param stream Stream to print to
+- * @param indent Number of indents to use
+- */
+-void print_indent(FILE *stream, unsigned int indent) {
+-  int i;
+-  for (i = 0; i < indent; i++)
+-    fprintf(stream, "  ");
+-}
+-
+ /**
+  * Connect entries with 'child' type to their child entries.
+  * @param headentry Head of list of entries that need to be connected
+-- 
+GitLab
+

--- a/build-aux/flatpak/python-deps.json
+++ b/build-aux/flatpak/python-deps.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-deps",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} pyparsing"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b9/b8/6b32b3e84014148dcd60dd05795e35c2e7f4b72f918616c61fdce83d27fc/pyparsing-2.3.1.tar.gz",
+            "sha256": "66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a"
+        }
+    ]
+}


### PR DESCRIPTION
This is extremely experimental but it seems to kinda work, added a flatpak manifest based on [Souk's manifest](https://gitlab.gnome.org/haecker-felix/souk/-/tree/souk-next/build-aux/flatpak?ref_type=heads) the store seems to be running, but it segfaults with an error from LibGlycin


You can build this by running:
`flatpak run org.flatpak.Builder $"./build-dir" --state-dir=$"./flatpak-builder" --ccache --force-clean --install --disable-rofiles-fuse ./io.github.kolunmi.Bazaar.Devel`

IF this ends up working, itll Fix: #6 