### PR TITLE
fix: launching applications from flatpak-spawn

### DIFF
--- a/src/bz-flatpak-entry.c
+++ b/src/bz-flatpak-entry.c
@@ -938,7 +938,11 @@ bz_flatpak_entry_launch (BzFlatpakEntry    *self,
 
 #ifdef SANDBOXED_LIBFLATPAK
   fmt     = flatpak_ref_format_ref (FLATPAK_REF (ref));
-  cmdline = g_strdup_printf ("flatpak-spawn --host systemd-run --user --pipe flatpak run %s", fmt);
+
+  if (g_file_test ("/run/systemd", G_FILE_TEST_EXISTS))
+    cmdline = g_strdup_printf ("flatpak-spawn --host systemd-run --user --pipe flatpak run %s", fmt);
+  else
+    cmdline = g_strdup_printf ("flatpak-spawn --host flatpak run %s", fmt);
 
   return g_spawn_command_line_async (cmdline, error);
 #else


### PR DESCRIPTION
Fixes #247 
Previously opening installed programs (X11 or Wayland) largely didn't work, as the flatpak-system-helper service that runs the commands invoked by `flatpak-spawn` does not have a proper graphical environment. 
Using `systemd-run` resolves this, as it connects to the user's graphical session and has the correct environment.
Example of the environment difference:
```
> flatpak run --command=sh io.github.ilya_zlobintsev.LACT
F: Not sharing "/usr/share/icons" with sandbox: Path "/usr" is reserved by Flatpak
[📦 io.github.ilya_zlobintsev.LACT ~]$ flatpak-spawn --host sh -c 'echo $WAYLAND_DISPLAY'

[📦 io.github.ilya_zlobintsev.LACT ~]$ flatpak-spawn --host systemd-run --user --pipe sh -c 'echo $WAYLAND_DISPLAY'
Running as unit: run-p63500-i63501.service
wayland-0
```
With this PR both Wayland and X11 applications now launch correctly.

Obviously this won't work on systems without systemd, but I'm not sure if this is a major concern or not.