### PR TITLE
Rework the Installed page

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -133,9 +133,9 @@ template $BzFullView: Adw.Bin {
                           Button {
                             visible: bind $invert_boolean($is_null(template.ui-entry as <$BzResult>.object as <$BzEntry>.donation-url) as <bool>) as <bool>;
                             styles [
-                              "pill",
+                              "small-pill",
                               "suggested-action",
-                              "support-button"
+                              "support"
                             ]
                             margin-top:8;
                             valign: start;
@@ -153,9 +153,9 @@ template $BzFullView: Adw.Bin {
                             reveal-child: false;
                             child: Button {
                               styles [
-                                "pill",
+                                "small-pill",
                                 "suggested-action",
-                                "star-button"
+                                "star"
                               ]
 
                               margin-top:8;

--- a/src/bz-installed-page.blp
+++ b/src/bz-installed-page.blp
@@ -71,102 +71,79 @@ template $BzInstalledPage: Adw.Bin {
                     visible: bind $is_null(template.item as <$BzEntry>.icon-paintable) as <bool>;
                   }
 
-                  Label {
-                    styles [
-                      "heading",
-                    ]
-
-                    hexpand: true;
-                    xalign: 0.0;
-                    ellipsize: end;
-                    single-line-mode: true;
-                    label: bind template.item as <$BzEntry>.title;
-                  }
-
-                  Label {
-                    styles [
-                      "dimmed",
-                    ]
-
-                    xalign: 1.0;
-                    ellipsize: end;
-                    single-line-mode: true;
-                    selectable: true;
-                    has-tooltip: true;
-                    tooltip-text: bind template.item as <$BzEntry>.unique_id;
-                    label: bind template.item as <$BzEntry>.id;
-                  }
-
                   Box {
-                    styles [
-                      "linked",
-                    ]
-                      
                     orientation: horizontal;
-                    hexpand: false;
-                    
+                    spacing: 8;
+                    hexpand: true;
+
+                    Label {
+                      xalign: 0.0;
+                      ellipsize: end;
+                      single-line-mode: true;
+                      has-tooltip: true;
+                      tooltip-text: bind template.item as <$BzEntry>.id;
+                      label: bind template.item as <$BzEntry>.title;
+                    }
+
                     Button {
                       styles [
+                        "circular",
+                        "flat",
                         "suggested-action",
-                        "card-row-btn",
+                        "support"
                       ]
                       
                       has-tooltip: true;
                       tooltip-text: _("Support this application");
                       
-                      width-request: 60;
-                      valign: fill;
-                      halign: fill;
-                      hexpand: true;
+                      width-request: 32;
+                      height-request: 32;
+                      valign: center;
                       icon-name: "heart-filled-symbolic";
                       visible: bind $invert_boolean($is_null(template.item as <$BzEntry>.donation-url) as <bool>) as <bool>;
                       
                       clicked => $support_cb(template);
                     }
+                  }
 
-                    Button {
-                      styles [
-                        "card-row-btn",
-                      ]
-                      
-                      has-tooltip: true;
-                      tooltip-text: _("This application does not provide a donation link");
-                      
-                      width-request: 60;
-                      valign: fill;
-                      halign: fill;
-                      hexpand: true;
-                      icon-name: "heart-outline-thick-symbolic";
-                      visible: bind $is_null(template.item as <$BzEntry>.donation-url) as <bool>;
-
-                      clicked => $no_support_cb(template);
-                    }
+                  Box {
+                    orientation: horizontal;
+                    hexpand: false;
+                    spacing: 8;
+                    margin-end:8;
                     
                     Button {
                       styles [
-                        "card-row-btn",
+                        "destructive-action",
+                        "flat"
                       ]
                       
                       has-tooltip: true;
-                      tooltip-text: _("Run this application");
+                      tooltip-text: _("Remove");
+                      
+                      width-request: 32;
+                      height-request: 32;
+                      valign: center;
+                      icon-name: "user-trash-symbolic";
+                      sensitive: bind $invert_boolean(template.item as <$BzEntry>.holding) as <bool>;
+                      
+                      clicked => $remove_cb(template);
+                    }
 
-                      width-request: 60;
-                      valign: fill;
-                      halign: fill;
-                      hexpand: true;
-                      icon-name: "media-playback-start-symbolic";
-                      clicked => $run_cb(template);
+                    Separator {
+                      orientation: vertical;
+                      margin-top: 12;
+                      margin-bottom: 12;
                     }
 
                     MenuButton {
                       styles [
-                        "card-row-btn",
+                        "flat"
                       ]
 
-                      width-request: 60;
-                      valign: fill;
-                      halign: fill;
-                      hexpand: true;
+                      width-request: 32;
+                      height-request: 32;
+                      valign: center;
                       icon-name: "view-more-symbolic";
                       has-tooltip: true;
                       tooltip-text: _("More actions");
@@ -181,6 +158,30 @@ template $BzInstalledPage: Adw.Bin {
                           orientation: vertical;
                           homogeneous: true;
                           spacing: 10;
+
+                          Button {
+                            styles [
+                              "flat",
+                            ]
+
+                            has-tooltip: true;
+                            tooltip-text: _("Run this application");
+
+                            child: Box {
+                              orientation: horizontal;
+                              spacing: 6;
+
+                              Image {
+                                icon-name: "media-playback-start-symbolic";
+                              }
+
+                              Label {
+                                label: _("Run");
+                              }
+                            };
+
+                            clicked => $run_cb(template);
+                          }
 
                           Button {
                             styles [
@@ -206,7 +207,7 @@ template $BzInstalledPage: Adw.Bin {
 
                             clicked => $install_addons_cb(template);
                           }
-
+                          /*
                           Button {
                             styles [
                               "flat",
@@ -230,6 +231,7 @@ template $BzInstalledPage: Adw.Bin {
 
                             clicked => $edit_permissions_cb(template);
                           }
+                          */
 
                           Button {
                             styles [
@@ -253,32 +255,6 @@ template $BzInstalledPage: Adw.Bin {
                             };
 
                             clicked => $view_store_page_cb(template);
-                          }
-                          
-                          Button {
-                            styles [
-                              "flat",
-                              "destructive-action",
-                            ]
-
-                            has-tooltip: true;
-                            tooltip-text: _("Remove");
-                            sensitive: bind $invert_boolean(template.item as <$BzEntry>.holding) as <bool>;
-
-                            child: Box {
-                              orientation: horizontal;
-                              spacing: 6;
-
-                              Image {
-                                icon-name: "user-trash-symbolic";
-                              }
-
-                              Label {
-                                label: _("Remove");
-                              }
-                            };
-
-                            clicked => $remove_cb(template);
                           }
                         };
                       };

--- a/src/bz-installed-page.c
+++ b/src/bz-installed-page.c
@@ -174,8 +174,13 @@ run_cb (GtkListItem *list_item,
 {
   BzEntry         *entry = NULL;
   BzInstalledPage *self  = NULL;
+  GtkWidget       *menu_btn = NULL;
 
   entry = gtk_list_item_get_item (list_item);
+
+  menu_btn = gtk_widget_get_ancestor (GTK_WIDGET (button), GTK_TYPE_MENU_BUTTON);
+  if (menu_btn != NULL)
+    gtk_menu_button_set_active (GTK_MENU_BUTTON (menu_btn), FALSE);
 
   self = BZ_INSTALLED_PAGE (gtk_widget_get_ancestor (GTK_WIDGET (button), BZ_TYPE_INSTALLED_PAGE));
   g_assert (self != NULL);
@@ -211,62 +216,6 @@ support_cb (GtkListItem *list_item,
 
   url = bz_entry_get_donation_url (entry);
   g_app_info_launch_default_for_uri (url, NULL, NULL);
-}
-
-static void
-no_support_cb (GtkListItem *list_item,
-               GtkButton   *button)
-{
-  BzEntry         *entry  = NULL;
-  GListModel      *urls   = NULL;
-  guint            n_urls = 0;
-  GtkWidget       *window = NULL;
-  g_autofree char *body   = NULL;
-
-  entry = gtk_list_item_get_item (list_item);
-  urls  = bz_entry_get_share_urls (entry);
-  if (urls != NULL)
-    n_urls = g_list_model_get_n_items (urls);
-
-  if (urls != NULL && n_urls > 0)
-    {
-      g_autoptr (BzUrl) select = NULL;
-
-      for (guint i = 0; i < n_urls; i++)
-        {
-          g_autoptr (BzUrl) url = NULL;
-          const char *name      = NULL;
-
-          url  = g_list_model_get_item (urls, i);
-          name = bz_url_get_name (url);
-          if (name != NULL && g_strcmp0 (name, "Homepage") == 0)
-            {
-              select = g_steal_pointer (&url);
-              break;
-            }
-        }
-      if (select == NULL)
-        select = g_list_model_get_item (urls, 0);
-
-      body = g_strdup_printf (
-          _ ("\"%s\" does not provide a donations link. "
-             "This does not mean you cannot support them! "
-             "Try looking at their "
-             "<a href=\"%s\">project page</a> "
-             "for more information."),
-          bz_entry_get_title (entry),
-          bz_url_get_url (select));
-    }
-  else
-    body = g_strdup_printf (
-        _ ("\"%s\" does not provide a donations link. "
-           "This does not mean you cannot support them! "
-           "Try finding their project page for more information."),
-        bz_entry_get_title (entry));
-
-  window = gtk_widget_get_ancestor (GTK_WIDGET (button), GTK_TYPE_WINDOW);
-  if (window != NULL)
-    bz_show_alert_for_widget (window, _ ("No Donations Link"), body, TRUE);
 }
 
 static void
@@ -437,7 +386,6 @@ bz_installed_page_class_init (BzInstalledPageClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, is_null);
   gtk_widget_class_bind_template_callback (widget_class, run_cb);
   gtk_widget_class_bind_template_callback (widget_class, support_cb);
-  gtk_widget_class_bind_template_callback (widget_class, no_support_cb);
   gtk_widget_class_bind_template_callback (widget_class, view_store_page_cb);
   gtk_widget_class_bind_template_callback (widget_class, remove_cb);
   gtk_widget_class_bind_template_callback (widget_class, install_addons_cb);

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -45,16 +45,21 @@
     font-weight: normal;
 }
 
-.support-button {
-    background-color: alpha(#f06292, 0.25);
-    color: #f06292;
-    padding: 2px 12px;
+.support {
+    --accent-fg-color : #f06292;
+    --accent-bg-color : alpha(#f06292, 0.25);
+    --accent-color : #f06292;
 }
 
-.star-button {
-    background-color: alpha(@warning_bg_color, 0.25);
-    color: @warning_color;
+.star {
+    --accent-fg-color: @warning_bg_color;
+    --accent-bg-color : alpha(@warning_bg_color, 0.25);
+    --accent-color: @warning_color;
+}
+
+.small-pill {
     padding: 2px 12px;
+    border-radius: 99999px;
 }
 
 .flathub-page-section {


### PR DESCRIPTION
I made some adjustments that should hopefully lead to a better UX:

- Switched to Remove and Run buttons as i believe that most people visiting this page want to probably remove some app

- Set the application ID as the tooltip for the app name and removed the unique ID tooltip, since I don’t think even most developers need to worry about that.

- Moved the support button next to the app name and gave it styling similar to what you see on the app store page.

- Hid the permissions button under the “More actions” menu, as it’s not yet implemented. ( At first I thought I needed to install Flatseal for it to work, but the code indicates it’s simply not implemented at all.)

- Removed the “No support” button, since most users will probably understand that not having a donation link doesn’t necessarily mean the project can’t be supported. This also saves new translators some work.

Feel free to ask me to make further changes or bring things back.

<p align="center">
  <img width="1342" height="915" alt="image" src="https://github.com/user-attachments/assets/de8dd7d9-24e9-426d-a320-e81f5dd82726" />
</p>

<p align="center">
  <img width="472" height="236" alt="image" src="https://github.com/user-attachments/assets/52c05060-3608-405f-8152-abf731bb3544" />
</p>
