### PR TITLE
(UI) Make share dialog use action rows

### DIFF
--- a/src/bz-flatpak-entry.c
+++ b/src/bz-flatpak-entry.c
@@ -559,7 +559,7 @@ bz_flatpak_entry_new_for_ref (BzFlatpakInstance *instance,
           flathub_url = g_strdup_printf ("https://flathub.org/apps/%s", id);
 
           url = bz_url_new ();
-          bz_url_set_name (url, C_ ("Project URL Type", "Flathub Link"));
+          bz_url_set_name (url, C_ ("Project URL Type", "Flathub Page"));
           bz_url_set_url (url, flathub_url);
 
           g_list_store_append (share_urls, url);
@@ -581,7 +581,7 @@ bz_flatpak_entry_new_for_ref (BzFlatpakInstance *instance,
                   enum_string = C_ ("Project URL Type", "Homepage");
                   break;
                 case AS_URL_KIND_BUGTRACKER:
-                  enum_string = C_ ("Project URL Type", "Bugtracker");
+                  enum_string = C_ ("Project URL Type", "Issue Tracker");
                   break;
                 case AS_URL_KIND_FAQ:
                   enum_string = C_ ("Project URL Type", "FAQ");
@@ -590,7 +590,7 @@ bz_flatpak_entry_new_for_ref (BzFlatpakInstance *instance,
                   enum_string = C_ ("Project URL Type", "Help");
                   break;
                 case AS_URL_KIND_DONATION:
-                  enum_string = C_ ("Project URL Type", "Donation");
+                  enum_string = C_ ("Project URL Type", "Donate");
                   g_clear_pointer (&donation_url, g_free);
                   donation_url = g_strdup (url);
                   break;
@@ -601,7 +601,7 @@ bz_flatpak_entry_new_for_ref (BzFlatpakInstance *instance,
                   enum_string = C_ ("Project URL Type", "Contact");
                   break;
                 case AS_URL_KIND_VCS_BROWSER:
-                  enum_string = C_ ("Project URL Type", "VCS Browser");
+                  enum_string = C_ ("Project URL Type", "Source Code");
                   g_clear_pointer (&forge_url, g_free);
                   forge_url = g_strdup (url);
                   break;

--- a/src/bz-share-dialog.blp
+++ b/src/bz-share-dialog.blp
@@ -2,87 +2,23 @@ using Gtk 4.0;
 using Adw 1;
 
 template $BzShareDialog: Adw.Dialog {
-  child: Adw.ToolbarView {
-    [top]
-    Adw.HeaderBar {
-      title-widget: Label {
-        styles [
-          "heading",
-        ]
+  child: Adw.ToastOverlay toast_overlay {
+    child: Adw.ToolbarView {
+      [top]
+      Adw.HeaderBar {
+        title-widget: Label {
+          styles [
+            "heading",
+          ]
+          label: _("Share");
+        };
+      }
 
-        label: _("Share");
-      };
-    }
-
-    content: ListView {
-      styles [
-        "navigation-sidebar",
-      ]
-
-      hexpand: true;
-      margin-start: 5;
-      margin-end: 5;
-      margin-top: 5;
-      margin-bottom: 5;
-
-      model: NoSelection {
-        model: bind template.entry as <$BzEntry>.share-urls;
-      };
-
-      factory: BuilderListItemFactory {
-        template ListItem {
-          activatable: false;
-
-          child: Box {
-            margin-top: 5;
-            margin-bottom: 5;
-            orientation: vertical;
-            spacing: 5;
-
-            Label {
-              styles [
-                "heading",
-              ]
-
-              xalign: 0.0;
-              ellipsize: middle;
-              label: bind template.item as <$BzUrl>.name;
-            }
-
-            Box {
-              orientation: horizontal;
-              spacing: 10;
-
-              Entry {
-                hexpand: true;
-                editable: false;
-                text: bind template.item as <$BzUrl>.url;
-              }
-
-              Box {
-                styles [
-                  "linked",
-                ]
-
-                orientation: horizontal;
-                
-                Button {
-                  has-tooltip: true;
-                  tooltip-text: _("Copy this link");
-                  icon-name: "copy-symbolic";
-                  clicked => $copy_cb(template);
-                }
-
-                Button {
-                  has-tooltip: true;
-                  tooltip-text: _("Open this link externally");
-                  icon-name: "external-link-symbolic";
-                  clicked => $follow_link_cb(template);
-                }
-              }
-            }
-          };
-        }
+      content: Adw.PreferencesGroup urls_group {
+        margin-top: 6;
+        margin-bottom: 18;
+        margin-start: 18;
+        margin-end: 18;
       };
     };
   };


### PR DESCRIPTION
This gives the dialog a more standard look and feel, and it also allows the use of activatable-widget property.
This moves the creation of the rows into code rather than a factory, since PreferenceGroups sadly can’t be created that way. 

<img width="655" height="620" alt="image" src="https://github.com/user-attachments/assets/a102dbb1-5cde-4e86-b523-575b76c5b5db" />
