### PR TITLE
meson: Install SearchProvider service file

### DIFF
--- a/data/dbus/io.github.kolunmi.Bazaar.SearchProvider.service.in
+++ b/data/dbus/io.github.kolunmi.Bazaar.SearchProvider.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=io.github.kolunmi.Bazaar.SearchProvider
+Exec=@bindir@/bazaar service

--- a/data/dbus/meson.build
+++ b/data/dbus/meson.build
@@ -6,3 +6,10 @@ configure_file(
   configuration: service_conf,
   install_dir: get_option('datadir') / 'dbus-1' / 'services'
 )
+
+configure_file(
+  input: 'io.github.kolunmi.bazaar.searchprovider.service.in',
+  output: 'io.github.kolunmi.Bazaar.Searchprovider.service',
+  configuration: service_conf,
+  install_dir: get_option('datadir') / 'dbus-1' / 'services'
+)

--- a/data/io.github.kolunmi.Bazaar.desktop.in
+++ b/data/io.github.kolunmi.Bazaar.desktop.in
@@ -9,3 +9,4 @@ Categories=Utility;
 Keywords=GTK;System;PackageManager;Discover;Flatpak;Software;Store;
 StartupNotify=true
 MimeType=x-scheme-handler/appstream;x-scheme-handler/flatpak;x-scheme-handler/flatpak+https;
+DBusActivatable=true


### PR DESCRIPTION
Also mark the desktop file as dbus-activatable so
it will work be able to get launched from dbus, and
without the service already running
