### PR TITLE
fix: add thousands separators to download counts with locale support

### DIFF
--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -189,7 +189,7 @@ format_recent_downloads (gpointer object,
                          int      value)
 {
   if (value > 0)
-    return g_strdup_printf ("%d", value);
+    return g_strdup_printf ("%'d", value);
   else
     return g_strdup ("---");
 }


### PR DESCRIPTION
This PR uses the `%'d` specifier to automatically format numbers with appropriate separators based on user's locale settings.

## Before
<img width="2014" height="1308" alt="Screenshot_20250720_125557" src="https://github.com/user-attachments/assets/af947ab5-0ef4-441e-ae64-03ff02c4a8a6" />

## After
<img width="1979" height="1320" alt="Screenshot_20250720_125126" src="https://github.com/user-attachments/assets/60ba4bec-185a-4a90-a59b-0b4082e3797d" />
