### PR TITLE
Rework button area on full view

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -128,6 +128,25 @@ template $BzFullView: Adw.Bin {
                             };
                           }
                         }
+
+                        Button {
+                          visible: bind $invert_boolean($is_null(template.ui-entry as <$BzResult>.object as <$BzEntry>.donation-url) as <bool>) as <bool>;
+                          styles [
+                            "pill",
+                            "suggested-action",
+                            "support-button"
+                          ]
+                          margin-top:8;
+                          valign: start;
+                          halign: start;
+                          has-tooltip: true;
+                          tooltip-text: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.donation-url;
+                          clicked => $support_cb(template);
+                          child: Adw.ButtonContent {
+                            label: _("Support");
+                            icon-name: "heart-filled-symbolic";
+                          };
+                        }
                       }
                     }
                   }
@@ -208,86 +227,18 @@ template $BzFullView: Adw.Bin {
                       focusable: false;
                       halign: start;
                       hexpand: false;
-                      
-                      child: Box {
+                      child: Button {
                         styles [
-                          "linked",
+                          "circular",
+                          "flat"
                         ]
 
-                        orientation: horizontal;
-
-                        Button {
-                          styles [
-                            "pill",
-                          ]
-
-                          vexpand: false;
-                          has-tooltip: true;
-                          tooltip-text: _("Share this application");
-                          icon-name: "share-alt-symbolic";
-                          clicked => $share_cb(template);
-                        }
-
-                        Button {
-                          styles [
-                            "pill",
-                          ]
-
-                          vexpand: false;
-                          has-tooltip: true;
-                          tooltip-text: _("The number of downloads in the last 30 days. Click to view this application's download statistics.");
-                          visible: bind $invert_boolean($is_null(template.debounced-ui-entry) as <bool>) as <bool>;
-                          sensitive: bind $invert_boolean($is_zero(template.debounced-ui-entry as <$BzResult>.object as <$BzEntry>.recent-downloads) as <bool>) as <bool>;
-                          clicked => $dl_stats_cb(template);
-
-                          child: Box {
-                            hexpand: false;
-                            orientation: horizontal;
-                            spacing: 10;
-
-                            Image {
-                              icon-name: "graph-symbolic";
-                            }
-
-                            Adw.Spinner {
-                              visible: bind $is_null(template.debounced-ui-entry) as <bool>;
-                            }
-                          
-                            Label {
-                              label: bind $format_recent_downloads(template.debounced-ui-entry as <$BzResult>.object as <$BzEntry>.recent-downloads) as <string>;
-                              visible: bind $invert_boolean($is_null(template.debounced-ui-entry) as <bool>) as <bool>;
-                            }
-                          };
-                        }
-                      };
-                    }
-
-                    FlowBoxChild {
-                      focusable: false;
-                      halign: start;
-                      hexpand: false;
-                      
-                      visible: bind $invert_boolean($is_null(template.ui-entry as <$BzResult>.object as <$BzEntry>.donation-url) as <bool>) as <bool>;
-
-                      child: Box {
-                        styles [
-                          "linked",
-                        ]
-
-                        orientation: horizontal;
-                      
-                        Button {
-                          styles [
-                            "pill",
-                            "suggested-action",
-                          ]
-
-                          valign: start;
-                          has-tooltip: true;
-                          tooltip-text: _("Support this developer");
-                          label: _("Support");
-                          clicked => $support_cb(template);
-                        }
+                        vexpand: false;
+                        width-request:45;
+                        has-tooltip: true;
+                        tooltip-text: _("Share this application");
+                        icon-name: "share-alt-symbolic";
+                        clicked => $share_cb(template);
                       };
                     }
 
@@ -428,6 +379,29 @@ template $BzFullView: Adw.Bin {
                         has-tooltip: true;
                         tooltip-text: _("Open in browser");
                         icon-name: "external-link-symbolic";
+                      }
+                    }
+
+                    Adw.ActionRow {
+                      title: _("Download Statistics");
+                      subtitle: bind $format_recent_downloads(template.debounced-ui-entry as <$BzResult>.object as <$BzEntry>.recent-downloads) as <string>;
+                      sensitive: bind $invert_boolean($is_null(template.debounced-ui-entry) as <bool>) as <bool>;
+                      activatable: true;
+                      activated => $dl_stats_cb(template);
+
+                      [prefix]
+                      Image {
+                        has-tooltip: true;
+                        tooltip-text: _("Download Statistics");
+                        icon-name: "graph-symbolic";
+                      }
+
+                      [suffix]
+                      Image {
+                        margin-end: 8;
+                        has-tooltip: true;
+                        tooltip-text: _("Show Downloads Over Time");
+                        icon-name: "go-next-symbolic";
                       }
                     }
 

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -184,12 +184,12 @@ is_null (gpointer object,
 
 static char *
 format_recent_downloads (gpointer object,
-                       int value)
+                         int      value)
 {
- if (value > 0)
-   return g_strdup_printf (_("%'d downloads in the last month"), value);
- else
-   return g_strdup ("---");
+  if (value > 0)
+    return g_strdup_printf (_ ("%'d downloads in the last month"), value);
+  else
+    return g_strdup ("---");
 }
 
 static char *

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -184,12 +184,12 @@ is_null (gpointer object,
 
 static char *
 format_recent_downloads (gpointer object,
-                         int      value)
+                       int value)
 {
-  if (value > 0)
-    return g_strdup_printf ("%'d", value);
-  else
-    return g_strdup ("---");
+ if (value > 0)
+   return g_strdup_printf (_("%'d downloads in the last month"), value);
+ else
+   return g_strdup ("---");
 }
 
 static char *

--- a/src/gtk/styles.css
+++ b/src/gtk/styles.css
@@ -44,3 +44,9 @@
     font-size: 1.33em;
     font-weight: normal;
 }
+
+.support-button {
+    background-color: alpha(#f06292, 0.25);
+    color: #f06292;
+    padding: 2px 12px;
+}


### PR DESCRIPTION
This PR reworks the button layout on the app listings page to reduce visual clutter. The previous design had 3 rows of pill buttons which looked awkward in my eyes.

Changes made:
- Moved the support button underneath the developer name with custom styling to make it more prominent, to be in line with the apps stated  goal of supporting app developers
- Relocated download statistics to the "App Details" section, which also now more obviously clarifies that the number shown represents downloads in the last month
- Changed the Share button to be styled flat to reduce the number of pill buttons

I would personally also suggest removing the install button when the app is already installed to reduce confusion, but I left it alone for now as there is probably a reason for it to be there.

Feel free once again to ask for changes.

<img width="1342" height="1022" alt="Screenshot From 2025-09-02 14-35-22" src="https://github.com/user-attachments/assets/b44b51cc-c3a5-4947-b29d-19d88023d491" />

<img width="1467" height="978" alt="image" src="https://github.com/user-attachments/assets/417728f3-6af1-4312-945a-b9b8b2f2cdeb" />
