### PR TITLE
libdex: bump down requirement to 0.10

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -7,7 +7,7 @@ libdex_opts = [
 
 gtk_dep              = dependency('gtk4')
 libadwaita_dep       = dependency('libadwaita-1', version: '>= 1.7')
-libdex_dep           = dependency('libdex-1', version: '>= 0.11.1', default_options: libdex_opts)
+libdex_dep           = dependency('libdex-1', version: '>= 0.10.0', default_options: libdex_opts)
 flatpak_dep          = dependency('flatpak', version: '>= 1.9')
 appstream_dep        = dependency('appstream', version: '>= 1.0')
 xmlb_dep             = dependency('xmlb', version: '>= 0.3.4')


### PR DESCRIPTION
This makes it so we dont need to repackage libdex for the flatpak build (org.gnome.Sdk 48 provides libdex 0.10.1)