### PR TITLE
Add libyaml-dev to dev container dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,5 +17,6 @@ RUN apt-get update && apt-get install -y \
     libgtk-4-dev \
     liblcms2-dev \
     libxmlb-dev \
+    libyaml-dev \
     meson \
     ninja-build


### PR DESCRIPTION
Had to add `libyaml-dev` to the dev container to get the proper dependencies.