### PR TITLE
Change per section limit to 12 from 9 on Flathub page

### DIFF
--- a/src/bz-flathub-page.c
+++ b/src/bz-flathub-page.c
@@ -128,7 +128,7 @@ static guint
 limit_if_false (gpointer object,
                 gboolean value)
 {
-  return value ? 256 : 9;
+  return value ? 256 : 12;
 }
 
 static void


### PR DESCRIPTION
To prevent listing sections from having an incomplete row when the layout is only two columns wide, I changed the limit to 12 since it’s divisible by both 3 and 2. This is also what other stores seem to do to resolve the issue.

Unfortunately, the incomplete row issue is still present for "Apps of the Week" as they only provide 5. We could fix this by adding a 6th tile, either by including an additional app ourselves, asking the Flathub team to provide 6 entries, or adding a completely different type of tile.
