### PR TITLE
fix: flatpak builds failing due to wrong libdex version

### DIFF
--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.yaml
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.yaml
@@ -84,13 +84,14 @@ modules:
     - name: libdex
       buildsystem: meson
       sources:
-        - type: archive
-          url: https://gitlab.gnome.org/GNOME/libdex/-/archive/0.9.1/libdex-0.9.1.tar.gz
-          sha256: 8106d034bd34fd3dd2160f9ac1c594e4291aa54a258c5c84cca7a7260fce2fe1
+        - type: git
+          url: https://gitlab.gnome.org/GNOME/libdex.git
+          tag: 0.9.1
+          commit: 259b26b22bc626635a2b156dabd00b6f0d79f249
           x-checker-data:
             type: anitya
             project-id: 328356
-            url-template: https://gitlab.gnome.org/GNOME/libdex/-/archive/$version/libdex-$version.tar.gz
+            tag-template: $version
     - name: glycin
       buildsystem: meson
       config-opts:

--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.yaml
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.yaml
@@ -85,8 +85,8 @@ modules:
       buildsystem: meson
       sources:
         - type: archive
-          url: https://gitlab.gnome.org/GNOME/libdex/-/archive/0.10.1/libdex-0.10.1.tar.gz
-          sha256: 3511e4ff25e5d82b7097d9602bc569bea7d3dc816c6fbbf1af68383f74ad9dd5
+          url: https://gitlab.gnome.org/GNOME/libdex/-/archive/0.9.1/libdex-0.9.1.tar.gz
+          sha256: 8106d034bd34fd3dd2160f9ac1c594e4291aa54a258c5c84cca7a7260fce2fe1
           x-checker-data:
             type: anitya
             project-id: 328356

--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.yaml
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.Devel.yaml
@@ -84,14 +84,13 @@ modules:
     - name: libdex
       buildsystem: meson
       sources:
-        - type: git
-          url: https://gitlab.gnome.org/GNOME/libdex.git
-          tag: 0.9.1
-          commit: 259b26b22bc626635a2b156dabd00b6f0d79f249
+        - type: archive
+          url: https://gitlab.gnome.org/GNOME/libdex/-/archive/0.9.1/libdex-0.9.1.tar.gz
+          sha256: 8106d034bd34fd3dd2160f9ac1c594e4291aa54a258c5c84cca7a7260fce2fe1
           x-checker-data:
             type: anitya
             project-id: 328356
-            tag-template: $version
+            url-template: https://gitlab.gnome.org/GNOME/libdex/-/archive/$version/libdex-$version.tar.gz
     - name: glycin
       buildsystem: meson
       config-opts:

--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.yaml
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.yaml
@@ -81,14 +81,13 @@ modules:
     - name: libdex
       buildsystem: meson
       sources:
-        - type: git
-          url: https://gitlab.gnome.org/GNOME/libdex.git
-          tag: 0.9.1
-          commit: 259b26b22bc626635a2b156dabd00b6f0d79f249
+        - type: archive
+          url: https://gitlab.gnome.org/GNOME/libdex/-/archive/0.9.1/libdex-0.9.1.tar.gz
+          sha256: 8106d034bd34fd3dd2160f9ac1c594e4291aa54a258c5c84cca7a7260fce2fe1
           x-checker-data:
             type: anitya
             project-id: 328356
-            tag-template: $version
+            url-template: https://gitlab.gnome.org/GNOME/libdex/-/archive/$version/libdex-$version.tar.gz
     - name: glycin
       buildsystem: meson
       config-opts:

--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.yaml
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.yaml
@@ -81,13 +81,14 @@ modules:
     - name: libdex
       buildsystem: meson
       sources:
-        - type: archive
-          url: https://gitlab.gnome.org/GNOME/libdex/-/archive/0.9.1/libdex-0.9.1.tar.gz
-          sha256: 8106d034bd34fd3dd2160f9ac1c594e4291aa54a258c5c84cca7a7260fce2fe1
+        - type: git
+          url: https://gitlab.gnome.org/GNOME/libdex.git
+          tag: 0.9.1
+          commit: 259b26b22bc626635a2b156dabd00b6f0d79f249
           x-checker-data:
             type: anitya
             project-id: 328356
-            url-template: https://gitlab.gnome.org/GNOME/libdex/-/archive/$version/libdex-$version.tar.gz
+            tag-template: $version
     - name: glycin
       buildsystem: meson
       config-opts:

--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.yaml
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.yaml
@@ -82,8 +82,8 @@ modules:
       buildsystem: meson
       sources:
         - type: archive
-          url: https://gitlab.gnome.org/GNOME/libdex/-/archive/0.10.1/libdex-0.10.1.tar.gz
-          sha256: 3511e4ff25e5d82b7097d9602bc569bea7d3dc816c6fbbf1af68383f74ad9dd5
+          url: https://gitlab.gnome.org/GNOME/libdex/-/archive/0.9.1/libdex-0.9.1.tar.gz
+          sha256: 8106d034bd34fd3dd2160f9ac1c594e4291aa54a258c5c84cca7a7260fce2fe1
           x-checker-data:
             type: anitya
             project-id: 328356

--- a/subprojects/libdex.wrap
+++ b/subprojects/libdex.wrap
@@ -1,8 +1,9 @@
-[wrap-git]
-directory = libdex
-url = https://gitlab.gnome.org/GNOME/libdex.git
-revision = 0.9.1
-depth = 1
+[wrap-file]
+directory = libdex-0.9.1
+source_url = https://gitlab.gnome.org/GNOME/libdex/-/archive/0.9.1/libdex-0.9.1.tar.gz
+source_filename = libdex-0.9.1.tar.gz
+source_hash = 8106d034bd34fd3dd2160f9ac1c594e4291aa54a258c5c84cca7a7260fce2fe1
+
 
 [provide]
 dependency_names = libdex-1


### PR DESCRIPTION
Fixes #213 