### PR TITLE
Rework Version History

### DIFF
--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -949,11 +949,11 @@ bz_entry_real_serialize (BzSerializable  *serializable,
               const char *version                        = NULL;
               const char *description                    = NULL;
 
-              release   = g_list_model_get_item (priv->version_history, i);
-              issues    = bz_release_get_issues (release);
-              timestamp = bz_release_get_timestamp (release);
-              url       = bz_release_get_url (release);
-              version   = bz_release_get_version (release);
+              release     = g_list_model_get_item (priv->version_history, i);
+              issues      = bz_release_get_issues (release);
+              timestamp   = bz_release_get_timestamp (release);
+              url         = bz_release_get_url (release);
+              version     = bz_release_get_version (release);
               description = bz_release_get_description (release);
 
               if (issues != NULL)
@@ -977,16 +977,16 @@ bz_entry_real_serialize (BzSerializable  *serializable,
                     }
                 }
 
-            g_variant_builder_add (
-                sub_builder,
-                "(msmvtmsms)",
-                description,
-                issues_builder != NULL
-                    ? g_variant_builder_end (issues_builder)
-                    : NULL,
-                timestamp,
-                url,
-                version);
+              g_variant_builder_add (
+                  sub_builder,
+                  "(msmvtmsms)",
+                  description,
+                  issues_builder != NULL
+                      ? g_variant_builder_end (issues_builder)
+                      : NULL,
+                  timestamp,
+                  url,
+                  version);
             }
 
           g_variant_builder_add (builder, "{sv}", "version-history", g_variant_builder_end (sub_builder));

