### PR TITLE
added pt_PT translations

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -8,6 +8,7 @@ fr
 id
 pl
 pt_BR
+pt_PT
 ru
 zh_CN
 zh_TW

--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -1,0 +1,587 @@
+# Portuguese translations for bazaar package
+# Tradução portuguesa (Portugal) para o pacote bazaar.
+# Copyright (C) 2025 THE bazaar'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the bazaar package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: bazaar\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-15 11:36+0100\n"
+"PO-Revision-Date: 2025-07-15 11:36+0100\n"
+"Last-Translator: Azenyr\n"
+"Language-Team: Portuguese (Portugal)\n"
+"Language: pt_PT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/io.github.kolunmi.Bazaar.desktop.in:2
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:7 src/bz-window.blp:5
+msgid "Bazaar"
+msgstr "Bazaar"
+
+#: data/io.github.kolunmi.Bazaar.desktop.in:3
+msgid "Add, remove or update flatpak software on this computer"
+msgstr "Adicionar, remover ou atualizar software flatpak neste computador"
+
+#: data/io.github.kolunmi.Bazaar.desktop.in:9
+msgid "GTK;System;PackageManager;Discover;Flatpak;Software;Store;"
+msgstr "GTK;Sistema;GestorDePacotes;Discover;Flatpak;Aplicações;Loja;"
+
+#: data/io.github.kolunmi.Bazaar.gschema.xml:6
+msgid "Show Animated Background"
+msgstr "Mostrar Imagem de Fundo Animada"
+
+#: data/io.github.kolunmi.Bazaar.gschema.xml:7
+msgid "Whether to show the animated icon background on the home page"
+msgstr "Mostrar o ícone de imagem de fundo animada na página inicial"
+
+#. FIXME: add descriptions and summary
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:9
+msgid "Keep the summary shorter, between 10 and 35 characters"
+msgstr "Mantenha o resumo curto, entre 10 e 35 caracteres"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:11
+msgid "No description"
+msgstr "Sem descrição"
+
+#: data/io.github.kolunmi.Bazaar.metainfo.xml.in:41
+msgid "Main Bazaar window showing Blender"
+msgstr "Janela principal do Bazaar a mostrar o Blender"
+
+#: src/bz-addons-dialog.blp:13 src/bz-installed-page.blp:162
+#: src/bz-installed-page.blp:174
+msgid "Manage Addons"
+msgstr "Gerir Extensões"
+
+#: src/bz-app-tile.blp:65 src/bz-full-view.blp:139
+msgid "This flatpak is verified by the original developers of the software."
+msgstr "Este flatpak foi verificado pelos desenvolvedores originais do software."
+
+#: src/bz-application.c:1186
+msgctxt "About Dialog Developer Credit"
+msgid "Adam Masciola <kolunmi@posteo.net>"
+msgstr "Adam Masciola <kolunmi@posteo.net>"
+
+#: src/bz-application.c:1191
+msgctxt "About Dialog Translator Credit"
+msgid "Ahmed Najmawi"
+msgstr "Ahmed Najmawi"
+
+#: src/bz-application.c:1192
+msgctxt "About Dialog Translator Credit"
+msgid "AtomHare"
+msgstr "AtomHare"
+
+#: src/bz-application.c:1193
+msgctxt "About Dialog Translator Credit"
+msgid "Jill Fiore"
+msgstr "Jill Fiore"
+
+#: src/bz-application.c:1194
+msgctxt "About Dialog Translator Credit"
+msgid "Lucosec"
+msgstr "Lucosec"
+
+#: src/bz-application.c:1195
+msgctxt "About Dialog Translator Credit"
+msgid "Shihfu Juan"
+msgstr "Shihfu Juan"
+
+#: src/bz-application.c:1196
+msgctxt "About Dialog Translator Credit"
+msgid "Vlastimil Dědek"
+msgstr "Vlastimil Dědek"
+
+#: src/bz-application.c:1197
+msgctxt "About Dialog Translator Credit"
+msgid "asen23"
+msgstr "asen23"
+
+#: src/bz-application.c:1198
+msgctxt "About Dialog Translator Credit"
+msgid "renner"
+msgstr "renner"
+
+#: src/bz-application.c:1199
+msgctxt "About Dialog Translator Credit"
+msgid "robotta"
+msgstr "robotta"
+
+#: src/bz-application.c:1215
+msgid "Adam Masciola"
+msgstr "Adam Masciola"
+
+#: src/bz-browse-widget.blp:11 src/bz-full-view.blp:11
+#: src/bz-installed-page.blp:11 src/bz-window.blp:32
+msgid "Empty"
+msgstr "Vazio"
+
+#: src/bz-browse-widget.blp:15
+msgid "No Curated Applications"
+msgstr "Não Existem Aplicações Recomendadas"
+
+#: src/bz-browse-widget.blp:16
+msgid ""
+"Bazaar was not provided a curated content configuration. Contact your "
+"operating system's support channels for assistance."
+msgstr "O Bazaar não tem uma definição para conteúdo recomendado. "
+"Contacte os canais de suporte do seu sistema operativo para mais ajuda. "
+
+#: src/bz-browse-widget.blp:22 src/bz-flathub-page.blp:11
+msgid "Browser"
+msgstr "Explorador"
+
+#: src/bz-error.c:45
+msgid "An Error Occurred"
+msgstr "Ocorreu Um Erro"
+
+#: src/bz-error.c:51
+msgid "Close"
+msgstr "Fechar"
+
+#: src/bz-error.c:52
+msgid "Copy and Close"
+msgstr "Copiar e Fechar"
+
+#: src/bz-flathub-page.blp:41
+msgid "Apps Of The Week"
+msgstr "Aplicações da Semana"
+
+#: src/bz-flathub-page.blp:85
+msgid "Trending"
+msgstr "Tendências"
+
+#: src/bz-flathub-page.blp:117
+msgid "Recently Updated"
+msgstr "Atualizadas Recentemente"
+
+#: src/bz-flathub-page.blp:149
+msgid "Recently Added"
+msgstr "Adicionadas Recentemente"
+
+#: src/bz-flathub-page.blp:181
+msgid "Popular"
+msgstr "Mais Populares"
+
+#: src/bz-full-view.blp:15
+msgid "No Results"
+msgstr "Sem Resultados"
+
+#: src/bz-full-view.blp:16
+msgid "Try a different search query"
+msgstr "Tente outros termos de pesquisa"
+
+#: src/bz-full-view.blp:22 src/bz-window.blp:42
+msgid "Content"
+msgstr "Conteúdo"
+
+#: src/bz-full-view.blp:180
+msgid "Run this application"
+msgstr "Executar esta aplicação"
+
+#: src/bz-full-view.blp:204
+msgid "Download and install this application"
+msgstr "Transferir e instalar esta aplicação"
+
+#: src/bz-full-view.blp:222 src/bz-window.c:987
+msgid "Install"
+msgstr "Instalar"
+
+#: src/bz-full-view.blp:236
+msgid "Uninstall this application"
+msgstr "Desinstalar esta aplicação"
+
+#: src/bz-full-view.blp:262
+msgid "Share this application"
+msgstr "Partilhar esta aplicação"
+
+#: src/bz-full-view.blp:274
+msgid ""
+"The number of downloads in the last 30 days. Click to view this "
+"application's download statistics."
+msgstr "O número de transferências dos últimos 30 dias. Clique para "
+"ver as estatísticas desta aplicação."
+
+#: src/bz-full-view.blp:316
+msgid "Support this developer"
+msgstr "Apoiar este desenvolvedor"
+
+#: src/bz-full-view.blp:329
+msgid "Support"
+msgstr "Apoiar"
+
+#: src/bz-full-view.blp:387
+msgid "Remote repo name"
+msgstr "Nome do repositório remoto"
+
+#: src/bz-full-view.blp:400
+msgid "Project URL"
+msgstr "URL do Projeto"
+
+#: src/bz-full-view.blp:412
+msgid "Download size"
+msgstr "Tamanho da Transferência"
+
+#: src/bz-full-view.c:214
+#, c-format
+msgid "Released %x"
+msgstr "Lançado em %x"
+
+#: src/bz-full-view.c:225
+msgid "No URL"
+msgstr "Nenhum URL"
+
+#: src/bz-full-view.c:233
+msgid ""
+"This application has a FLOSS license, meaning the source code can be audited "
+"for safety."
+msgstr "Esta aplicação tem uma licença livre de código aberto (FOSS), o que significa que "
+"o código fonte pode ser auditável para verificações de segurança."
+
+#: src/bz-full-view.c:234
+msgid ""
+"This application has a proprietary license, meaning the source code is "
+"developed privately and cannot be audited by an independent third party."
+msgstr "Esta aplicação tem uma licença proprietária, o que significa que "
+"o código fonte é privado e não pode ser auditável por terceiros."
+
+#: src/bz-installed-page.blp:15
+msgid "No Flatpaks Installed"
+msgstr "Não Existem Flatpaks Instalados"
+
+#: src/bz-installed-page.blp:21 src/bz-window.blp:201 src/bz-window.blp:336
+msgid "Installed"
+msgstr "Instalados"
+
+#: src/bz-installed-page.blp:143
+msgid "More actions"
+msgstr "Mais Ações"
+
+#: src/bz-installed-page.blp:187 src/bz-installed-page.blp:198
+msgid "Edit Permissions"
+msgstr "Editar Permissões"
+
+#: src/bz-preferences-dialog.blp:9
+msgid "Preferences"
+msgstr "Preferências"
+
+#: src/bz-preferences-dialog.blp:13
+msgid "How the application looks"
+msgstr "A aparência da aplicação"
+
+#: src/bz-preferences-dialog.blp:14
+msgid "Appearance"
+msgstr "Aparência"
+
+#: src/bz-preferences-dialog.blp:17
+msgid "Show animated background"
+msgstr "Mostrar imagem de fundo animada"
+
+#: src/bz-search-widget.blp:69
+msgid "Type to filter"
+msgstr "Escreva para filtrar"
+
+#: src/bz-search-widget.blp:98 src/bz-search-widget.blp:115
+msgid "Search Options"
+msgstr "Opções de Pesquisa"
+
+#: src/bz-search-widget.blp:119
+msgid "Exclude results with proprietary licenses"
+msgstr "Excluir da pesquisa resultados com licenças proprietárias"
+
+#: src/bz-search-widget.blp:124
+msgid "Exclude results not originating from Flathub"
+msgstr "Excluir da pesquisa resultados que não sejam do Flathub"
+
+#: src/bz-search-widget.blp:139
+msgid "Advanced"
+msgstr "Avançado"
+
+#: src/bz-search-widget.blp:143
+msgid "Match using regular expressions"
+msgstr "Corresponder através de expressões regulares"
+
+#: src/bz-search-widget.blp:148
+msgid "Hide filtering and sorting behind a crossfade effect"
+msgstr "Ocultar filtragem e ordenação através de um efeito visual de transição crossfade"
+
+#: src/bz-search-widget.blp:153
+msgid "Debounce input to prevent instant replies"
+msgstr "Atrasar a entrada de texto para evitar respostas múltiplas"
+
+#: src/bz-share-dialog.blp:13
+msgid "Share"
+msgstr "Partilhar"
+
+#: src/bz-share-dialog.blp:64
+msgid "Copy this link"
+msgstr "Copiar a ligação"
+
+#: src/bz-share-dialog.blp:71
+msgid "Open this link externally"
+msgstr "Abrir a ligação externamente"
+
+#: src/bz-stats-dialog.blp:15
+msgid "Downloads Over Time"
+msgstr "Transferências Ao Longo Do Tempo"
+
+#: src/bz-stats-dialog.blp:31
+msgid "Minimize Lower Bound"
+msgstr "Minimizar o Limite Inferior"
+
+#: src/bz-stats-dialog.blp:36
+msgid "Maximize Upper Bound"
+msgstr "Maximizar o Limite Superior"
+
+#: src/bz-transaction-manager.c:451
+#, c-format
+msgid "Finished in %.02f seconds"
+msgstr "Concluído em %.02f segundos"
+
+#: src/bz-transaction-view.blp:34
+msgid "Installing"
+msgstr "A Instalar"
+
+#: src/bz-transaction-view.blp:63
+msgid "Updating"
+msgstr "A Atualizar"
+
+#: src/bz-transaction-view.blp:92
+msgid "Removing"
+msgstr "A Remover"
+
+#: src/bz-transaction.c:268
+msgid "Pending"
+msgstr "Pendente"
+
+#: src/bz-update-dialog.blp:6
+msgid "Later"
+msgstr "Mais Tarde"
+
+#: src/bz-update-dialog.blp:7
+msgid "Install Now"
+msgstr "Instalar Agora"
+
+#: src/bz-update-dialog.blp:10
+msgid "Updates Are Available"
+msgstr "Estão Disponíveis Atualizações"
+
+#: src/bz-update-dialog.blp:11
+msgid ""
+"The following applications are eligible for updates. Would you like to "
+"install them?"
+msgstr "As seguintes aplicações têm atualizações disponíveis. Deseja instalá-las agora?"
+
+#: src/bz-update-dialog.c:135
+#, c-format
+msgid ""
+"%d runtimes and/or addons are eligible for updates. Would you like to "
+"install them?"
+msgstr "Os serviços de execução (runtimes) pretencentes a %d e/ou respetivas extensões podem ser atualizados(as); Deseja "
+"atualizá-los(as) agora?"
+
+#: src/bz-update-dialog.c:143
+#, c-format
+msgid "Additionally, %d runtimes and/or addons will be updated."
+msgstr "Os serviços de execução (runtimes) pretencentes a %d e/ou respetivas extensões também serão atualizados(as)."
+
+#: src/bz-window.blp:36
+msgid "Transactions Will Appear Here"
+msgstr "As Transações Irão Aparecer Aqui"
+
+#: src/bz-window.blp:97
+msgid "Halt the execution of transactions"
+msgstr "Interromper a execução das transações"
+
+#: src/bz-window.blp:105
+msgid "Clear all finished transactions"
+msgstr "Limpar as transações já finalizadas"
+
+#: src/bz-window.blp:136 src/bz-window.blp:140
+msgid "Offline"
+msgstr "Sem Ligação"
+
+#: src/bz-window.blp:146
+msgid "Loading"
+msgstr "A Carregar"
+
+#: src/bz-window.blp:170
+msgid "Browse"
+msgstr "Explorar"
+
+#: src/bz-window.blp:180
+msgid "App View"
+msgstr "Vista de Aplicação"
+
+#: src/bz-window.blp:191 src/bz-window.blp:315
+msgid "Flathub"
+msgstr "Flathub"
+
+#: src/bz-window.blp:220
+msgid "Go Back"
+msgstr "Voltar"
+
+#: src/bz-window.blp:228
+msgid "Refresh"
+msgstr "Recarregar"
+
+#: src/bz-window.blp:237
+msgid "Search"
+msgstr "Pesquisar"
+
+#: src/bz-window.blp:249
+msgid "Update"
+msgstr "Atualizar"
+
+#: src/bz-window.blp:263
+msgid "Checking for updates"
+msgstr "A procurar atualizações"
+
+#: src/bz-window.blp:279
+msgid "View curated applications"
+msgstr "Ver as aplicações recomendadas"
+
+#: src/bz-window.blp:294
+msgid "Curated"
+msgstr "Recomendadas"
+
+#: src/bz-window.blp:300
+msgid "View the latest on Flathub"
+msgstr "Ver as mais recentes do Flathub"
+
+#: src/bz-window.blp:321
+msgid "View installed applications"
+msgstr "Ver as aplicações instaladas"
+
+#: src/bz-window.blp:350
+msgid "Main Menu"
+msgstr "Menu Principal"
+
+#: src/bz-window.blp:361
+msgid "Toggle transaction sidebar"
+msgstr "Alternar a barra lateral de transações"
+
+#: src/bz-window.blp:400
+msgid "Up to date!"
+msgstr "Atualizado!"
+
+#: src/bz-window.blp:425
+msgid "_Keyboard Shortcuts"
+msgstr "_Atalhos de Teclado"
+
+#: src/bz-window.blp:430
+msgid "_About Bazaar"
+msgstr "_Acerca do Bazaar"
+
+#: src/bz-window.blp:435
+msgid "_Donate to Bazaar ❤️"
+msgstr "_Efetuar uma doação para o Bazaar ❤️"
+
+#: src/bz-window.c:856
+msgid ""
+"The ability to inspect and install local .flatpak bundle files is coming "
+"soon! In the meantime, try running\n"
+"\n"
+"flatpak install --bundle your-bundle.flatpak\n"
+"\n"
+"on the command line."
+msgstr "A funcionalidade de verificar e instalar ficheiros/conjuntos .flatpak está a caminho! "
+"Enquanto não está disponível, experimente executar o comando\n"
+"\n"
+"flatpak install --bundle <nome_do_ficheiro>.flatpak\n"
+"\n"
+"a partir do terminal."
+
+#: src/bz-window.c:927
+msgid "Can't do that right now!"
+msgstr "Não é possível neste momento!"
+
+#: src/bz-window.c:940
+msgid "Confirm Action"
+msgstr "Confirmar Ação"
+
+#: src/bz-window.c:958
+#, c-format
+msgid ""
+"You are about to remove the following Flatpak:\n"
+"\n"
+"<b>%s</b>\n"
+"<tt>%s</tt>\n"
+"\n"
+"Are you sure?"
+msgstr "Irá a remover a seguinte aplicação Flatpak:\n"
+"\n"
+"<b>%s</b>\n"
+"<tt>%s</tt>\n"
+"\n"
+"Deseja continuar?"
+
+#: src/bz-window.c:966 src/bz-window.c:986
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: src/bz-window.c:967
+msgid "Remove"
+msgstr "Remover"
+
+#: src/bz-window.c:978
+#, c-format
+msgid ""
+"You are about to install the following Flatpak:\n"
+"\n"
+"<b>%s</b>\n"
+"<tt>%s</tt>\n"
+"\n"
+"Are you sure?"
+msgstr "Irá instalar a seguinte aplicação Flatpak:\n"
+"\n"
+"<b>%s</b>\n"
+"<tt>%s</tt>\n"
+"\n"
+"Deseja continuar?"
+
+#: src/bz-window.c:1012
+msgid "More details"
+msgstr "Mais detalhes"
+
+#: src/bz-window.c:1138
+msgid "Resume the execution of transactions"
+msgstr "Retomar a execução das transações"
+
+#: src/bz-window.c:1144
+msgid "Pause the execution of transactions"
+msgstr "Colocar a execução das transações em pausa"
+
+#: src/gtk/help-overlay.blp:11
+msgctxt "shortcut window"
+msgid "General"
+msgstr "Geral"
+
+#: src/gtk/help-overlay.blp:14
+msgctxt "shortcut window"
+msgid "Open Search Dialog"
+msgstr "Abrir a Janela de Pesquisa"
+
+#: src/gtk/help-overlay.blp:19
+msgctxt "shortcut window"
+msgid "Refresh"
+msgstr "Recarregar"
+
+#: src/gtk/help-overlay.blp:24
+msgctxt "shortcut window"
+msgid "Toggle Transaction Manager"
+msgstr "Alternar o Gestor de Transações"
+
+#: src/gtk/help-overlay.blp:29
+msgctxt "shortcut window"
+msgid "Show Shortcuts"
+msgstr "Mostrar Atalhos"
+
+#: src/gtk/help-overlay.blp:34
+msgctxt "shortcut window"
+msgid "Quit"
+msgstr "Sair"


