### PR TITLE
(chore) Add correct icon css classes

### DIFF
--- a/src/bz-app-tile.blp
+++ b/src/bz-app-tile.blp
@@ -1,5 +1,4 @@
 using Gtk 4.0;
-using Adw 1;
 
 template $BzAppTile: Button {
   styles [
@@ -24,6 +23,8 @@ template $BzAppTile: Button {
     Image {
       pixel-size: 64;
       paintable: bind template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.icon-paintable;
+
+      styles ["icon-dropshadow"]
     }
 
     Box {

--- a/src/bz-category-tile.blp
+++ b/src/bz-category-tile.blp
@@ -24,6 +24,8 @@ template $BzCategoryTile: Button {
       pixel-size: 32;
       icon-name: bind template.category as <$BzFlathubCategory>.icon-name;
       visible: bind $invert_boolean($is_null(template.category as <$BzFlathubCategory>.icon-name) as <bool>) as <bool>;
+      
+      styles ["icon-dropshadow"]
     }
     
     Label {

--- a/src/bz-detailed-app-tile.blp
+++ b/src/bz-detailed-app-tile.blp
@@ -1,5 +1,4 @@
 using Gtk 4.0;
-using Adw 1;
 
 template $BzDetailedAppTile: Button {
   styles [
@@ -24,6 +23,8 @@ template $BzDetailedAppTile: Button {
     Image {
       pixel-size: 128;
       paintable: bind template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.icon-paintable;
+
+      styles ["icon-dropshadow"]
     }
 
     Box {

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -72,6 +72,8 @@ template $BzFullView: Adw.Bin {
                       width-request: 128;
                       height-request: 128;
                       paintable: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.icon-paintable;
+
+                      styles ["icon-dropshadow"]
                     }
 
                     Box {

--- a/src/bz-installed-page.blp
+++ b/src/bz-installed-page.blp
@@ -58,6 +58,7 @@ template $BzInstalledPage: Adw.Bin {
                     width-request: 32;
                     paintable: bind template.item as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.icon-paintable;
                     visible: bind $invert_boolean($is_null(template.item as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.icon-paintable) as <bool>) as <bool>;
+                    styles ["lowres-icon"]
                   }
 
                   Image {

--- a/src/bz-transaction-view.blp
+++ b/src/bz-transaction-view.blp
@@ -43,6 +43,8 @@ template $BzTransactionView: Adw.Bin {
                   paintable: bind template.item as <$BzEntry>.icon-paintable;
                   pixel-size: 64;
                   valign: center;
+                                      
+                  styles ["icon-dropshadow"]
                 }
                 Box {
                   valign:center;
@@ -127,6 +129,8 @@ template $BzTransactionView: Adw.Bin {
                   paintable: bind template.item as <$BzEntry>.icon-paintable;
                   pixel-size: 64;
                   valign: center;
+
+                  styles ["icon-dropshadow"]
                 }
                 Box {
                   valign:center;
@@ -211,6 +215,8 @@ template $BzTransactionView: Adw.Bin {
                   paintable: bind template.item as <$BzEntry>.icon-paintable;
                   pixel-size: 64;
                   valign: center;
+
+                  styles ["icon-dropshadow"]
                 }
                 Box {
                   valign:center;

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -174,6 +174,8 @@ template $BzWindow: Adw.ApplicationWindow {
                           icon-name: "io.github.kolunmi.Bazaar";
                           pixel-size: 128;
                           margin-bottom:24;
+
+                          styles ["icon-dropshadow"]
                       }
 
                       $BzGlobalProgress {


### PR DESCRIPTION
Adds the `icon-dropshadow` and `lowres-icon` classes to app icons for better visibility in light mode.

See:
https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.3/style-classes.html#app-icons