--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -937,7 +937,7 @@ bz_entry_real_serialize (BzSerializable  *serializable,
         {
           g_autoptr (GVariantBuilder) sub_builder = NULL;
 
-          sub_builder = g_variant_builder_new (G_VARIANT_TYPE ("a(mvtmsms)"));
+          sub_builder = g_variant_builder_new (G_VARIANT_TYPE ("a(msmvtmsms)"));
           for (guint i = 0; i < n_items; i++)
             {
               g_autoptr (BzRelease) release              = NULL;
@@ -947,12 +947,14 @@ bz_entry_real_serialize (BzSerializable  *serializable,
               guint64     timestamp                      = 0;
               const char *url                            = NULL;
               const char *version                        = NULL;
+              const char *description                    = NULL;
 
               release   = g_list_model_get_item (priv->version_history, i);
               issues    = bz_release_get_issues (release);
               timestamp = bz_release_get_timestamp (release);
               url       = bz_release_get_url (release);
               version   = bz_release_get_version (release);
+              description = bz_release_get_description (release);
 
               if (issues != NULL)
                 {
@@ -975,15 +977,16 @@ bz_entry_real_serialize (BzSerializable  *serializable,
                     }
                 }
 
-              g_variant_builder_add (
-                  sub_builder,
-                  "(mvtmsms)",
-                  issues_builder != NULL
-                      ? g_variant_builder_end (issues_builder)
-                      : NULL,
-                  timestamp,
-                  url,
-                  version);
+            g_variant_builder_add (
+                sub_builder,
+                "(msmvtmsms)",
+                description,
+                issues_builder != NULL
+                    ? g_variant_builder_end (issues_builder)
+                    : NULL,
+                timestamp,
+                url,
+                version);
             }
 
           g_variant_builder_add (builder, "{sv}", "version-history", g_variant_builder_end (sub_builder));
@@ -1197,10 +1200,11 @@ bz_entry_real_deserialize (BzSerializable *serializable,
               g_autoptr (GListStore) issues_store = NULL;
               guint64          timestamp          = 0;
               g_autofree char *url                = NULL;
+              g_autofree char *description        = NULL;
               g_autofree char *version            = NULL;
               g_autoptr (BzRelease) release       = NULL;
 
-              if (!g_variant_iter_next (version_iter, "(mvtmsms)", &issues, &timestamp, &url, &version))
+              if (!g_variant_iter_next (version_iter, "(msmvtmsms)", &description, &issues, &timestamp, &url, &version))
                 break;
 
               if (issues != NULL)
@@ -1232,6 +1236,7 @@ bz_entry_real_deserialize (BzSerializable *serializable,
               bz_release_set_timestamp (release, timestamp);
               bz_release_set_url (release, url);
               bz_release_set_version (release, version);
+              bz_release_set_description (release, description);
               g_list_store_append (store, release);
             }
 

--- a/src/bz-flatpak-entry.c
+++ b/src/bz-flatpak-entry.c
@@ -86,10 +86,9 @@ enum
 };
 static GParamSpec *props[LAST_PROP] = { 0 };
 
-
 static char *
-parse_appstream_to_markdown (const char  *description_raw,
-                               GError     **error);
+parse_appstream_to_markdown (const char *description_raw,
+                             GError    **error);
 
 static inline void
 append_markup_escaped (GString    *string,
@@ -462,7 +461,7 @@ bz_flatpak_entry_new_for_ref (BzFlatpakInstance *instance,
         }
 
       long_description_raw = as_component_get_description (component);
-      long_description = parse_appstream_to_markdown (long_description_raw, error);
+      long_description     = parse_appstream_to_markdown (long_description_raw, error);
       if (long_description_raw != NULL && long_description == NULL)
         return NULL;
 
@@ -591,18 +590,18 @@ bz_flatpak_entry_new_for_ref (BzFlatpakInstance *instance,
 
           for (guint i = 0; i < releases_arr->len; i++)
             {
-              AsRelease *as_release                   = NULL;
-              GPtrArray *as_issues                    = NULL;
-              const char *release_description_raw     = NULL;
-              g_autofree char *release_description    = NULL;
-              g_autoptr (GListStore) issues           = NULL;
-              g_autoptr (BzRelease) release           = NULL;
+              AsRelease       *as_release              = NULL;
+              GPtrArray       *as_issues               = NULL;
+              const char      *release_description_raw = NULL;
+              g_autofree char *release_description     = NULL;
+              g_autoptr (GListStore) issues            = NULL;
+              g_autoptr (BzRelease) release            = NULL;
 
               as_release = g_ptr_array_index (releases_arr, i);
               as_issues  = as_release_get_issues (as_release);
 
               release_description_raw = as_release_get_description (as_release);
-              release_description = parse_appstream_to_markdown (release_description_raw, NULL);
+              release_description     = parse_appstream_to_markdown (release_description_raw, NULL);
 
               if (as_issues != NULL && as_issues->len > 0)
                 {
@@ -1042,8 +1041,8 @@ compile_appstream_description (XbNode  *node,
 }
 
 static char *
-parse_appstream_to_markdown (const char  *description_raw,
-                               GError     **error)
+parse_appstream_to_markdown (const char *description_raw,
+                             GError    **error)
 {
   g_autoptr (XbSilo) silo          = NULL;
   g_autoptr (XbNode) root          = NULL;

--- a/src/bz-flatpak-entry.c
+++ b/src/bz-flatpak-entry.c
@@ -86,11 +86,10 @@ enum
 };
 static GParamSpec *props[LAST_PROP] = { 0 };
 
-static void
-compile_appstream_description (XbNode  *node,
-                               GString *string,
-                               int      parent_kind,
-                               int      idx);
+
+static char *
+parse_appstream_to_markdown (const char  *description_raw,
+                               GError     **error);
 
 static inline void
 append_markup_escaped (GString    *string,
@@ -463,50 +462,9 @@ bz_flatpak_entry_new_for_ref (BzFlatpakInstance *instance,
         }
 
       long_description_raw = as_component_get_description (component);
-      if (long_description_raw != NULL)
-        {
-          g_autoptr (XbSilo) silo          = NULL;
-          g_autoptr (XbNode) root          = NULL;
-          g_autoptr (GString) string       = NULL;
-          g_autoptr (GRegex) cleanup_regex = NULL;
-
-          silo = xb_silo_new_from_xml (long_description_raw, error);
-          if (silo == NULL)
-            return NULL;
-
-          root   = xb_silo_get_root (silo);
-          string = g_string_new (NULL);
-
-          /* TODO this sucks big time */
-          cleanup_regex = g_regex_new (
-              "^ +| +$|\\t+|\\A\\s+|\\s+\\z",
-              G_REGEX_MULTILINE,
-              G_REGEX_MATCH_DEFAULT,
-              NULL);
-          g_assert (cleanup_regex != NULL);
-
-          for (int i = 0; root != NULL; i++)
-            {
-              const char *tail = NULL;
-              XbNode     *next = NULL;
-
-              compile_appstream_description (root, string, NO_ELEMENT, i);
-
-              tail = xb_node_get_tail (root);
-              if (tail != NULL)
-                append_markup_escaped (string, tail);
-
-              next = xb_node_get_next (root);
-              g_object_unref (root);
-              root = next;
-            }
-
-          /* Could be better but bleh */
-          g_string_replace (string, "  ", "", 0);
-          long_description = g_regex_replace (
-              cleanup_regex, string->str, -1, 0,
-              "", G_REGEX_MATCH_DEFAULT, NULL);
-        }
+      long_description = parse_appstream_to_markdown (long_description_raw, error);
+      if (long_description_raw != NULL && long_description == NULL)
+        return NULL;
 
       screenshots = as_component_get_screenshots_all (component);
       if (screenshots != NULL)
@@ -633,13 +591,18 @@ bz_flatpak_entry_new_for_ref (BzFlatpakInstance *instance,
 
           for (guint i = 0; i < releases_arr->len; i++)
             {
-              AsRelease *as_release         = NULL;
-              GPtrArray *as_issues          = NULL;
-              g_autoptr (GListStore) issues = NULL;
-              g_autoptr (BzRelease) release = NULL;
+              AsRelease *as_release                   = NULL;
+              GPtrArray *as_issues                    = NULL;
+              const char *release_description_raw     = NULL;
+              g_autofree char *release_description    = NULL;
+              g_autoptr (GListStore) issues           = NULL;
+              g_autoptr (BzRelease) release           = NULL;
 
               as_release = g_ptr_array_index (releases_arr, i);
               as_issues  = as_release_get_issues (as_release);
+
+              release_description_raw = as_release_get_description (as_release);
+              release_description = parse_appstream_to_markdown (release_description_raw, NULL);
 
               if (as_issues != NULL && as_issues->len > 0)
                 {
@@ -663,6 +626,7 @@ bz_flatpak_entry_new_for_ref (BzFlatpakInstance *instance,
 
               release = g_object_new (
                   BZ_TYPE_RELEASE,
+                  "description", release_description,
                   "issues", issues,
                   "timestamp", as_release_get_timestamp (as_release),
                   "url", as_release_get_url (as_release, AS_RELEASE_URL_KIND_DETAILS),
@@ -1043,7 +1007,7 @@ compile_appstream_description (XbNode  *node,
           g_string_append_printf (string, "%d. ", idx);
           break;
         case UNORDERED_LIST:
-          g_string_append (string, "- ");
+          g_string_append (string, "• ");
           break;
         default:
           break;
@@ -1075,6 +1039,57 @@ compile_appstream_description (XbNode  *node,
     g_string_append (string, "</tt>");
   else
     g_string_append (string, "\n");
+}
+
+static char *
+parse_appstream_to_markdown (const char  *description_raw,
+                               GError     **error)
+{
+  g_autoptr (XbSilo) silo          = NULL;
+  g_autoptr (XbNode) root          = NULL;
+  g_autoptr (GString) string       = NULL;
+  g_autoptr (GRegex) cleanup_regex = NULL;
+  g_autofree char *cleaned         = NULL;
+
+  if (description_raw == NULL)
+    return NULL;
+
+  silo = xb_silo_new_from_xml (description_raw, error);
+  if (silo == NULL)
+    return NULL;
+
+  root   = xb_silo_get_root (silo);
+  string = g_string_new (NULL);
+
+  cleanup_regex = g_regex_new (
+      "^ +| +$|\\t+|\\A\\s+|\\s+\\z",
+      G_REGEX_MULTILINE,
+      G_REGEX_MATCH_DEFAULT,
+      NULL);
+  g_assert (cleanup_regex != NULL);
+
+  for (int i = 0; root != NULL; i++)
+    {
+      const char *tail = NULL;
+      XbNode     *next = NULL;
+
+      compile_appstream_description (root, string, NO_ELEMENT, i);
+
+      tail = xb_node_get_tail (root);
+      if (tail != NULL)
+        append_markup_escaped (string, tail);
+
+      next = xb_node_get_next (root);
+      g_object_unref (root);
+      root = next;
+    }
+
+  g_string_replace (string, "  ", "", 0);
+  cleaned = g_regex_replace (
+      cleanup_regex, string->str, -1, 0,
+      "", G_REGEX_MATCH_DEFAULT, NULL);
+
+  return g_steal_pointer (&cleaned);
 }
 
 static inline void

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -417,102 +417,26 @@ template $BzFullView: Adw.Bin {
                         icon-name: "network-server-symbolic";
                       }
                     }
-
                   }
 
-                  Frame {
-                    styles [
-                      "card",
-                    ]
+                  Box {
+                    orientation: vertical;
 
-                    child: ListView {
+                    Label {
                       styles [
-                        "navigation-sidebar",
+                        "heading", "h4"
                       ]
 
-                      margin-start: 5;
-                      margin-end: 5;
-                      margin-top: 5;
-                      margin-bottom: 5;
-                      single-click-activate: true;
+                      label: _("Version History");
+                      xalign: 0;
+                      margin-bottom: 12;
+                    }
 
-                      model: NoSelection {
-                        model: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.version-history;
-                      };
+                    ListBox releases_box {
+                      styles ["boxed-list"]
 
-                      factory: BuilderListItemFactory {
-                        template ListItem {
-                          activatable: false;
-                          child: Box {
-                            margin-top: 10;
-                            margin-bottom: 10;
-                            orientation: vertical;
-                            spacing: 3;
-
-                            Label {
-                              styles [
-                                "accent",
-                                "title-4",
-                              ]
-
-                              ellipsize: end;
-                              xalign: 0.0;
-                              label: bind template.item as <$BzRelease>.version;
-                            }
-
-                            Label {
-                              ellipsize: end;
-                              xalign: 0.0;
-                              label: bind $format_timestamp(template.item as <$BzRelease>.timestamp) as <string>;
-                            }
-
-                            ListView {
-                              styles [
-                                "navigation-sidebar",
-                              ]
-
-                              visible: bind $invert_boolean($is_null(template.item as <$BzRelease>.issues) as <bool>) as <bool>;
-                              margin-start: 25;
-
-                              model: NoSelection {
-                                model: bind template.item as <$BzRelease>.issues;
-                              };
-
-                              factory: BuilderListItemFactory {
-                                template ListItem {
-                                  activatable: false;
-
-                                  child: Box {
-                                    margin-top: 10;
-                                    margin-bottom: 10;
-                                    orientation: vertical;
-                                    spacing: 3;
-
-                                    Label {
-                                      styles [
-                                        "heading",
-                                      ]
-
-                                      wrap: true;
-                                      wrap-mode: word_char;
-                                      xalign: 0.0;
-                                      label: bind template.item as <$BzIssue>.id;
-                                    }
-
-                                    Label {
-                                      ellipsize: end;
-                                      xalign: 0.0;
-                                      use-markup: true;
-                                      label: bind $format_as_link(template.item as <$BzIssue>.url) as <string>;
-                                    }
-                                  };
-                                }
-                              };
-                            }
-                          };
-                        }
-                      };
-                    };
+                      selection-mode: none;
+                    }
                   }
                 };
               }

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -53,9 +53,10 @@ struct _BzFullView
   DexFuture *loading_forge_stars;
 
   /* Template widgets */
-  AdwViewStack *stack;
-  GtkWidget    *forge_stars;
-  GtkLabel     *forge_stars_label;
+  AdwViewStack          *stack;
+  GtkWidget             *forge_stars;
+  GtkLabel              *forge_stars_label;
+  GtkListBox            *releases_box;
 };
 
 G_DEFINE_FINAL_TYPE (BzFullView, bz_full_view, ADW_TYPE_BIN)
@@ -222,7 +223,7 @@ format_timestamp (gpointer object,
   g_autoptr (GDateTime) date = NULL;
 
   date = g_date_time_new_from_unix_utc (value);
-  return g_date_time_format (date, _ ("Released %x"));
+  return g_date_time_format (date, _ ("%x"));
 }
 
 static char *
@@ -435,6 +436,133 @@ addon_transact_cb (BzFullView     *self,
 }
 
 static void
+clear_releases_box (BzFullView *self)
+{
+  GtkWidget *child;
+
+  while ((child = gtk_widget_get_first_child (GTK_WIDGET (self->releases_box))))
+    gtk_list_box_remove (self->releases_box, child);
+}
+
+static GtkWidget *
+create_release_row (const char *version,
+                   const char *description,
+                   guint64     timestamp)
+{
+  AdwActionRow *row;
+  GtkBox *content_box;
+  GtkBox *header_box;
+  GtkLabel *version_label;
+  GtkLabel *date_label;
+  GtkLabel *description_label;
+  g_autoptr (GDateTime) date = NULL;
+  g_autofree char *date_str = NULL;
+  g_autofree char *version_text = NULL;
+
+  date = g_date_time_new_from_unix_utc (timestamp);
+  if (date)
+    date_str = g_date_time_format (date, _("%x"));
+
+  row = ADW_ACTION_ROW (adw_action_row_new ());
+  gtk_list_box_row_set_activatable (GTK_LIST_BOX_ROW (row), FALSE);
+
+  content_box = GTK_BOX (gtk_box_new (GTK_ORIENTATION_VERTICAL, 3));
+  gtk_widget_set_margin_top (GTK_WIDGET (content_box), 15);
+  gtk_widget_set_margin_bottom (GTK_WIDGET (content_box), 15);
+  gtk_widget_set_margin_start (GTK_WIDGET (content_box), 15);
+  gtk_widget_set_margin_end (GTK_WIDGET (content_box), 15);
+
+  header_box = GTK_BOX (gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0));
+
+  version_text = g_strdup_printf (_("Version %s"), version);
+  version_label = GTK_LABEL (gtk_label_new (version_text));
+  gtk_widget_add_css_class (GTK_WIDGET (version_label), "accent");
+  gtk_widget_add_css_class (GTK_WIDGET (version_label), "heading");
+  gtk_label_set_ellipsize (version_label, PANGO_ELLIPSIZE_END);
+  gtk_widget_set_halign (GTK_WIDGET (version_label), GTK_ALIGN_START);
+  gtk_widget_set_hexpand (GTK_WIDGET (version_label), TRUE);
+  gtk_box_append (header_box, GTK_WIDGET (version_label));
+
+  date_label = GTK_LABEL (gtk_label_new (date_str ? date_str : ""));
+  gtk_widget_add_css_class (GTK_WIDGET (date_label), "dim-label");
+  gtk_widget_set_halign (GTK_WIDGET (date_label), GTK_ALIGN_END);
+  gtk_box_append (header_box, GTK_WIDGET (date_label));
+
+  gtk_box_append (content_box, GTK_WIDGET (header_box));
+
+  description_label = GTK_LABEL (gtk_label_new (
+      (description && *description) ? description : _("No details for this release")
+  ));
+  gtk_widget_set_halign (GTK_WIDGET (description_label), GTK_ALIGN_FILL);
+  gtk_label_set_xalign (description_label, 0.0);
+
+  if (description && *description)
+    {
+      gtk_widget_set_margin_top (GTK_WIDGET (description_label), 10);
+      gtk_label_set_wrap (description_label, TRUE);
+      gtk_label_set_use_markup (description_label, TRUE);
+      gtk_label_set_selectable (description_label, TRUE);
+    }
+  else
+    {
+      gtk_widget_set_margin_top (GTK_WIDGET (description_label), 5);
+      gtk_widget_add_css_class (GTK_WIDGET (description_label), "dim-label");
+    }
+
+  gtk_box_append (content_box, GTK_WIDGET (description_label));
+  gtk_list_box_row_set_child (GTK_LIST_BOX_ROW (row), GTK_WIDGET (content_box));
+
+  return GTK_WIDGET (row);
+}
+
+static void
+populate_releases_box (BzFullView *self)
+{
+  BzEntry *entry;
+  GListModel *version_history = NULL;
+  guint n_items;
+
+  clear_releases_box (self);
+
+  if (self->debounced_ui_entry == NULL)
+    return;
+
+  entry = bz_result_get_object (self->debounced_ui_entry);
+  if (entry == NULL)
+    return;
+
+  g_object_get (entry, "version-history", &version_history, NULL);
+  if (version_history == NULL)
+    return;
+
+  n_items = g_list_model_get_n_items (version_history);
+
+  for (guint i = 0; i < n_items; i++)
+    {
+      g_autoptr (GObject) item = NULL;
+      const char *version = NULL;
+      const char *description = NULL;
+      guint64 timestamp = 0;
+      GtkWidget *row;
+
+      item = g_list_model_get_item (version_history, i);
+      if (item == NULL)
+        continue;
+
+      g_object_get (item,
+                    "version", &version,
+                    "description", &description,
+                    "timestamp", &timestamp,
+                    NULL);
+
+      row = create_release_row (version, description, timestamp);
+      gtk_list_box_append (self->releases_box, row);
+    }
+
+  g_object_unref (version_history);
+}
+
+static void
 screenshots_bind_widget_cb (BzFullView            *self,
                             BzDecoratedScreenshot *screenshot,
                             GdkPaintable          *paintable,
@@ -570,6 +698,7 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_child (widget_class, BzFullView, stack);
   gtk_widget_class_bind_template_child (widget_class, BzFullView, forge_stars);
   gtk_widget_class_bind_template_child (widget_class, BzFullView, forge_stars_label);
+  gtk_widget_class_bind_template_child (widget_class, BzFullView, releases_box);
   gtk_widget_class_bind_template_callback (widget_class, invert_boolean);
   gtk_widget_class_bind_template_callback (widget_class, is_zero);
   gtk_widget_class_bind_template_callback (widget_class, is_null);
@@ -641,6 +770,8 @@ bz_full_view_set_entry_group (BzFullView   *self,
   g_clear_object (&self->debounced_ui_entry);
   g_clear_object (&self->group_model);
 
+  clear_releases_box (self);
+
   gtk_widget_set_visible (self->forge_stars, FALSE);
   gtk_revealer_set_reveal_child (GTK_REVEALER (self->forge_stars), FALSE);
   gtk_label_set_label (self->forge_stars_label, "...");
@@ -685,7 +816,10 @@ debounce_timeout (BzFullView *self)
   self->debounced_ui_entry = g_object_ref (self->ui_entry);
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_DEBOUNCED_UI_ENTRY]);
 
-  /* Disabled by default in gsettings schema since we don't want to
+  if (bz_result_get_resolved (self->debounced_ui_entry))
+    populate_releases_box (self);
+
+    /* Disabled by default in gsettings schema since we don't want to
      users to be rate limited by github */
   if (self->state != NULL &&
       g_settings_get_boolean (

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -439,7 +439,7 @@ addon_transact_cb (BzFullView     *self,
 static void
 clear_releases_box (BzFullView *self)
 {
-  GtkWidget *child;
+  GtkWidget *child = NULL;
 
   while ((child = gtk_widget_get_first_child (GTK_WIDGET (self->releases_box))))
     gtk_list_box_remove (self->releases_box, child);
@@ -450,15 +450,15 @@ create_release_row (const char *version,
                     const char *description,
                     guint64     timestamp)
 {
-  AdwActionRow *row;
-  GtkBox       *content_box;
-  GtkBox       *header_box;
-  GtkLabel     *version_label;
-  GtkLabel     *date_label;
-  GtkLabel     *description_label;
-  g_autoptr (GDateTime) date    = NULL;
-  g_autofree char *date_str     = NULL;
-  g_autofree char *version_text = NULL;
+  AdwActionRow *row               = NULL;
+  GtkBox       *content_box       = NULL;
+  GtkBox       *header_box        = NULL;
+  GtkLabel     *version_label     = NULL;
+  GtkLabel     *date_label        = NULL;
+  GtkLabel     *description_label = NULL;
+  g_autoptr (GDateTime) date      = NULL;
+  g_autofree char *date_str       = NULL;
+  g_autofree char *version_text   = NULL;
 
   date = g_date_time_new_from_unix_utc (timestamp);
   if (date)

--- a/src/bz-release.c
+++ b/src/bz-release.c
@@ -24,6 +24,7 @@ struct _BzRelease
 {
   GObject parent_instance;
 
+  char       *description;
   GListModel *issues;
   guint64     timestamp;
   char       *url;
@@ -36,6 +37,7 @@ enum
 {
   PROP_0,
 
+  PROP_DESCRIPTION,
   PROP_ISSUES,
   PROP_TIMESTAMP,
   PROP_URL,
@@ -50,6 +52,7 @@ bz_release_dispose (GObject *object)
 {
   BzRelease *self = BZ_RELEASE (object);
 
+  g_clear_pointer (&self->description, g_free);
   g_clear_pointer (&self->issues, g_object_unref);
   g_clear_pointer (&self->url, g_free);
   g_clear_pointer (&self->version, g_free);
@@ -67,6 +70,9 @@ bz_release_get_property (GObject    *object,
 
   switch (prop_id)
     {
+    case PROP_DESCRIPTION:
+      g_value_set_string (value, bz_release_get_description (self));
+      break;
     case PROP_ISSUES:
       g_value_set_object (value, bz_release_get_issues (self));
       break;
@@ -94,6 +100,9 @@ bz_release_set_property (GObject      *object,
 
   switch (prop_id)
     {
+    case PROP_DESCRIPTION:
+      bz_release_set_description (self, g_value_get_string (value));
+      break;
     case PROP_ISSUES:
       bz_release_set_issues (self, g_value_get_object (value));
       break;
@@ -119,6 +128,12 @@ bz_release_class_init (BzReleaseClass *klass)
   object_class->set_property = bz_release_set_property;
   object_class->get_property = bz_release_get_property;
   object_class->dispose      = bz_release_dispose;
+
+  props[PROP_DESCRIPTION] =
+      g_param_spec_string (
+          "description",
+          NULL, NULL, NULL,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
   props[PROP_ISSUES] =
       g_param_spec_object (
@@ -160,6 +175,17 @@ bz_release_new (void)
   return g_object_new (BZ_TYPE_RELEASE, NULL);
 }
 
+const char *
+bz_release_get_description (BzRelease *self)
+{
+  g_return_val_if_fail (BZ_IS_RELEASE (self), NULL);
+
+  if (self->description == NULL)
+    return NULL;
+
+  return self->description;
+}
+
 GListModel *
 bz_release_get_issues (BzRelease *self)
 {
@@ -186,6 +212,19 @@ bz_release_get_version (BzRelease *self)
 {
   g_return_val_if_fail (BZ_IS_RELEASE (self), NULL);
   return self->version;
+}
+
+void
+bz_release_set_description (BzRelease  *self,
+                            const char *description)
+{
+  g_return_if_fail (BZ_IS_RELEASE (self));
+
+  g_clear_pointer (&self->description, g_free);
+  if (description != NULL)
+    self->description = g_strdup (description);
+
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_DESCRIPTION]);
 }
 
 void

--- a/src/bz-release.h
+++ b/src/bz-release.h
@@ -40,6 +40,9 @@ const char *
 bz_release_get_url (BzRelease *self);
 
 const char *
+bz_release_get_description (BzRelease *self);
+
+const char *
 bz_release_get_version (BzRelease *self);
 
 void
@@ -53,6 +56,10 @@ bz_release_set_timestamp (BzRelease *self,
 void
 bz_release_set_url (BzRelease  *self,
                     const char *url);
+
+void
+bz_release_set_description (BzRelease  *self,
+                            const char *description);
 
 void
 bz_release_set_version (BzRelease  *self,


### PR DESCRIPTION
This PR redesigns the version history section of the BzFullView.  
The biggest actual change is replacing the list of issues with the release description, parsed in the same way as the long description.  

Release descriptions are included more often than issue lists and are also much more user-facing.  

I also switched to a boxed list design again, which fits better with the other design elements. Unfortunately, `boxed-list` does not work with `ListView`, so we have to construct it manually in code.

I don’t think we need to hide the version history behind a dialog, since it’s already at the bottom of the scrolled window and so it doesn’t make any other parts less accessible.

<img width="1246" height="981" alt="image" src="https://github.com/user-attachments/assets/07fef8d4-9b9f-4aa0-bce6-14cfe5f218bd" />
