### PR TITLE
Move search settings to preferences dialog

### DIFF
--- a/data/io.github.kolunmi.Bazaar.gschema.xml
+++ b/data/io.github.kolunmi.Bazaar.gschema.xml
@@ -6,5 +6,20 @@
       <summary>Show Git Forge Star Counts</summary>
       <description>Whether to attempt to detect and show "star counts" for projects in the full view</description>
     </key>
+    <key name="search-only-foss" type="b">
+      <default>false</default>
+      <summary>Only Show Free Software</summary>
+      <description>Hide proprietary software when searching</description>
+    </key>
+    <key name="search-only-flathub" type="b">
+      <default>false</default>
+      <summary>Show Only Flathub Content</summary>
+      <description>Filter search results to only show applications available on Flathub</description>
+    </key>
+    <key name="search-debounce" type="b">
+      <default>true</default>
+      <summary>Debounce Search Inputs</summary>
+      <description>Add a delay before searching to prevent instant replies while typing</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/bz-preferences-dialog.blp
+++ b/src/bz-preferences-dialog.blp
@@ -10,13 +10,30 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
     use-underline: true;
 
     Adw.PreferencesGroup {
-      title: _("Full Application View");
-      description: _("Change what content is shown when viewing applications");
+      title: _("Application Details");
 
-      Adw.SwitchRow {
+      Adw.SwitchRow git_forge_star_counts_switch{
         title: _("Git Forge Star Counts");
-        subtitle: _("If you do not have an access token, turning this setting on may cause GitHub to eventually rate limit you.");
-        active: bind template.show-git-forge-star-counts bidirectional;
+        subtitle: _("Not having a GitHub acess token may tigger rate limits");
+      }
+    }
+
+    Adw.PreferencesGroup {
+      title: _("Search");
+
+      Adw.SwitchRow search_only_foss_switch{
+        title: _("Only Show Free Software");
+        subtitle: _("Hide proprietary applications from search results");
+      }
+
+      Adw.SwitchRow search_only_flathub_switch{
+        title: _("Show Only Flathub Apps");
+        subtitle: _("Limit search results to applications available on Flathub");
+      }
+
+      Adw.SwitchRow search_debounce_switch{
+        title: _("Debounce Search Results");
+        subtitle: _("Wait for a brief pause to reduce system load");
       }
     }
   }

--- a/src/bz-search-widget.blp
+++ b/src/bz-search-widget.blp
@@ -66,7 +66,7 @@ template $BzSearchWidget: Adw.Bin {
 
       Text search_bar {
         hexpand: true;
-        placeholder-text: _("Type to filter");
+        placeholder-text: _("Search Apps");
       }
 
       Label search_text {}
@@ -79,66 +79,6 @@ template $BzSearchWidget: Adw.Bin {
       Image search_busy {
         visible: false;
         icon-name: "timer-sand-symbolic";
-      }
-
-      MenuButton {
-        styles [
-          "flat",
-        ]
-
-        icon-name: "view-more-horizontal-symbolic";
-        has-tooltip: true;
-        tooltip-text: _("Search Options");
-        direction: down;
-
-        popover: Popover {
-          child: Box {
-            halign: start;
-            orientation: vertical;
-            spacing: 8;
-
-            Box {
-              orientation: vertical;
-              spacing: 3;
-
-              Label {
-                styles [
-                  "heading",
-                ]
-                label: _("Search Options");
-              }
-
-              CheckButton foss_check {
-                label: _("Exclude results with proprietary licenses");
-                toggled => $foss_toggled_cb(template);
-              }
-
-              CheckButton flathub_check {
-                label: _("Exclude results not originating from Flathub");
-                toggled => $flathub_toggled_cb(template);
-              }
-            }
-
-            Separator {}
-
-            Box {
-              orientation: vertical;
-              spacing: 3;
-
-              Label {
-                styles [
-                  "heading",
-                ]
-                label: _("Advanced");
-              }
-
-              CheckButton debounce_check {
-                label: _("Debounce input to prevent instant replies");
-                active: true;
-              }
-            }
-          };
-        };
       }
     }
 


### PR DESCRIPTION
This PR moves the search settings to the preferences menu. This provides a more standard experience than using a popover, with the added benefits of persistence and subtitles for clearer explanations.

I also reworked the preferences dialog to use `g_settings_bind`, creating a direct binding between the setting keys and the switch widgets. This simplifies the management of these settings.

Feel free to ask for changes.

<img width="1342" height="1025" alt="image" src="https://github.com/user-attachments/assets/cd20d707-39cf-4c4f-9d38-e01bb698beaa" />
