### PR TITLE
Move forge stars next to donation button

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -128,24 +128,57 @@ template $BzFullView: Adw.Bin {
                             };
                           }
                         }
+                        Box {
+                          spacing: 8;
+                          Button {
+                            visible: bind $invert_boolean($is_null(template.ui-entry as <$BzResult>.object as <$BzEntry>.donation-url) as <bool>) as <bool>;
+                            styles [
+                              "pill",
+                              "suggested-action",
+                              "support-button"
+                            ]
+                            margin-top:8;
+                            valign: start;
+                            halign: start;
+                            has-tooltip: true;
+                            tooltip-text: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.donation-url;
+                            clicked => $support_cb(template);
+                            child: Adw.ButtonContent {
+                              label: _("Support");
+                              icon-name: "heart-filled-symbolic";
+                            };
+                          }
+                          Revealer forge_stars{
+                            transition-type: slide_down;
+                            reveal-child: false;
+                            child: Button {
+                              styles [
+                                "pill",
+                                "suggested-action",
+                                "star-button"
+                              ]
 
-                        Button {
-                          visible: bind $invert_boolean($is_null(template.ui-entry as <$BzResult>.object as <$BzEntry>.donation-url) as <bool>) as <bool>;
-                          styles [
-                            "pill",
-                            "suggested-action",
-                            "support-button"
-                          ]
-                          margin-top:8;
-                          valign: start;
-                          halign: start;
-                          has-tooltip: true;
-                          tooltip-text: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.donation-url;
-                          clicked => $support_cb(template);
-                          child: Adw.ButtonContent {
-                            label: _("Support");
-                            icon-name: "heart-filled-symbolic";
-                          };
+                              margin-top:8;
+                              valign: start;
+                              halign: start;
+                              has-tooltip: true;
+                              tooltip-text: _("Repository Star Count");
+                              clicked => $forge_cb(template);
+
+                              child: Box {
+                                hexpand: false;
+                                orientation: horizontal;
+                                spacing: 10;
+
+                                Image {
+                                  icon-name: "starred-symbolic";
+                                }
+
+                                Label forge_stars_label {}
+                              };
+                            };
+                          }
+
                         }
                       }
                     }
@@ -239,43 +272,6 @@ template $BzFullView: Adw.Bin {
                         tooltip-text: _("Share this application");
                         icon-name: "share-alt-symbolic";
                         clicked => $share_cb(template);
-                      };
-                    }
-
-                    FlowBoxChild forge_stars {
-                      focusable: false;
-                      halign: start;
-                      hexpand: false;
-                      
-                      child: Box {
-                        styles [
-                          "linked",
-                        ]
-
-                        orientation: horizontal;
-                      
-                        Button {
-                          styles [
-                            "pill",
-                          ]
-
-                          valign: start;
-                          has-tooltip: true;
-                          tooltip-text: _("VCS Forge Star Count");
-                          clicked => $forge_cb(template);
-
-                          child: Box {
-                            hexpand: false;
-                            orientation: horizontal;
-                            spacing: 10;
-
-                            Image {
-                              icon-name: "starred-symbolic";
-                            }
-
-                            Label forge_stars_label {}
-                          };
-                        }
                       };
                     }
                   }

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -544,6 +544,7 @@ bz_full_view_set_entry_group (BzFullView   *self,
   g_clear_object (&self->group_model);
 
   gtk_widget_set_visible (self->forge_stars, FALSE);
+  gtk_revealer_set_reveal_child(GTK_REVEALER(self->forge_stars), FALSE);
   gtk_label_set_label (self->forge_stars_label, "...");
 
   if (group != NULL)
@@ -646,6 +647,7 @@ retrieve_star_string_fiber (BzFullView *self)
   fmt        = g_strdup_printf ("%'zu", star_count);
 
   gtk_widget_set_visible (self->forge_stars, TRUE);
+  gtk_revealer_set_reveal_child(GTK_REVEALER(self->forge_stars), TRUE);
 
 done:
   gtk_label_set_label (self->forge_stars_label, fmt != NULL ? fmt : "?");

--- a/src/gtk/styles.css
+++ b/src/gtk/styles.css
@@ -51,6 +51,11 @@
     padding: 2px 12px;
 }
 
+.star-button {
+    background-color: alpha(@warning_bg_color, 0.25);
+    color: @warning_color;
+    padding: 2px 12px;
+}
 
 .flathub-page-section {
     padding: 10px;


### PR DESCRIPTION
This PR moves the Git Forge Star counter next to the support button and gives it a custom style.

Since giving a star is also a form of support, I think it makes sense to place it next to the support button. This change also helps reduce clutter in the main row.

<img width="484" height="338" alt="image" src="https://github.com/user-attachments/assets/fcc1424c-0b13-498a-a27c-c75fad8b01ca" />
