### PR TITLE
(UI) Improve visiblility of add-on feature

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -220,7 +220,6 @@ template $BzFullView: Adw.Bin {
                       clicked => $install_cb(template);
                     }
 
-
                     Button remove_button {
                       styles [
                         "destructive-action",
@@ -235,6 +234,22 @@ template $BzFullView: Adw.Bin {
                         
                       icon-name: "user-trash-symbolic";
                       clicked => $remove_cb(template);
+                    }
+
+                    Button addons_btn {
+                      styles [
+                        "circular",
+                      ]
+                      visible:bind $logical_and(
+                            $invert_boolean($is_null(template.entry-group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.addons) as <bool>) as <bool>,
+                            $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.removable) as <bool>) as <bool>
+                      ) as <bool>;
+
+                      width-request:45;
+                      has-tooltip: true;
+                      tooltip-text: _("Manage Add-ons");
+                      clicked => $install_addons_cb(template);
+                      icon-name: "puzzle-piece-symbolic";
                     }
 
                     Button {

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -23,6 +23,7 @@
 #include <glib/gi18n.h>
 #include <json-glib/json-glib.h>
 
+#include "bz-addons-dialog.h"
 #include "bz-decorated-screenshot.h"
 #include "bz-dynamic-list-view.h"
 #include "bz-env.h"
@@ -77,6 +78,8 @@ enum
 {
   SIGNAL_INSTALL,
   SIGNAL_REMOVE,
+  SIGNAL_INSTALL_ADDON,
+  SIGNAL_REMOVE_ADDON,
 
   LAST_SIGNAL,
 };
@@ -87,6 +90,10 @@ debounce_timeout (BzFullView *self);
 
 static DexFuture *
 retrieve_star_string_fiber (BzFullView *self);
+
+static void addon_transact_cb (BzFullView     *self,
+                               BzEntry        *entry,
+                               BzAddonsDialog *dialog);
 
 static void
 bz_full_view_dispose (GObject *object)
@@ -378,6 +385,56 @@ forge_cb (BzFullView *self,
 }
 
 static void
+install_addons_cb (BzFullView *self,
+                   GtkButton  *button)
+{
+  BzEntry *entry = NULL;
+  GListModel *model = NULL;
+  g_autoptr (GListModel) mapped_model = NULL;
+  AdwDialog *addons_dialog = NULL;
+
+  if (self->group == NULL)
+    return;
+
+  entry = bz_result_get_object (self->ui_entry);
+  if (entry == NULL)
+    return;
+
+  model = bz_entry_get_addons (entry);
+  if (model == NULL || g_list_model_get_n_items (model) == 0)
+    return;
+
+  mapped_model = bz_application_map_factory_generate (
+      bz_state_info_get_entry_factory (self->state),
+      model);
+
+  addons_dialog = bz_addons_dialog_new (entry, mapped_model);
+  adw_dialog_set_content_width (addons_dialog, 750);
+  gtk_widget_set_size_request (GTK_WIDGET (addons_dialog), 350, -1);
+
+  g_signal_connect_swapped (
+      addons_dialog, "transact",
+      G_CALLBACK (addon_transact_cb), self);
+
+  adw_dialog_present (addons_dialog, GTK_WIDGET (self));
+}
+
+static void
+addon_transact_cb (BzFullView   *self,
+                   BzEntry      *entry,
+                   BzAddonsDialog *dialog)
+{
+  gboolean installed = FALSE;
+
+  g_object_get (entry, "installed", &installed, NULL);
+
+  if (installed)
+    g_signal_emit (self, signals[SIGNAL_REMOVE_ADDON], 0, entry);
+  else
+    g_signal_emit (self, signals[SIGNAL_INSTALL_ADDON], 0, entry);
+}
+
+static void
 screenshots_bind_widget_cb (BzFullView            *self,
                             BzDecoratedScreenshot *screenshot,
                             GdkPaintable          *paintable,
@@ -471,6 +528,36 @@ bz_full_view_class_init (BzFullViewClass *klass)
       G_TYPE_FROM_CLASS (klass),
       g_cclosure_marshal_VOID__OBJECTv);
 
+  signals[SIGNAL_INSTALL_ADDON] =
+      g_signal_new (
+          "install-addon",
+          G_OBJECT_CLASS_TYPE (klass),
+          G_SIGNAL_RUN_FIRST,
+          0,
+          NULL, NULL,
+          g_cclosure_marshal_VOID__OBJECT,
+          G_TYPE_NONE, 1,
+          BZ_TYPE_ENTRY);
+  g_signal_set_va_marshaller (
+      signals[SIGNAL_INSTALL_ADDON],
+      G_TYPE_FROM_CLASS (klass),
+      g_cclosure_marshal_VOID__OBJECTv);
+
+  signals[SIGNAL_REMOVE_ADDON] =
+      g_signal_new (
+          "remove-addon",
+          G_OBJECT_CLASS_TYPE (klass),
+          G_SIGNAL_RUN_FIRST,
+          0,
+          NULL, NULL,
+          g_cclosure_marshal_VOID__OBJECT,
+          G_TYPE_NONE, 1,
+          BZ_TYPE_ENTRY);
+  g_signal_set_va_marshaller (
+      signals[SIGNAL_REMOVE_ADDON],
+      G_TYPE_FROM_CLASS (klass),
+      g_cclosure_marshal_VOID__OBJECTv);
+
   g_type_ensure (BZ_TYPE_DECORATED_SCREENSHOT);
   g_type_ensure (BZ_TYPE_DYNAMIC_LIST_VIEW);
   g_type_ensure (BZ_TYPE_ENTRY);
@@ -502,6 +589,9 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, screenshots_bind_widget_cb);
   gtk_widget_class_bind_template_callback (widget_class, screenshots_unbind_widget_cb);
   gtk_widget_class_bind_template_callback (widget_class, pick_license_warning);
