### PR TITLE
ui: Clean up full app view

### DIFF
--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -1525,6 +1525,17 @@ bz_entry_get_share_urls (BzEntry *self)
 }
 
 const char *
+bz_entry_get_url (BzEntry *self)
+{
+  BzEntryPrivate *priv = NULL;
+
+  g_return_val_if_fail (BZ_IS_ENTRY (self), NULL);
+  priv = bz_entry_get_instance_private (self);
+
+  return priv->url;
+}
+
+const char *
 bz_entry_get_donation_url (BzEntry *self)
 {
   BzEntryPrivate *priv = NULL;

--- a/src/bz-entry.h
+++ b/src/bz-entry.h
@@ -116,6 +116,9 @@ GListModel *
 bz_entry_get_share_urls (BzEntry *self);
 
 const char *
+bz_entry_get_url (BzEntry *self);
+
+const char *
 bz_entry_get_donation_url (BzEntry *self);
 
 const char *

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -76,6 +76,7 @@ template $BzFullView: Adw.Bin {
 
                     Box {
                       orientation: vertical;
+                      valign: center;
                       spacing: 15;
 
                       Box {
@@ -100,7 +101,6 @@ template $BzFullView: Adw.Bin {
                           
                           Label {
                             styles [
-                              "title-4",
                               "accent",
                             ]
 
@@ -127,17 +127,6 @@ template $BzFullView: Adw.Bin {
                               icon-size: normal;
                             };
                           }
-                        }
-                        
-                        Label {
-                          styles [
-                            "title-2",
-                          ]
-
-                          xalign: 0.0;
-                          wrap: true;
-                          wrap-mode: word_char;
-                          label: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.description;
                         }
                       }
                     }
@@ -193,25 +182,7 @@ template $BzFullView: Adw.Bin {
                             tooltip-text: _("Download and install this application");
                             visible: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.installable) as <bool>) as <bool>;
                             sensitive: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.installable-and-available) as <bool>) as <bool>;
-
-                            child: Box {
-                              orientation: horizontal;
-                              spacing: 5;
-                              hexpand: false;
-
-                              Image {
-                                icon-name: "folder-download-symbolic";
-                              }
-
-                              Label {
-                                styles [
-                                  "caption-heading",
-                                ]
-
-                                label: _("Install");
-                              }
-                            };
-
+                            label: _("Install");
                             clicked => $install_cb(template);
                           }
 
@@ -314,21 +285,8 @@ template $BzFullView: Adw.Bin {
                           valign: start;
                           has-tooltip: true;
                           tooltip-text: _("Support this developer");
+                          label: _("Support");
                           clicked => $support_cb(template);
-
-                          child: Box {
-                            hexpand: false;
-                            orientation: horizontal;
-                            spacing: 10;
-
-                            Image {
-                              icon-name: "heart-filled-symbolic";
-                            }
-
-                            Label {
-                              label: _("Support");
-                            }
-                          };
                         }
                       };
                     }
