### PR TITLE
Change the design of the Flathub page

### DIFF
--- a/src/bazaar.gresource.xml
+++ b/src/bazaar.gresource.xml
@@ -2,7 +2,8 @@
 <gresources>
   <gresource prefix="/io/github/kolunmi/Bazaar/">
     
-    <file>gtk/styles.css</file>
+    <file alias="style.css">gtk/style.css</file>
+    <file alias="style-dark.css">gtk/style-dark.css</file>
 
     <file preprocess="xml-stripblanks">main-config-schema.xml</file>
     <file preprocess="xml-stripblanks">bz-content-provider-config-schema.xml</file>

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -1002,16 +1002,6 @@ init_service_struct (BzApplication *self)
   g_debug ("Constructing gsettings for %s ...", app_id);
   self->settings = g_settings_new (app_id);
 
-  g_debug ("Loading css provider from resource path %s",
-           "/io/github/kolunmi/Bazaar/gtk/styles.css");
-  self->css = gtk_css_provider_new ();
-  gtk_css_provider_load_from_resource (
-      self->css, "/io/github/kolunmi/Bazaar/gtk/styles.css");
-  gtk_style_context_add_provider_for_display (
-      gdk_display_get_default (),
-      GTK_STYLE_PROVIDER (self->css),
-      GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-
   self->groups         = g_list_store_new (BZ_TYPE_ENTRY_GROUP);
   self->installed_apps = g_list_store_new (BZ_TYPE_ENTRY);
   self->ids_to_groups  = g_hash_table_new_full (

--- a/src/bz-flathub-page.blp
+++ b/src/bz-flathub-page.blp
@@ -2,308 +2,304 @@ using Gtk 4.0;
 using Adw 1;
 
 template $BzFlathubPage: Adw.Bin {
-  child: Adw.ViewStack stack {
-    enable-transitions: true;
-    transition-duration: 400;
+ child: Adw.ViewStack stack {
+   enable-transitions: true;
+   transition-duration: 400;
 
-    Adw.ViewStackPage {
-      name: "empty";
-      title: _("Empty");
+   Adw.ViewStackPage {
+     name: "empty";
+     title: _("Empty");
 
-      child: Adw.StatusPage {
-        icon-name: "flatpak-symbolic";
-        title: _("Flathub Not Added");
-        description: _("The Flathub remote was not found on any of your flatpak installations");
-      };
-    }
-    
-    Adw.ViewStackPage {
-      name: "content";
-      title: _("Browser");
+     child: Adw.StatusPage {
+       icon-name: "flatpak-symbolic";
+       title: _("Flathub Not Added");
+       description: _("The Flathub remote was not found on any of your flatpak installations");
+     };
+   }
+   
+   Adw.ViewStackPage {
+     name: "content";
+     title: _("Browser");
 
-      child: Overlay {
-        child: $BzPatternedBackground {
-          styles [
-            "flathub-background",
-          ]
-          tint: "#2c2737";
-          widget: Image {
-            icon-name: "flathub-favicon";
-            icon-size: large;
-          };
-        };
+     child: ScrolledWindow {
+       styles [
+         "transparent"
+       ]
 
-        [overlay]
-        ScrolledWindow {
-          styles [
-            "transparent",
-          ]
+       hscrollbar-policy: never;
 
-          hscrollbar-policy: never;
+       child: Adw.ClampScrollable {
+         maximum-size: 1500;
+         tightening-threshold: 1400;
 
-          child: Adw.ClampScrollable {
-            maximum-size: 1500;
-            tightening-threshold: 1400;
+         child: Viewport {
+           child: Box {
+             margin-start: 25;
+             margin-end: 25;
+             margin-top: 20;
+             margin-bottom: 20;
+             orientation: vertical;
+             spacing: 50;
 
-            child: Viewport {
-              child: Box {
-                margin-start: 20;
-                margin-end: 20;
-                margin-top: 20;
-                margin-bottom: 20;
-                orientation: vertical;
-                spacing: 50;
+             Box {
+               orientation: vertical;
+               spacing: 10;
+             
+               Label {
+                 margin-start: 8;
+                 styles [
+                   "title-1",
+                 ]
+                 label: _("Apps Of The Week");
+                 xalign: 0.0;
+               }
 
-                Box {
-                  orientation: vertical;
-                  spacing: 10;
-                
-                  Label {
-                    styles [
-                      "title-1",
-                    ]
-                    label: _("Apps Of The Week");
-                    xalign: 0.0;
-                  }
+               $BzDynamicListView {
+                 styles [
+                   "flathub-page-section",
+                 ]
+             
+                 hexpand: true;
+                 
+                 scroll: false;
+                 noscroll-kind: flow-box;
+                 child-type: "BzDetailedAppTile";
+                 child-prop: "group";
+                 model: SliceListModel {
+                   offset: 0;
+                   size: 7;
+                   model: bind template.state as <$BzFlathubState>.apps_of_the_week;
+                 };
 
-                  $BzDynamicListView {
-                    styles [
-                      "flathub-page-section",
-                    ]
-                
-                    hexpand: true;
-                    
-                    scroll: false;
-                    noscroll-kind: flow-box;
-                    child-type: "BzDetailedAppTile";
-                    child-prop: "group";
-                    model: SliceListModel {
-                      offset: 0;
-                      size: 7;
-                      model: bind template.state as <$BzFlathubState>.apps_of_the_week;
-                    };
+                 bind-widget => $bind_widget_cb(template);      
+                 unbind-widget => $unbind_widget_cb(template);      
+               }
+             }
 
-                    bind-widget => $bind_widget_cb(template);      
-                    unbind-widget => $unbind_widget_cb(template);      
-                  }
-                }
+             Box {
+               orientation: vertical;
+               spacing: 10;
 
-                Box {
-                  orientation: vertical;
-                  spacing: 10;
+               Box {
+                 orientation: horizontal;
+                 spacing: 10;
+                 margin-start: 8;
+                 margin-end: 8;
+               
+                 Label {
+                   styles [
+                     "title-1",
+                   ]
+                   label: _("Trending");
+                   xalign: 0.0;
+                   hexpand: true;
+                 }
 
-                  Box {
-                    orientation: horizontal;
-                    spacing: 10;
-                  
-                    Label {
-                      styles [
-                        "title-1",
-                      ]
-                      label: _("Trending");
-                      xalign: 0.0;
-                      hexpand: true;
-                    }
+                 ToggleButton show_more_trending {
+                   label: _("Show More");
+                   active: false;
+                 }
+               }
+             
+               $BzDynamicListView {
+                 styles [
+                   "flathub-page-section",
+                 ]
+               
+                 hexpand: true;
+               
+                 scroll: false;
+                 noscroll-kind: flow-box;
+                 child-type: "BzAppTile";
+                 child-prop: "group";
+                 model: SliceListModel {
+                   offset: 0;
+                   size: bind $limit_if_false(show_more_trending.active) as <uint>;
+                   model: bind template.state as <$BzFlathubState>.trending;
+                 };
+               
+                 bind-widget => $bind_widget_cb(template);      
+                 unbind-widget => $unbind_widget_cb(template);      
+               }
+             }
 
-                    ToggleButton show_more_trending {
-                      label: _("Show More");
-                      active: false;
-                    }
-                  }
-                
-                  $BzDynamicListView {
-                    styles [
-                      "flathub-page-section",
-                    ]
-                  
-                    hexpand: true;
-                  
-                    scroll: false;
-                    noscroll-kind: flow-box;
-                    child-type: "BzAppTile";
-                    child-prop: "group";
-                    model: SliceListModel {
-                      offset: 0;
-                      size: bind $limit_if_false(show_more_trending.active) as <uint>;
-                      model: bind template.state as <$BzFlathubState>.trending;
-                    };
-                  
-                    bind-widget => $bind_widget_cb(template);      
-                    unbind-widget => $unbind_widget_cb(template);      
-                  }
-                }
+             Box {
+               orientation: vertical;
+               spacing: 10;
 
-                Box {
-                  orientation: vertical;
-                  spacing: 10;
+               Label {
+                 margin-start: 8;
+                 styles [
+                   "title-1",
+                 ]
+                 label: _("Categories");
+                 xalign: 0.0;
+                 hexpand: true;
+               }
+             
+               $BzDynamicListView {
+                 styles [
+                   "flathub-page-section",
+                 ]
+               
+                 hexpand: true;
+               
+                 scroll: false;
+                 noscroll-kind: flow-box;
+                 child-type: "GtkButton";
+                 child-prop: "label";
+                 object-prop: "name";
+                 model: bind template.state as <$BzFlathubState>.categories;
+               
+                 bind-widget => $bind_category_btn_cb(template);
+                 unbind-widget => $unbind_category_btn_cb(template);
+               }
+             }
 
-                  Label {
-                    styles [
-                      "title-1",
-                    ]
-                    label: _("Categories");
-                    xalign: 0.0;
-                    hexpand: true;
-                  }
-                
-                  $BzDynamicListView {
-                    styles [
-                      "flathub-page-section",
-                    ]
-                  
-                    hexpand: true;
-                  
-                    scroll: false;
-                    noscroll-kind: flow-box;
-                    child-type: "GtkButton";
-                    child-prop: "label";
-                    object-prop: "name";
-                    model: bind template.state as <$BzFlathubState>.categories;
-                  
-                    bind-widget => $bind_category_btn_cb(template);
-                    unbind-widget => $unbind_category_btn_cb(template);
-                  }
-                }
+             Box {
+               orientation: vertical;
+               spacing: 10;
+             
+               Box {
+                 orientation: horizontal;
+                 spacing: 10;
+                 margin-start: 8;
+                 margin-end: 8;
+               
+                 Label {
+                   styles [
+                     "title-1",
+                   ]
+                   label: _("Recently Updated");
+                   xalign: 0.0;
+                   hexpand: true;
+                 }
+               
+                 ToggleButton show_more_recently_updated {
+                   label: _("Show More");
+                   active: false;
+                 }
+               }
+             
+               $BzDynamicListView {
+                 styles [
+                   "flathub-page-section",
+                 ]
+               
+                 hexpand: true;
+               
+                 scroll: false;
+                 noscroll-kind: flow-box;
+                 child-type: "BzAppTile";
+                 child-prop: "group";
+                 model: SliceListModel {
+                   offset: 0;
+                   size: bind $limit_if_false(show_more_recently_updated.active) as <uint>;
+                   model: bind template.state as <$BzFlathubState>.recently_updated;
+                 };
+               
+                 bind-widget => $bind_widget_cb(template);      
+                 unbind-widget => $unbind_widget_cb(template);      
+               }
+             }
 
-                Box {
-                  orientation: vertical;
-                  spacing: 10;
-                
-                  Box {
-                    orientation: horizontal;
-                    spacing: 10;
-                  
-                    Label {
-                      styles [
-                        "title-1",
-                      ]
-                      label: _("Recently Updated");
-                      xalign: 0.0;
-                      hexpand: true;
-                    }
-                  
-                    ToggleButton show_more_recently_updated {
-                      label: _("Show More");
-                      active: false;
-                    }
-                  }
-                
-                  $BzDynamicListView {
-                    styles [
-                      "flathub-page-section",
-                    ]
-                  
-                    hexpand: true;
-                  
-                    scroll: false;
-                    noscroll-kind: flow-box;
-                    child-type: "BzAppTile";
-                    child-prop: "group";
-                    model: SliceListModel {
-                      offset: 0;
-                      size: bind $limit_if_false(show_more_recently_updated.active) as <uint>;
-                      model: bind template.state as <$BzFlathubState>.recently_updated;
-                    };
-                  
-                    bind-widget => $bind_widget_cb(template);      
-                    unbind-widget => $unbind_widget_cb(template);      
-                  }
-                }
-
-                Box {
-                  orientation: vertical;
-                  spacing: 10;
-                
-                  Box {
-                    orientation: horizontal;
-                    spacing: 10;
-                  
-                    Label {
-                      styles [
-                        "title-1",
-                      ]
-                      label: _("Recently Added");
-                      xalign: 0.0;
-                      hexpand: true;
-                    }
-                  
-                    ToggleButton show_more_recently_added {
-                      label: _("Show More");
-                      active: false;
-                    }
-                  }
-                
-                  $BzDynamicListView {
-                    styles [
-                      "flathub-page-section",
-                    ]
-                  
-                    hexpand: true;
-                  
-                    scroll: false;
-                    noscroll-kind: flow-box;
-                    child-type: "BzAppTile";
-                    child-prop: "group";
-                    model: SliceListModel {
-                      offset: 0;
-                      size: bind $limit_if_false(show_more_recently_added.active) as <uint>;
-                      model: bind template.state as <$BzFlathubState>.recently_added;
-                    };
-                  
-                    bind-widget => $bind_widget_cb(template);      
-                    unbind-widget => $unbind_widget_cb(template);      
-                  }
-                }
-              
-                Box {
-                  orientation: vertical;
-                  spacing: 10;
-                
-                  Box {
-                    orientation: horizontal;
-                    spacing: 10;
-                  
-                    Label {
-                      styles [
-                        "title-1",
-                      ]
-                      label: _("Popular");
-                      xalign: 0.0;
-                      hexpand: true;
-                    }
-                  
-                    ToggleButton show_more_popular {
-                      label: _("Show More");
-                      active: false;
-                    }
-                  }
-                
-                  $BzDynamicListView {
-                    styles [
-                      "flathub-page-section",
-                    ]
-                  
-                    hexpand: true;
-                  
-                    scroll: false;
-                    noscroll-kind: flow-box;
-                    child-type: "BzAppTile";
-                    child-prop: "group";
-                    model: SliceListModel {
-                      offset: 0;
-                      size: bind $limit_if_false(show_more_popular.active) as <uint>;
-                      model: bind template.state as <$BzFlathubState>.popular;
-                    };
-                  
-                    bind-widget => $bind_widget_cb(template);      
-                    unbind-widget => $unbind_widget_cb(template);      
-                  }
-                }
-              };
-            };
-          };
-        }
-      };
-    }
-  };
+             Box {
+               orientation: vertical;
+               spacing: 10;
+             
+               Box {
+                 orientation: horizontal;
+                 spacing: 10;
+                 margin-start: 8;
+                 margin-end: 8;
+               
+                 Label {
+                   styles [
+                     "title-1",
+                   ]
+                   label: _("Recently Added");
+                   xalign: 0.0;
+                   hexpand: true;
+                 }
+               
+                 ToggleButton show_more_recently_added {
+                   label: _("Show More");
+                   active: false;
+                 }
+               }
+             
+               $BzDynamicListView {
+                 styles [
+                   "flathub-page-section",
+                 ]
+               
+                 hexpand: true;
+               
+                 scroll: false;
+                 noscroll-kind: flow-box;
+                 child-type: "BzAppTile";
+                 child-prop: "group";
+                 model: SliceListModel {
+                   offset: 0;
+                   size: bind $limit_if_false(show_more_recently_added.active) as <uint>;
+                   model: bind template.state as <$BzFlathubState>.recently_added;
+                 };
+               
+                 bind-widget => $bind_widget_cb(template);      
+                 unbind-widget => $unbind_widget_cb(template);      
+               }
+             }
+           
+             Box {
+               orientation: vertical;
+               spacing: 10;
+             
+               Box {
+                 orientation: horizontal;
+                 spacing: 10;
+                 margin-start: 8;
+                 margin-end: 8;
+               
+                 Label {
+                   styles [
+                     "title-1",
+                   ]
+                   label: _("Popular");
+                   xalign: 0.0;
+                   hexpand: true;
+                 }
+               
+                 ToggleButton show_more_popular {
+                   label: _("Show More");
+                   active: false;
+                 }
+               }
+             
+               $BzDynamicListView {
+                 styles [
+                   "flathub-page-section",
+                 ]
+               
+                 hexpand: true;
+               
+                 scroll: false;
+                 noscroll-kind: flow-box;
+                 child-type: "BzAppTile";
+                 child-prop: "group";
+                 model: SliceListModel {
+                   offset: 0;
+                   size: bind $limit_if_false(show_more_popular.active) as <uint>;
+                   model: bind template.state as <$BzFlathubState>.popular;
+                 };
+               
+                 bind-widget => $bind_widget_cb(template);      
+                 unbind-widget => $unbind_widget_cb(template);      
+               }
+             }
+           };
+         };
+       };
+     };
+   }
+ };
 }

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -33,8 +33,8 @@ template $BzWindow: Adw.ApplicationWindow {
       height-request: 450;
 
       child: Adw.ToolbarView toolbar_view {
-        top-bar-style: raised_border;
-        bottom-bar-style: raised_border;
+        top-bar-style: raised;
+        bottom-bar-style: raised;
         reveal-bottom-bars: false;
 
         content: Adw.OverlaySplitView split_view {
@@ -45,6 +45,7 @@ template $BzWindow: Adw.ApplicationWindow {
           sidebar: Adw.ViewStack transactions_stack {
             enable-transitions: true;
             transition-duration: 200;
+            styles ["transactions-stack"]
 
             Adw.ViewStackPage {
               name: "empty";
@@ -148,6 +149,8 @@ template $BzWindow: Adw.ApplicationWindow {
                 child: Adw.ViewStack main_stack {
                   enable-transitions: true;
                   transition-duration: 200;
+
+                  notify::visible-child => $visible_page_changed_cb(template);
 
                   Adw.ViewStackPage {
                     name: "offline";
@@ -253,6 +256,10 @@ template $BzWindow: Adw.ApplicationWindow {
 
         [top]
         Adw.HeaderBar top_header_bar {
+          styles [
+            "toplevel-headerbar"
+          ]
+
           [start]
           Button go_back {
             has-tooltip: true;
@@ -415,6 +422,9 @@ template $BzWindow: Adw.ApplicationWindow {
 
         [bottom]
         Adw.HeaderBar bottom_header_bar {
+          styles [
+            "toplevel-headerbar"
+          ]
           show-start-title-buttons: false;
           show-end-title-buttons: false;
         }

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -310,6 +310,21 @@ page_toggled_cb (BzWindow       *self,
 }
 
 static void
+visible_page_changed_cb (BzWindow     *self,
+                         GParamSpec   *pspec,
+                         AdwViewStack *view_stack)
+{
+  const char *visible_child_name = NULL;
+
+  visible_child_name = adw_view_stack_get_visible_child_name (view_stack);
+
+  if (g_strcmp0 (visible_child_name, "flathub") == 0)
+    gtk_widget_add_css_class (GTK_WIDGET (self), "flathub");
+  else
+    gtk_widget_remove_css_class (GTK_WIDGET (self), "flathub");
+}
+
+static void
 breakpoint_apply_cb (BzWindow      *self,
                      AdwBreakpoint *breakpoint)
 {
@@ -468,6 +483,7 @@ bz_window_class_init (BzWindowClass *klass)
   // gtk_widget_class_bind_template_callback (widget_class, refresh_cb);
   gtk_widget_class_bind_template_callback (widget_class, update_cb);
   gtk_widget_class_bind_template_callback (widget_class, transactions_clear_cb);
+  gtk_widget_class_bind_template_callback (widget_class, visible_page_changed_cb);
 
   gtk_widget_class_install_action (widget_class, "escape", NULL, action_escape);
 }

--- a/src/gtk/style-dark.css
+++ b/src/gtk/style-dark.css
@@ -1,0 +1,12 @@
+.flathub .toplevel-headerbar{
+  background-color: #3e3947;
+}
+.flathub .global-search {
+  background-color: #251f32;
+}
+window.flathub {
+  background-color: #251f32;
+}
+.flathub .transactions-stack {
+  background-color: #2f273f;
+}

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -21,7 +21,7 @@
 }
 
 .app-tile {
-    background-color: alpha(var(--card-bg-color), 0.4);
+    background-color: alpha(var(--card-bg-color), 0.7);
 }
 
 .screenshot {
@@ -51,13 +51,13 @@
     padding: 2px 12px;
 }
 
-
 .flathub-page-section {
-    padding: 10px;
-    background-color: alpha(var(--accent-bg-color), 0.45);
     border-radius: 10px;
 }
 
-.flathub-background {
-    background-color: #251f32;
+window,
+headerbar,
+.global-search {
+  transition: background-color 0.2s ease;
 }
+


### PR DESCRIPTION
This PR updates the design of the Flathub page to better match the style of the Flathub website, which seems to be the design goal for this page, i believe. I also updated other UI elements, such as the download sidebar and header bar, to follow the same style when on the Flathub page.

In addition, I removed the unnecessary manual loading of stylesheets by using GTK’s automatic asset loading.

<img width="1453" height="1022" alt="image" src="https://github.com/user-attachments/assets/ea1cd3c5-ce3c-4739-985c-66722f1f4bc9" />

Before:

<img width="1342" height="1022" alt="image" src="https://github.com/user-attachments/assets/030c7089-6eb3-4ee8-8926-dcbca3e89a6e" />

Feel free to ask for changes.