### PR DESCRIPTION
Portuguese (from Portugal) is my native language and since on the Linux world we usually have a notorious lack of pt_PT translators, I decided to translate Bazaar myself. First time doing this (both translating an app and doing the github PR), so I hope everything was done right. Tell me if something needs to be adjusted. I used the commands and instructions provided in TRANSLATORS.md .

Please note that some DEs or distros configure the locale code "pt" instead of pt_PT, even KDE had a bug for some time (now fixed) that you could not select Portuguese from Portugal from the language settings UI since the options were configured in the backend as "pt_BR" and "pt" (not pt_PT) and it ended up having all apps showing Brazilian translations on both options. On this PR I used pt_PT since it is the correct Portuguese (Portugal) language code, even though some distros like to wrongly refer to it as just "pt". If Bazaar ends up getting just "pt" from the distro locale variables, please serve the correct pt_PT language (since pt_BR is usually well coded and defined by itself, as it already is here on Bazaar) and not Brazilian, since both languages are actually very different in many aspects and some sentences and words don't make much sense between both. Things like these happen because, again, the Linux world has a lack of Portuguese (Portugal) maintainers/translators so devs don't usually notice things like these.

TL;DR - If LC_MESSAGES=pt (not pt_PT, nor pt_BR), Bazaar should serve pt_PT by default, since thats how some (especially smaller) distros/DEs implement these two language locales. Most of modern DEs have the correct LC_MESSAGES=pt_PT nowdays, but still happens.

