### PR TITLE
fix installed page list outline ring

### DIFF
--- a/src/bz-installed-page.blp
+++ b/src/bz-installed-page.blp
@@ -29,6 +29,7 @@ template $BzInstalledPage: Adw.Bin {
           child: ListView {
             styles [
               "navigation-sidebar",
+              "installed-list-view"
             ]
 
             model: NoSelection {

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -219,9 +219,10 @@ background: shade(#deddda, 1.05);
 background: shade(#deddda, .95);
 }
 
-
-
-
+.installed-list-view > * {
+    padding: 0;
+    border-radius: 12px;
+}
 
 .transaction-sidebar-entry-list {
     margin: 0;


### PR DESCRIPTION
The outline ring when navigating with the keyboard didn’t follow the card because of the extra padding added by the `ListItem` widget. This CSS fixes it.

I believe I tried to fix this before with [this](https://github.com/kolunmi/bazaar/commit/3a923410ab76198a6426d45bbb11023b936b84fd), but unsuccessfully.