@@ -375,13 +333,26 @@ template $BzFullView: Adw.Bin {
                   }
 
                   Label {
+                      styles [
+                        "title-2",
+                      ]
+                      margin-start: 5;
+                      margin-top: 20;
+                      valign: start;
+                      xalign: 0;
+                      wrap: true;
+                      wrap-mode: word_char;
+                      label: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.description;
+                  }
+
+                  Label {
                     styles [
                       "body",
                     ]
 
-                    margin-start: 10;
+                    margin-start: 5;
                     margin-end: 10;
-                    margin-top: 10;
+                    margin-top: 0;
                     margin-bottom: 10;
                     valign: start;
                     xalign: 0;
@@ -397,13 +368,25 @@ template $BzFullView: Adw.Bin {
                     title: "App Details";
 
                     Adw.ActionRow {
-                      title: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.project-license;
-                      title-selectable: true;
-                      subtitle: bind $pick_license_warning(template.ui-entry as <$BzResult>.object as <$BzEntry>.is-floss) as <string>;
+                      title: _("Download Size");
+                      subtitle: bind $format_size(template.ui-entry as <$BzResult>.object as <$BzEntry>.size) as <string>;
 
                       [prefix]
                       Image {
-                        icon-size: large;
+                        has-tooltip: true;
+                        tooltip-text: _("Download size");
+                        icon-name: "folder-download-symbolic";
+                      }
+                    }
+
+                    Adw.ActionRow {
+                      title: _("License");
+                      subtitle: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.project-license;
+                      title-selectable: true;
+                      activatable-widget: license_button;
+
+                      [prefix]
+                      Image {
                         has-tooltip: true;
                         icon-name: "license-symbolic";
                         visible: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.is-floss;
@@ -411,49 +394,55 @@ template $BzFullView: Adw.Bin {
 
                       [prefix]
                       Image {
-                        icon-size: large;
                         has-tooltip: true;
                         icon-name: "dialog-warning-symbolic";
                         visible: bind $invert_boolean(template.ui-entry as <$BzResult>.object as <$BzEntry>.is-floss) as <bool>;
                       }
-                    }
 
-                    Adw.ActionRow {
-                      title: bind template.entry-group as <$BzEntryGroup>.remote-repos-string;
-
-                      [prefix]
-                      Image {
-                        icon-size: large;
-                        has-tooltip: true;
-                        tooltip-text: _("Remote repo name");
-                        icon-name: "globe-symbolic";
+                      [suffix]
+                      MenuButton license_button {
+                        popover: license_info_popover;
+                        icon-name: "dialog-information-symbolic";
+                        valign: center;
+                        styles ["flat"]
                       }
                     }
 
                     Adw.ActionRow {
                       use-markup: true;
-                      title: bind $format_as_link(template.ui-entry as <$BzResult>.object as <$BzEntry>.url) as <string>;
+                      title: _("Project Website");
+                      subtitle: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.url;
+                      activatable: true;
+                      activated => $open_url_cb(template);
 
                       [prefix]
                       Image {
-                        icon-size: large;
                         has-tooltip: true;
-                        tooltip-text: _("Project URL");
+                        tooltip-text: _("Project Website");
+                        icon-name: "globe-symbolic";
+                      }
+
+                      [suffix]
+                      Image {
+                        margin-end: 8;
+                        has-tooltip: true;
+                        tooltip-text: _("Open in browser");
                         icon-name: "external-link-symbolic";
                       }
                     }
 
                     Adw.ActionRow {
-                      title: bind $format_size(template.ui-entry as <$BzResult>.object as <$BzEntry>.size) as <string>;
+                      title: _("Repositories");
+                      subtitle: bind template.entry-group as <$BzEntryGroup>.remote-repos-string;
 
                       [prefix]
                       Image {
-                        icon-size: large;
                         has-tooltip: true;
-                        tooltip-text: _("Download size");
-                        icon-name: "drive-harddisk-symbolic";
+                        tooltip-text: _("Remote repo name");
+                        icon-name: "network-server-symbolic";
                       }
                     }
+
                   }
 
                   Frame {
@@ -582,4 +571,20 @@ template $BzFullView: Adw.Bin {
       };
     }
   };
+}
+
+
+Popover license_info_popover {
+  Label {
+    max-width-chars: 30;
+    justify: center;
+    wrap: true;
+
+    margin-top: 6;
+    margin-bottom: 6;
+    margin-start: 6;
+    margin-end: 6;
+
+   label:bind $pick_license_warning(template.ui-entry as <$BzResult>.object as <$BzEntry>.is-floss) as <string>;
+  }
 }

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -193,13 +193,9 @@ format_recent_downloads (gpointer object,
 }
 
 static char *
-format_size (gpointer object,
-             guint64  value)
+format_size (gpointer object, guint64 value)
 {
-  g_autofree char *size = NULL;
-
-  size = g_format_size (value);
-  return g_strdup_printf ("%s Download", size);
+  return g_format_size (value);
 }
 
 static char *
@@ -230,6 +226,22 @@ pick_license_warning (gpointer object,
   return value
              ? g_strdup (_ ("This application has a FLOSS license, meaning the source code can be audited for safety."))
              : g_strdup (_ ("This application has a proprietary license, meaning the source code is developed privately and cannot be audited by an independent third party."));
+}
+
+static void
+open_url_cb (BzFullView   *self,
+             AdwActionRow *row)
+{
+  BzEntry    *entry = NULL;
+  const char *url   = NULL;
+
+  entry = BZ_ENTRY (bz_result_get_object (self->ui_entry));
+  url   = bz_entry_get_url (entry);
+
+  if (url != NULL && *url != '\0')
+    g_app_info_launch_default_for_uri (url, NULL, NULL);
+  else
+    g_warning ("Invalid or empty URL provided");
 }
 
 static void
@@ -467,6 +479,7 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, format_size);
   gtk_widget_class_bind_template_callback (widget_class, format_timestamp);
   gtk_widget_class_bind_template_callback (widget_class, format_as_link);
+  gtk_widget_class_bind_template_callback (widget_class, open_url_cb);
   gtk_widget_class_bind_template_callback (widget_class, share_cb);
   gtk_widget_class_bind_template_callback (widget_class, dl_stats_cb);
   gtk_widget_class_bind_template_callback (widget_class, run_cb);


### PR DESCRIPTION
I have tried to rework some UI elements in the full app view that I personally found a bit awkward. Here are the changes I made:

- Changed prefix icons in `ActionRow`s to the sizes usually seen in other apps.
- Added titles and subtitles to `ActionRow`s.
- Removed icons from buttons that already have labels, following the [HIG](https://developer.gnome.org/hig/patterns/controls/buttons.html).
- Moved license context into a popover instead of a subtitle.
- Made `ActionRow`s with actions activatable.
- Moved the summary above the description, as app developers generally expect them to appear together. Flathub also recommends not repeating the summary in the description for this reason.

Feel free to ask for changes.

<img width="1342" height="1022" alt="full-view-cleanup" src="https://github.com/user-attachments/assets/3f3ca9e7-e39d-439b-b46c-6a51e17ec8a0" />
