### PR TITLE
(UX) Refine the Flathub views to be denser and have less partial lines

### DIFF
--- a/src/bz-app-tile.blp
+++ b/src/bz-app-tile.blp
@@ -40,12 +40,13 @@ template $BzAppTile: Button {
         Label {
           css-name: "app-tile-title";
           styles [
-            "title-2",
+            "heading",
           ]
 
           xalign: 0.0;
           ellipsize: end;
           label: bind template.group as <$BzEntryGroup>.title;
+          max-width-chars: 18;
         }
 
         Revealer {
@@ -69,17 +70,12 @@ template $BzAppTile: Button {
 
       Label {
         css-name: "app-tile-description";
-        styles [
-          "heading",
-          "dimmed",
-        ]
-
         xalign: 0.0;
         yalign: 0.0;
         wrap: true;
         ellipsize: end;
         vexpand: true;
-        lines: 3;
+        lines: 2;
         max-width-chars: 15;
         single-line-mode: true;
         label: bind template.group as <$BzEntryGroup>.description;

--- a/src/bz-detailed-app-tile.blp
+++ b/src/bz-detailed-app-tile.blp
@@ -21,7 +21,7 @@ template $BzDetailedAppTile: Button {
     can-focus: false;
 
     Image {
-      pixel-size: 128;
+      pixel-size: 96;
       paintable: bind template.group as <$BzEntryGroup>.icon-paintable;
 
       styles ["icon-dropshadow"]
@@ -39,7 +39,7 @@ template $BzDetailedAppTile: Button {
 
         Label {
           styles [
-            "title-1",
+            "title-2",
           ]
 
           xalign: 0.0;
@@ -66,11 +66,6 @@ template $BzDetailedAppTile: Button {
       }
       
       Label {
-        styles [
-          "title-4",
-          "dimmed",
-        ]
-
         xalign: 0.0;
         yalign: 0.0;
         wrap: true;

--- a/src/bz-dynamic-list-view.c
+++ b/src/bz-dynamic-list-view.c
@@ -38,6 +38,7 @@ struct _BzDynamicListView
   GType                 child_type;
   char                 *child_prop;
   char                 *object_prop;
+  guint                 max_children_per_line;
 
   char *child_type_string;
 };
@@ -54,6 +55,7 @@ enum
   PROP_CHILD_TYPE,
   PROP_CHILD_PROP,
   PROP_OBJECT_PROP,
+  PROP_MAX_CHILDREN_PER_LINE,
 
   LAST_PROP
 };
@@ -146,6 +148,9 @@ bz_dynamic_list_view_get_property (GObject    *object,
     case PROP_OBJECT_PROP:
       g_value_set_string (value, bz_dynamic_list_view_get_object_prop (self));
       break;
+    case PROP_MAX_CHILDREN_PER_LINE:
+      g_value_set_uint (value, bz_dynamic_list_view_get_max_children_per_line (self));
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -178,6 +183,9 @@ bz_dynamic_list_view_set_property (GObject      *object,
       break;
     case PROP_OBJECT_PROP:
       bz_dynamic_list_view_set_object_prop (self, g_value_get_string (value));
+      break;
+    case PROP_MAX_CHILDREN_PER_LINE:
+      bz_dynamic_list_view_set_max_children_per_line (self, g_value_get_uint (value));
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -212,6 +220,13 @@ bz_dynamic_list_view_class_init (BzDynamicListViewClass *klass)
           NULL, NULL,
           BZ_TYPE_DYNAMIC_LIST_VIEW_KIND, BZ_DYNAMIC_LIST_VIEW_KIND_LIST_BOX,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+
+  props[PROP_MAX_CHILDREN_PER_LINE] =
+    g_param_spec_uint (
+        "max-children-per-line",
+        NULL, NULL,
+        1, G_MAXUINT, 4,
+        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
   props[PROP_CHILD_TYPE] =
       g_param_spec_string (
@@ -269,8 +284,9 @@ bz_dynamic_list_view_class_init (BzDynamicListViewClass *klass)
 static void
 bz_dynamic_list_view_init (BzDynamicListView *self)
 {
-  self->child_type    = G_TYPE_INVALID;
-  self->noscroll_kind = BZ_DYNAMIC_LIST_VIEW_KIND_LIST_BOX;
+  self->child_type            = G_TYPE_INVALID;
+  self->noscroll_kind         = BZ_DYNAMIC_LIST_VIEW_KIND_LIST_BOX;
+  self->max_children_per_line = 4;
 }
 
 BzDynamicListView *
@@ -319,6 +335,13 @@ bz_dynamic_list_view_get_object_prop (BzDynamicListView *self)
 {
   g_return_val_if_fail (BZ_IS_DYNAMIC_LIST_VIEW (self), NULL);
   return self->object_prop;
+}
+
+guint
+bz_dynamic_list_view_get_max_children_per_line (BzDynamicListView *self)
+{
+  g_return_val_if_fail (BZ_IS_DYNAMIC_LIST_VIEW (self), 4);
+  return self->max_children_per_line;
 }
 
 void
@@ -416,6 +439,28 @@ bz_dynamic_list_view_set_object_prop (BzDynamicListView *self,
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_OBJECT_PROP]);
 }
 
+void
+bz_dynamic_list_view_set_max_children_per_line (BzDynamicListView *self,
+                                                guint              max_children)
+{
+  GtkWidget *child;
+
+  g_return_if_fail (BZ_IS_DYNAMIC_LIST_VIEW (self));
+  g_return_if_fail (max_children > 0);
+
+  self->max_children_per_line = max_children;
+
+  child = adw_bin_get_child (ADW_BIN (self));
+  if (child != NULL &&
+      self->noscroll_kind == BZ_DYNAMIC_LIST_VIEW_KIND_FLOW_BOX &&
+      !self->scroll)
+    {
+      gtk_flow_box_set_max_children_per_line (GTK_FLOW_BOX (child), max_children);
+    }
+
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_MAX_CHILDREN_PER_LINE]);
+}
+
 static void
 refresh (BzDynamicListView *self)
 {
@@ -475,7 +520,7 @@ refresh (BzDynamicListView *self)
 
             widget = gtk_flow_box_new ();
             gtk_flow_box_set_homogeneous (GTK_FLOW_BOX (widget), TRUE);
-            gtk_flow_box_set_max_children_per_line (GTK_FLOW_BOX (widget), 5);
+            gtk_flow_box_set_max_children_per_line (GTK_FLOW_BOX (widget), self->max_children_per_line);
             gtk_flow_box_set_selection_mode (GTK_FLOW_BOX (widget), GTK_SELECTION_NONE);
             gtk_flow_box_bind_model (
                 GTK_FLOW_BOX (widget), self->model,

--- a/src/bz-dynamic-list-view.c
+++ b/src/bz-dynamic-list-view.c
@@ -222,11 +222,11 @@ bz_dynamic_list_view_class_init (BzDynamicListViewClass *klass)
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
   props[PROP_MAX_CHILDREN_PER_LINE] =
-    g_param_spec_uint (
-        "max-children-per-line",
-        NULL, NULL,
-        1, G_MAXUINT, 4,
-        G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+      g_param_spec_uint (
+          "max-children-per-line",
+          NULL, NULL,
+          1, G_MAXUINT, 4,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
   props[PROP_CHILD_TYPE] =
       g_param_spec_string (

--- a/src/bz-dynamic-list-view.h
+++ b/src/bz-dynamic-list-view.h
@@ -87,6 +87,7 @@ bz_dynamic_list_view_set_object_prop (BzDynamicListView *self,
 
 guint
 bz_dynamic_list_view_get_max_children_per_line (BzDynamicListView *self);
+
 void
 bz_dynamic_list_view_set_max_children_per_line (BzDynamicListView *self,
                                                 guint              max_children);

--- a/src/bz-dynamic-list-view.h
+++ b/src/bz-dynamic-list-view.h
@@ -85,6 +85,12 @@ void
 bz_dynamic_list_view_set_object_prop (BzDynamicListView *self,
                                       const char        *object_prop);
 
+guint
+bz_dynamic_list_view_get_max_children_per_line (BzDynamicListView *self);
+void
+bz_dynamic_list_view_set_max_children_per_line (BzDynamicListView *self,
+                                                guint              max_children);
+
 G_END_DECLS
 
 /* End of bz-dynamic-list-view.h */

--- a/src/bz-flathub-page.blp
+++ b/src/bz-flathub-page.blp
@@ -39,41 +39,28 @@ template $BzFlathubPage: Adw.Bin {
              margin-top: 20;
              margin-bottom: 20;
              orientation: vertical;
-             spacing: 50;
+             spacing: 30;
 
-             Box {
-               orientation: vertical;
-               spacing: 10;
-             
-               Label {
-                 margin-start: 8;
-                 styles [
-                   "title-1",
-                 ]
-                 label: _("Apps Of The Week");
-                 xalign: 0.0;
-               }
+             $BzDynamicListView {
+               styles [
+                 "flathub-page-section",
+               ]
 
-               $BzDynamicListView {
-                 styles [
-                   "flathub-page-section",
-                 ]
-             
-                 hexpand: true;
-                 
-                 scroll: false;
-                 noscroll-kind: flow-box;
-                 child-type: "BzDetailedAppTile";
-                 child-prop: "group";
-                 model: SliceListModel {
-                   offset: 0;
-                   size: 7;
-                   model: bind template.state as <$BzFlathubState>.apps_of_the_week;
-                 };
+               margin-top: 16;
+               hexpand: true;
+               max-children-per-line:3;
+               scroll: false;
+               noscroll-kind: flow-box;
+               child-type: "BzDetailedAppTile";
+               child-prop: "group";
+               model: SliceListModel {
+                 offset: 0;
+                 size: 6;
+                 model: bind template.state as <$BzFlathubState>.apps_of_the_day_week;
+               };
 
-                 bind-widget => $bind_widget_cb(template);      
-                 unbind-widget => $unbind_widget_cb(template);      
-               }
+               bind-widget => $bind_widget_cb(template);
+               unbind-widget => $unbind_widget_cb(template);
              }
 
              Box {
@@ -143,7 +130,7 @@ template $BzFlathubPage: Adw.Bin {
                  ]
                
                  hexpand: true;
-               
+                 max-children-per-line:5;
                  scroll: false;
                  noscroll-kind: flow-box;
                  child-type: "BzCategoryTile";

--- a/src/bz-flathub-page.c
+++ b/src/bz-flathub-page.c
@@ -128,7 +128,7 @@ static guint
 limit_if_false (gpointer object,
                 gboolean value)
 {
-  return value ? 256 : 12;
+  return value ? 96 : 12;
 }
 
 static void

--- a/src/bz-flathub-state.c
+++ b/src/bz-flathub-state.c
@@ -332,7 +332,6 @@ GListModel *
 bz_flathub_state_dup_apps_of_the_day_week (BzFlathubState *self)
 {
   g_autoptr (GtkStringList) combined_list = NULL;
-  g_autoptr (GtkStringObject) string = NULL;
 
   g_return_val_if_fail (BZ_IS_FLATHUB_STATE (self), NULL);
   if (self->initializing != NULL)
@@ -341,10 +340,7 @@ bz_flathub_state_dup_apps_of_the_day_week (BzFlathubState *self)
   combined_list = gtk_string_list_new (NULL);
 
   if (self->app_of_the_day != NULL)
-    {
-      string = gtk_string_object_new (self->app_of_the_day);
-      gtk_string_list_append (combined_list, self->app_of_the_day);
-    }
+    gtk_string_list_append (combined_list, self->app_of_the_day);
 
   if (self->apps_of_the_week != NULL)
     {
@@ -449,7 +445,7 @@ bz_flathub_state_dup_trending (BzFlathubState *self)
 
 void
 bz_flathub_state_set_for_day (BzFlathubState *self,
-                             const char      *for_day)
+                              const char     *for_day)
 {
   g_return_if_fail (BZ_IS_FLATHUB_STATE (self));
 
@@ -533,7 +529,7 @@ bz_flathub_state_set_map_factory (BzFlathubState          *self,
 static DexFuture *
 initialize_fiber (BzFlathubState *self)
 {
-  const char *for_day           = self->for_day;
+  const char *for_day            = self->for_day;
   g_autoptr (GError) local_error = NULL;
   g_autoptr (GHashTable) futures = NULL;
   g_autoptr (GHashTable) nodes   = NULL;
@@ -541,20 +537,20 @@ initialize_fiber (BzFlathubState *self)
   futures = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, dex_unref);
   nodes   = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, (GDestroyNotify) json_node_unref);
 
-#define ADD_REQUEST(key, ...)                 \
-  G_STMT_START                                \
-  {                                           \
-    g_autofree char *_request      = NULL;    \
-    g_autoptr (DexFuture) _future = NULL;    \
-                                              \
-    _request = g_strdup_printf (__VA_ARGS__); \
+#define ADD_REQUEST(key, ...)                  \
+  G_STMT_START                                 \
+  {                                            \
+    g_autofree char *_request     = NULL;      \
+    g_autoptr (DexFuture) _future = NULL;      \
+                                               \
+    _request = g_strdup_printf (__VA_ARGS__);  \
     _future  = bz_query_flathub_v2_json_take ( \
         g_steal_pointer (&_request));         \
-    g_hash_table_replace (                    \
-        futures,                              \
-        g_strdup (key),                       \
-        g_steal_pointer (&_future));          \
-  }                                           \
+    g_hash_table_replace (                     \
+        futures,                               \
+        g_strdup (key),                        \
+        g_steal_pointer (&_future));           \
+  }                                            \
   G_STMT_END
 
   ADD_REQUEST ("/app-picks/app-of-the-day", "/app-picks/app-of-the-day/%s", for_day);
@@ -567,7 +563,7 @@ initialize_fiber (BzFlathubState *self)
 
   while (g_hash_table_size (futures) > 0)
     {
-      GHashTableIter    iter     = { 0 };
+      GHashTableIter   iter        = { 0 };
       g_autofree char *request     = NULL;
       g_autoptr (DexFuture) future = NULL;
       g_autoptr (JsonNode) node    = NULL;
@@ -615,7 +611,7 @@ initialize_fiber (BzFlathubState *self)
   if (g_hash_table_contains (nodes, "/collection/category"))
     {
       JsonArray *array  = NULL;
-      guint       length = 0;
+      guint      length = 0;
 
       array  = json_node_get_array (g_hash_table_lookup (nodes, "/collection/category"));
       length = json_array_get_length (array);
@@ -630,14 +626,14 @@ initialize_fiber (BzFlathubState *self)
 
       while (g_hash_table_size (futures) > 0)
         {
-          GHashTableIter    iter              = { 0 };
-          g_autofree char *name               = NULL;
-          g_autoptr (DexFuture) future        = NULL;
-          g_autoptr (JsonNode) node           = NULL;
+          GHashTableIter   iter                  = { 0 };
+          g_autofree char *name                  = NULL;
+          g_autoptr (DexFuture) future           = NULL;
+          g_autoptr (JsonNode) node              = NULL;
           g_autoptr (BzFlathubCategory) category = NULL;
-          g_autoptr (GtkStringList) store      = NULL;
-          JsonArray *category_array           = NULL;
-          guint      category_length          = 0;
+          g_autoptr (GtkStringList) store        = NULL;
+          JsonArray *category_array              = NULL;
+          guint      category_length             = 0;
 
           g_hash_table_iter_init (&iter, futures);
           g_hash_table_iter_next (&iter, (gpointer *) &name, (gpointer *) &future);


### PR DESCRIPTION
This PR aims to make Flathub views less awkward by ensuring complete rows are always displayed and adding some other minor visual tweaks:

- Added a `max-lines-per-row` parameter to `dynamic-list-view` for better layout control.
- Displaying the app of the day together with apps of the week to ensure a divisible 6 entries.
- Updated category pages to fetch 60 entries instead of 50, so the total is divisible.
- Adjusted text weight and size in app tiles for improved readability and a cleaner look.
- Updated collections to only fetch 96 instead of a 100
