### PR TITLE
 fix: use hardcoded config path

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -9,7 +9,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-49
       options: --privileged
     steps:
     - uses: actions/checkout@v4

--- a/Justfile
+++ b/Justfile
@@ -2,7 +2,7 @@
 
 appid := env("BAZAAR_APPID", "io.github.kolunmi.Bazaar")
 manifest := "./build-aux/flatpak/" + appid + ".json"
-branch := env("BAZAAR_BRANCH", "stable")
+branch := env("BAZAAR_BRANCH", "master")
 just := just_executable()
 
 alias run := run-base

--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.json
@@ -39,7 +39,9 @@
       "name": "bazaar",
       "buildsystem": "meson",
       "config-opts": [
-        "-Dsandboxed_libflatpak=true"
+        "-Dsandboxed_libflatpak=true",
+        "-Dhardcoded_content_config_path=/run/host/etc/bazaar/config.yaml",
+        "-Dhardcoded_blocklist_path=/run/host/etc/bazaar/blocklist.txt"
       ],
       "sources": [
         {


### PR DESCRIPTION
This is currently the only major difference between the manifests and would make it easier for me to test the flatpak that CI spits out

See:
https://github.com/flathub/io.github.kolunmi.Bazaar/commit/d46c650a51f466beded821f16e5cdc7a6b287cb0