### PR TITLE
UI: Rework loading

### DIFF
--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -1195,7 +1195,8 @@ refresh_fiber (BzApplication *self)
 {
   g_autoptr (GError) local_error            = NULL;
   gboolean         has_flathub              = FALSE;
-  g_autofree char *busy_label               = NULL;
+  g_autofree char *busy_step_label          = NULL;
+  g_autofree char *busy_progress_label      = NULL;
   g_autoptr (GHashTable) installed_set      = NULL;
   guint total                               = 0;
   guint out_of                              = 0;
@@ -1211,7 +1212,7 @@ refresh_fiber (BzApplication *self)
 
   if (self->flatpak == NULL)
     {
-      bz_state_info_set_busy_label (self->state, _ ("Constructing Flatpak instance..."));
+      bz_state_info_set_busy_step_label (self->state, _ ("Constructing Flatpak instance..."));
       g_debug ("Constructing flatpak instance for the first time...");
       self->flatpak = dex_await_object (bz_flatpak_instance_new (), &local_error);
       if (self->flatpak == NULL)
@@ -1221,7 +1222,7 @@ refresh_fiber (BzApplication *self)
     }
   else
     {
-      bz_state_info_set_busy_label (self->state, _ ("Reusing last Flatpak instance..."));
+      bz_state_info_set_busy_step_label (self->state, _ ("Reusing last Flatpak instance..."));
       g_debug ("Reusing previous flatpak instance...");
     }
 
@@ -1287,9 +1288,9 @@ refresh_fiber (BzApplication *self)
       bz_flathub_state_update_to_today (self->flathub);
     }
 