+  gtk_widget_class_bind_template_callback (widget_class, install_addons_cb);
+  gtk_widget_class_bind_template_callback (widget_class, addon_transact_cb);
+
 }
 
 static void

--- a/src/bz-installed-page.blp
+++ b/src/bz-installed-page.blp
@@ -117,6 +117,31 @@ template $BzInstalledPage: Adw.Bin {
                     
                     Button {
                       styles [
+                        "flat"
+                      ]
+
+                      has-tooltip: true;
+                      tooltip-text: _("Manage Add-ons");
+
+                      width-request: 32;
+                      height-request: 32;
+                      valign: center;
+                      icon-name: "puzzle-piece-symbolic";
+                      sensitive: bind $invert_boolean($is_zero(template.item as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>;
+                      visible: bind $invert_boolean($is_null(template.item as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.addons) as <bool>) as <bool>;
+
+                      clicked => $install_addons_cb(template);
+                    }
+
+                    Separator {
+                      visible: bind $invert_boolean($is_null(template.item as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.addons) as <bool>) as <bool>;
+                      orientation: vertical;
+                      margin-top: 12;
+                      margin-bottom: 12;
+                    }
+
+                    Button {
+                      styles [
                         "destructive-action",
                         "flat"
                       ]
@@ -186,58 +211,6 @@ template $BzInstalledPage: Adw.Bin {
 
                             clicked => $run_cb(template);
                           }
-
-                          Button {
-                            styles [
-                              "flat",
-                            ]
-
-                            has-tooltip: true;
-                            tooltip-text: _("Manage Addons");
-                            visible: bind $invert_boolean($is_null(template.item as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.addons) as <bool>) as <bool>;
-                            sensitive: bind $invert_boolean($is_zero(template.item as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>;
-
-                            child: Box {
-                              orientation: horizontal;
-                              spacing: 6;
-
-                              Image {
-                                icon-name: "puzzle-piece-symbolic";
-                              }
-
-                              Label {
-                                label: _("Manage Addons");
-                              }
-                            };
-
-                            clicked => $install_addons_cb(template);
-                          }
-                          /*
-                          Button {
-                            styles [
-                              "flat",
-                            ]
-
-                            has-tooltip: true;
-                            tooltip-text: _("Edit Permissions");
-
-                            child: Box {
-                              orientation: horizontal;
-                              spacing: 6;
-
-                              Image {
-                                icon-name: "sliders-horizontal-symbolic";
-                              }
-
-                              Label {
-                                label: _("Edit Permissions");
-                              }
-                            };
-
-                            clicked => $edit_permissions_cb(template);
-                          }
-                          */
-
                           Button {
                             styles [
                               "flat",

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -227,6 +227,8 @@ template $BzWindow: Adw.ApplicationWindow {
                       transaction-manager: bind template.state as <$BzStateInfo>.transaction-manager;
                       install => $full_view_install_cb(template);
                       remove => $full_view_remove_cb(template);
+                      install-addon => $install_addon_cb(template);
+                      remove-addon => $remove_addon_cb(template);
                     };
                   }
 
@@ -247,8 +249,8 @@ template $BzWindow: Adw.ApplicationWindow {
                     child: $BzInstalledPage {
                       state: bind template.state;
                       model: bind template.state as <$BzStateInfo>.all-installed-entry-groups;
-                      install => $installed_page_install_cb(template);
-                      remove => $installed_page_remove_cb(template);
+                      install => $install_addon_cb(template);
+                      remove => $remove_addon_cb(template);
                       show-entry => $installed_page_show_cb(template);
                     };
                   }

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -276,8 +276,9 @@ full_view_remove_cb (BzWindow   *self,
   try_transact (self, NULL, bz_full_view_get_entry_group (view), TRUE, source);
 }
 
+
 static void
-installed_page_install_cb (BzWindow   *self,
+install_addon_cb (BzWindow   *self,
                            BzEntry    *entry,
                            BzFullView *view)
 {
@@ -285,7 +286,7 @@ installed_page_install_cb (BzWindow   *self,
 }
 
 static void
-installed_page_remove_cb (BzWindow   *self,
+remove_addon_cb (BzWindow   *self,
                           BzEntry    *entry,
                           BzFullView *view)
 {
@@ -484,8 +485,8 @@ bz_window_class_init (BzWindowClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, search_widget_select_cb);
   gtk_widget_class_bind_template_callback (widget_class, full_view_install_cb);
   gtk_widget_class_bind_template_callback (widget_class, full_view_remove_cb);
-  gtk_widget_class_bind_template_callback (widget_class, installed_page_install_cb);
-  gtk_widget_class_bind_template_callback (widget_class, installed_page_remove_cb);
+  gtk_widget_class_bind_template_callback (widget_class, install_addon_cb);
+  gtk_widget_class_bind_template_callback (widget_class, remove_addon_cb);
   gtk_widget_class_bind_template_callback (widget_class, installed_page_show_cb);
   gtk_widget_class_bind_template_callback (widget_class, page_toggled_cb);
   gtk_widget_class_bind_template_callback (widget_class, breakpoint_apply_cb);


### PR DESCRIPTION
People seem to sometimes miss the existence of the add-ons feature. This patch tries to address that by adding a button on the `full-view` page to open the add-ons dialog.

It also moves the add-ons button out of the popover dialog on the installed page. Normally, I would avoid having three buttons in a row, but since apps with add-ons are relatively rare, I think this is acceptable.


<img width="654" height="194" alt="image" src="https://github.com/user-attachments/assets/ff227a67-8687-4b73-8ff8-0f29ed9cdc33" />

<img width="410" height="277" alt="image" src="https://github.com/user-attachments/assets/a89f7625-639e-4504-975d-bd548ba74ffb" />
