### PR TITLE
(UI) Add toast on screenshot copy

### DIFF
--- a/src/bz-decorated-screenshot.c
+++ b/src/bz-decorated-screenshot.c
@@ -122,20 +122,20 @@ open_externally_clicked (BzDecoratedScreenshot *self,
 
 static void
 copy_clicked (BzDecoratedScreenshot *self,
-              GtkButton *button)
+              GtkButton             *button)
 {
   g_autoptr (GdkTexture) texture = NULL;
   GdkClipboard *clipboard;
   BzWindow *window = NULL;
   AdwToast *toast = NULL;
-  
+
   texture = bz_async_texture_dup_texture (self->async_texture);
   /* button shouldn't be clickable if not loaded */
   g_assert (texture != NULL);
-  
+
   clipboard = gdk_display_get_clipboard (gdk_display_get_default ());
   gdk_clipboard_set_texture (clipboard, texture);
-  
+
   window = BZ_WINDOW (gtk_widget_get_root (GTK_WIDGET (self)));
   toast = adw_toast_new (_("Copied!"));
   adw_toast_set_timeout (toast, 1);

--- a/src/bz-decorated-screenshot.c
+++ b/src/bz-decorated-screenshot.c
@@ -20,7 +20,9 @@
 
 #include "bz-decorated-screenshot.h"
 #include "bz-error.h"
+#include "bz-window.h"
 #include "bz-screenshot.h"
+#include <glib/gi18n.h>
 
 struct _BzDecoratedScreenshot
 {
@@ -120,17 +122,24 @@ open_externally_clicked (BzDecoratedScreenshot *self,
 
 static void
 copy_clicked (BzDecoratedScreenshot *self,
-              GtkButton             *button)
+              GtkButton *button)
 {
   g_autoptr (GdkTexture) texture = NULL;
   GdkClipboard *clipboard;
-
+  BzWindow *window = NULL;
+  AdwToast *toast = NULL;
+  
   texture = bz_async_texture_dup_texture (self->async_texture);
   /* button shouldn't be clickable if not loaded */
   g_assert (texture != NULL);
-
+  
   clipboard = gdk_display_get_clipboard (gdk_display_get_default ());
   gdk_clipboard_set_texture (clipboard, texture);
+  
+  window = BZ_WINDOW (gtk_widget_get_root (GTK_WIDGET (self)));
+  toast = adw_toast_new (_("Copied!"));
+  adw_toast_set_timeout (toast, 1);
+  bz_window_add_toast (window, toast);
 }
 
 static void

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -814,6 +814,16 @@ bz_window_set_category_view_mode (BzWindow *self,
   gtk_revealer_set_reveal_child (self->title_revealer, !enabled);
 }
 
+void
+bz_window_add_toast (BzWindow *self,
+                     AdwToast *toast)
+{
+  g_return_if_fail (BZ_IS_WINDOW (self));
+  g_return_if_fail (ADW_IS_TOAST (toast));
+  
+  adw_toast_overlay_add_toast (self->toasts, toast);
+}
+
 static void
 transact (BzWindow  *self,
           BzEntry   *entry,

--- a/src/bz-window.h
+++ b/src/bz-window.h
@@ -54,4 +54,8 @@ void
 bz_window_set_category_view_mode (BzWindow *self,
                                   gboolean  enabled);
 
+void
+bz_window_add_toast (BzWindow *self,
+                     AdwToast *toast);
+
 G_END_DECLS


### PR DESCRIPTION
Adds a function in `BzWindow` for displaying toasts on the main window, and uses it to display a 'Copied!' toast on screenshot copy. Adding the function makes it so you don't need to scour the widget tree for the toast overlay every time you need to display a toast.