### PR TITLE
fix(po): fix POT-files generation

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -13,8 +13,6 @@ src/bz-async-texture.c
 src/bz-backend.c
 src/bz-browse-widget.blp
 src/bz-browse-widget.c
-src/bz-category-dialog.blp
-src/bz-category-dialog.c
 src/bz-comet-overlay.c
 src/bz-comet.c
 src/bz-content-provider.c


### PR DESCRIPTION
Fixes `translators.sh` script erroring out due to missing files.