-  busy_label = g_strdup_printf (_ ("Identifying installed entries..."));
-  bz_state_info_set_busy_label (self->state, busy_label);
-  g_clear_pointer (&busy_label, g_free);
+  busy_step_label = g_strdup_printf (_ ("Identifying installed entries..."));
+  bz_state_info_set_busy_step_label (self->state, busy_step_label);
+  g_clear_pointer (&busy_step_label, g_free);
 
   installed_set = dex_await_boxed (
       bz_backend_retrieve_install_ids (
@@ -1298,11 +1299,11 @@ refresh_fiber (BzApplication *self)
   if (installed_set == NULL)
     return dex_future_new_for_error (g_steal_pointer (&local_error));
 
-  busy_label = g_strdup_printf (
+  busy_step_label = g_strdup_printf (
       _ ("Beginning remote entry retrieval while referencing %d blocklist(s)..."),
       g_list_model_get_n_items (self->blocklists));
-  bz_state_info_set_busy_label (self->state, busy_label);
-  g_clear_pointer (&busy_label, g_free);
+  bz_state_info_set_busy_step_label (self->state, busy_step_label);
+  g_clear_pointer (&busy_step_label, g_free);
 
   channel            = dex_channel_new (50);
   sys_name_to_addons = g_hash_table_new_full (
@@ -1443,16 +1444,18 @@ refresh_fiber (BzApplication *self)
         g_assert_not_reached ();
 
       bz_state_info_set_busy_progress (self->state, (double) total / (double) out_of);
-      busy_label = g_strdup_printf (_ ("Received %'d entries out of %'d (%0.1f seconds elapsed)"),
-                                    total, out_of, g_timer_elapsed (self->init_timer, NULL));
-      bz_state_info_set_busy_label (self->state, busy_label);
-      g_clear_pointer (&busy_label, g_free);
+      busy_step_label = g_strdup_printf (_ ("Recieving Entries"));
+      busy_progress_label = g_strdup_printf (_ (" %'d of %'d"),
+                                    total, out_of);
+      bz_state_info_set_busy_step_label (self->state, busy_step_label);
+      bz_state_info_set_busy_progress_label (self->state, busy_progress_label);
+      g_clear_pointer (&busy_step_label, g_free);
     }
   g_list_store_sort (self->groups, (GCompareDataFunc) cmp_group, NULL);
 
-  busy_label = g_strdup_printf (_ ("Waiting for background indexing tasks to catch up...")),
-  bz_state_info_set_busy_label (self->state, busy_label);
-  g_clear_pointer (&busy_label, g_free);
+  busy_step_label = g_strdup_printf (_ ("Waiting for background indexing tasks to catch up...")),
+  bz_state_info_set_busy_step_label (self->state, busy_step_label);
+  g_clear_pointer (&busy_step_label, g_free);
 
   dex_await (dex_future_allv (
                  (DexFuture *const *) cache_futures->pdata,
@@ -1485,11 +1488,11 @@ refresh_fiber (BzApplication *self)
 
   gtk_filter_changed (GTK_FILTER (self->application_filter), GTK_FILTER_CHANGE_DIFFERENT);
 
-  busy_label = g_strdup_printf (
+  busy_step_label = g_strdup_printf (
       _ ("Completed initialization in %0.2f seconds"),
       g_timer_elapsed (self->init_timer, NULL));
-  bz_state_info_set_busy_label (self->state, busy_label);
-  g_clear_pointer (&busy_label, g_free);
+  bz_state_info_set_busy_step_label (self->state, busy_step_label);
+  g_clear_pointer (&busy_step_label, g_free);
 
   g_debug ("Checking for updates...");
   bz_state_info_set_checking_for_updates (self->state, TRUE);

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -1444,9 +1444,8 @@ refresh_fiber (BzApplication *self)
         g_assert_not_reached ();
 
       bz_state_info_set_busy_progress (self->state, (double) total / (double) out_of);
-      busy_step_label = g_strdup_printf (_ ("Recieving Entries"));
-      busy_progress_label = g_strdup_printf (_ (" %'d of %'d"),
-                                    total, out_of);
+      busy_step_label     = g_strdup_printf (_ ("Receiving Entries"));
+      busy_progress_label = g_strdup_printf (_ ("%'d of %'d"), total, out_of);
       bz_state_info_set_busy_step_label (self->state, busy_step_label);
       bz_state_info_set_busy_progress_label (self->state, busy_progress_label);
       g_clear_pointer (&busy_step_label, g_free);

--- a/src/bz-state-info.c
+++ b/src/bz-state-info.c
@@ -411,7 +411,7 @@ bz_state_info_class_init (BzStateInfoClass *klass)
           "busy-step-label",
           NULL, NULL, NULL,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
-  
+
   props[PROP_BUSY_PROGRESS_LABEL] =
       g_param_spec_string (
           "busy-progress-label",
@@ -839,7 +839,7 @@ bz_state_info_set_busy (BzStateInfo *self,
 
 void
 bz_state_info_set_busy_step_label (BzStateInfo *self,
-                              const char  *busy_step_label)
+                                   const char  *busy_step_label)
 {
   g_return_if_fail (BZ_IS_STATE_INFO (self));
 
@@ -852,7 +852,7 @@ bz_state_info_set_busy_step_label (BzStateInfo *self,
 
 void
 bz_state_info_set_busy_progress_label (BzStateInfo *self,
-                              const char  *busy_progress_label)
+                                       const char  *busy_progress_label)
 {
   g_return_if_fail (BZ_IS_STATE_INFO (self));
 

--- a/src/bz-state-info.c
+++ b/src/bz-state-info.c
@@ -41,7 +41,8 @@ struct _BzStateInfo
   BzContentProvider       *curated_provider;
   BzFlathubState          *flathub;
   gboolean                 busy;
-  char                    *busy_label;
+  char                    *busy_step_label;
+  char                    *busy_progress_label;
   double                   busy_progress;
   gboolean                 online;
   gboolean                 checking_for_updates;
@@ -71,7 +72,8 @@ enum
   PROP_CURATED_PROVIDER,
   PROP_FLATHUB,
   PROP_BUSY,
-  PROP_BUSY_LABEL,
+  PROP_BUSY_STEP_LABEL,
+  PROP_BUSY_PROGRESS_LABEL,
   PROP_BUSY_PROGRESS,
   PROP_ONLINE,
   PROP_CHECKING_FOR_UPDATES,
@@ -102,7 +104,8 @@ bz_state_info_dispose (GObject *object)
   g_clear_pointer (&self->search_engine, g_object_unref);
   g_clear_pointer (&self->curated_provider, g_object_unref);
   g_clear_pointer (&self->flathub, g_object_unref);
-  g_clear_pointer (&self->busy_label, g_free);
+  g_clear_pointer (&self->busy_step_label, g_free);
+  g_clear_pointer (&self->busy_progress_label, g_free);
   g_clear_pointer (&self->background_task_label, g_free);
 
   G_OBJECT_CLASS (bz_state_info_parent_class)->dispose (object);
@@ -169,8 +172,11 @@ bz_state_info_get_property (GObject    *object,
     case PROP_BUSY:
       g_value_set_boolean (value, bz_state_info_get_busy (self));
       break;
-    case PROP_BUSY_LABEL:
-      g_value_set_string (value, bz_state_info_get_busy_label (self));
+    case PROP_BUSY_STEP_LABEL:
+      g_value_set_string (value, bz_state_info_get_busy_step_label (self));
+      break;
+    case PROP_BUSY_PROGRESS_LABEL:
+      g_value_set_string (value, bz_state_info_get_busy_progress_label (self));
       break;
     case PROP_BUSY_PROGRESS:
       g_value_set_double (value, bz_state_info_get_busy_progress (self));
@@ -250,8 +256,11 @@ bz_state_info_set_property (GObject      *object,
     case PROP_BUSY:
       bz_state_info_set_busy (self, g_value_get_boolean (value));
       break;
-    case PROP_BUSY_LABEL:
-      bz_state_info_set_busy_label (self, g_value_get_string (value));
+    case PROP_BUSY_STEP_LABEL:
+      bz_state_info_set_busy_step_label (self, g_value_get_string (value));
+      break;
+    case PROP_BUSY_PROGRESS_LABEL:
+      bz_state_info_set_busy_progress_label (self, g_value_get_string (value));
       break;
     case PROP_BUSY_PROGRESS:
       bz_state_info_set_busy_progress (self, g_value_get_double (value));
@@ -397,9 +406,15 @@ bz_state_info_class_init (BzStateInfoClass *klass)
           NULL, NULL, FALSE,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
-  props[PROP_BUSY_LABEL] =
+  props[PROP_BUSY_STEP_LABEL] =
       g_param_spec_string (
-          "busy-label",
+          "busy-step-label",
+          NULL, NULL, NULL,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+  
+  props[PROP_BUSY_PROGRESS_LABEL] =
+      g_param_spec_string (
+          "busy-progress-label",
           NULL, NULL, NULL,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
@@ -562,10 +577,17 @@ bz_state_info_get_busy (BzStateInfo *self)
 }
 
 const char *
-bz_state_info_get_busy_label (BzStateInfo *self)
+bz_state_info_get_busy_step_label (BzStateInfo *self)
 {
   g_return_val_if_fail (BZ_IS_STATE_INFO (self), NULL);
-  return self->busy_label;
+  return self->busy_step_label;
+}
+
+const char *
+bz_state_info_get_busy_progress_label (BzStateInfo *self)
+{
+  g_return_val_if_fail (BZ_IS_STATE_INFO (self), NULL);
+  return self->busy_progress_label;
 }
 
 double
@@ -816,16 +838,29 @@ bz_state_info_set_busy (BzStateInfo *self,
 }
 
 void
-bz_state_info_set_busy_label (BzStateInfo *self,
-                              const char  *busy_label)
+bz_state_info_set_busy_step_label (BzStateInfo *self,
+                              const char  *busy_step_label)
 {
   g_return_if_fail (BZ_IS_STATE_INFO (self));
 
-  g_clear_pointer (&self->busy_label, g_free);
-  if (busy_label != NULL)
-    self->busy_label = g_strdup (busy_label);
+  g_clear_pointer (&self->busy_step_label, g_free);
+  if (busy_step_label != NULL)
+    self->busy_step_label = g_strdup (busy_step_label);
 
-  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_BUSY_LABEL]);
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_BUSY_STEP_LABEL]);
+}
+
+void
+bz_state_info_set_busy_progress_label (BzStateInfo *self,
+                              const char  *busy_progress_label)
+{
+  g_return_if_fail (BZ_IS_STATE_INFO (self));
+
+  g_clear_pointer (&self->busy_progress_label, g_free);
+  if (busy_progress_label != NULL)
+    self->busy_progress_label = g_strdup (busy_progress_label);
+
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_BUSY_PROGRESS_LABEL]);
 }
 
 void

--- a/src/bz-state-info.h
+++ b/src/bz-state-info.h
@@ -88,7 +88,10 @@ gboolean
 bz_state_info_get_busy (BzStateInfo *self);
 
 const char *
-bz_state_info_get_busy_label (BzStateInfo *self);
+bz_state_info_get_busy_step_label (BzStateInfo *self);
+
+const char *
+bz_state_info_get_busy_progress_label (BzStateInfo *self);
 
 double
 bz_state_info_get_busy_progress (BzStateInfo *self);
@@ -171,8 +174,12 @@ bz_state_info_set_busy (BzStateInfo *self,
                         gboolean     busy);
 
 void
-bz_state_info_set_busy_label (BzStateInfo *self,
-                              const char  *busy_label);
+bz_state_info_set_busy_step_label (BzStateInfo *self,
+                              const char  *busy_step_label);
+
+void
+bz_state_info_set_busy_progress_label (BzStateInfo *self,
+                              const char  *busy_progress_label);
 
 void
 bz_state_info_set_busy_progress (BzStateInfo *self,

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -170,27 +170,21 @@ template $BzWindow: Adw.ApplicationWindow {
                       halign: fill;
                       valign: center;
                       orientation: vertical;
-                      spacing: 15;
+                      spacing: 6;
 
-                      Button {
-                        styles [
-                          "flat"
-                        ]
-
-                        halign: center;
-                        
-                        child: Image {
+                      Image {
                           icon-name: "io.github.kolunmi.Bazaar";
-                          pixel-size: 64;
-                        };
+                          pixel-size: 128;
+                          margin-bottom:24;
                       }
-                      
+
                       $BzGlobalProgress {
                         halign: center;
-                        height-request: 20;
-                        expand-size: 150;
+                        height-request: 8;
+                        expand-size: 250;
                         active: bind template.state as <$BzStateInfo>.busy;
                         fraction: bind template.state as <$BzStateInfo>.busy-progress;
+                        margin-bottom:12;
                       }
 
                       Label {
@@ -199,7 +193,17 @@ template $BzWindow: Adw.ApplicationWindow {
                         ]
 
                         ellipsize: end;
-                        label: bind template.state as <$BzStateInfo>.busy-label;
+                        label: bind template.state as <$BzStateInfo>.busy-step-label;
+                      }
+
+                      Label {
+                        styles [
+                          "heading",
+                          "dimmed"
+                        ]
+
+                        ellipsize: end;
+                        label: bind template.state as <$BzStateInfo>.busy-progress-label;
                       }
                     };
                   }


### PR DESCRIPTION
This PR adjusts the layout to look more polished by making several improvements: changing the loading bar height to match default Adwaita widget, removing the non functional button around the logo, and splitting the busy label into two separate labels to remove constant layout shifts during the 'Receiving entries' step.

<img width="1342" height="1022" alt="Screenshot From 2025-09-09 17-52-07" src="https://github.com/user-attachments/assets/c20e3ba7-3d7e-499e-9cd0-ba33ee0f10c2" />
