### PR TITLE
Fix app name in AppStream is not loaded correctly in non-English environments

### DIFF
--- a/src/bz-flatpak-instance.c
+++ b/src/bz-flatpak-instance.c
@@ -827,7 +827,8 @@ ref_remote_apps_for_single_remote_fiber (RefRemoteAppsForRemoteData *data)
 
   silo = xb_builder_compile (
       builder,
-      XB_BUILDER_COMPILE_FLAG_SINGLE_LANG,
+      // fallback for locales should be handled by AppStream as_component_get_name
+      XB_BUILDER_COMPILE_FLAG_NONE,
       cancellable,
       &local_error);
   if (silo == NULL)


### PR DESCRIPTION
Fixed: https://github.com/kolunmi/bazaar/issues/181

After cleaning up, there was only one small patch

The original XB_BUILDER_COMPILE_FLAG_SINGLE_LANG flag will cause all `lang` parameters in xml to be deleted, for example
`<name xml:lang="zh_CN">GNOME 数独</name>`

I've been understanding why `as_component_get_name_table` can't get anything except lang=C :sob: 
