### PR TITLE
Update glycin dependency for glycin-2

### DIFF
--- a/src/bz-async-texture.c
+++ b/src/bz-async-texture.c
@@ -23,7 +23,7 @@
 #define MAX_LOAD_RETRIES       3
 #define RETRY_INTERVAL_SECONDS 5
 
-#include <glycin-gtk4-1/glycin-gtk4.h>
+#include <glycin-gtk4-2/glycin-gtk4.h>
 #include <libdex.h>
 
 #include "bz-async-texture.h"

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,8 +13,8 @@ xmlb_dep             = dependency('xmlb', version: '>= 0.3.4')
 yaml_dep             = dependency('yaml-0.1', version: '>= 0.2.5')
 libsoup_dep          = dependency('libsoup-3.0', version: '>= 3.6.0')
 json_glib_dep        = dependency('json-glib-1.0', version: '>= 1.10.0')
-glycin_dep           = dependency('glycin-1', version: '>= 1.0')
-glycin_gtk4_dep      = dependency('glycin-gtk4-1', version: '>= 1.0')
+glycin_dep           = dependency('glycin-2', version: '>= 1.0')
+glycin_gtk4_dep      = dependency('glycin-gtk4-2', version: '>= 1.0')
 
 
 dl_worker_sources = [


### PR DESCRIPTION
Needed for Fedora rawhide, note that this will break building against older glycin. I would wait until glycin-2 is stable before merging this to make the transition as easy as possible.