### PR TITLE
(UI) Change remove button pulse effect color and comet size curve

### DIFF
--- a/src/bz-comet-overlay.h
+++ b/src/bz-comet-overlay.h
@@ -40,6 +40,12 @@ GtkWidget *
 bz_comet_overlay_get_child (BzCometOverlay *self);
 
 void
+bz_comet_overlay_set_pulse_color (BzCometOverlay *self,
+                                  GdkRGBA        *color);
+GdkRGBA *
+bz_comet_overlay_get_pulse_color (BzCometOverlay *self);
+
+void
 bz_comet_overlay_spawn (BzCometOverlay *self,
                         BzComet        *comet);
 

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -607,9 +607,12 @@ checking_for_updates_changed (BzWindow    *self,
   if (!busy && !checking_for_updates)
     {
       if (has_updates)
-        bz_comet_overlay_pulse_child (
-            self->comet_overlay,
-            GTK_WIDGET (self->update_button));
+        {
+          bz_comet_overlay_set_pulse_color (self->comet_overlay, NULL);
+          bz_comet_overlay_pulse_child (
+              self->comet_overlay,
+              GTK_WIDGET (self->update_button));
+        }
       else
         adw_toast_overlay_add_toast (
             self->toasts,
@@ -868,6 +871,24 @@ transact (BzWindow  *self,
   if (icon != NULL)
     {
       g_autoptr (BzComet) comet = NULL;
+
+      if (remove)
+        {
+          AdwStyleManager *style_manager = adw_style_manager_get_default ();
+          gboolean         is_dark       = adw_style_manager_get_dark (style_manager);
+          GdkRGBA          destructive_color;
+
+          if (is_dark)
+            destructive_color = (GdkRGBA) { 0.3, 0.2, 0.21, 0.6 };
+          else
+            destructive_color = (GdkRGBA) { 0.95, 0.84, 0.84, 0.6 };
+
+          bz_comet_overlay_set_pulse_color (self->comet_overlay, &destructive_color);
+        }
+      else
+        {
+          bz_comet_overlay_set_pulse_color (self->comet_overlay, NULL);
+        }
 
       comet = g_object_new (
           BZ_TYPE_COMET,


### PR DESCRIPTION
Changed the curve for the icon size of the comet to be inverse parabolic instead of linear, creating a nicer effect at the end of the animation. 

I also made the colour of the pulse a parameter of the overlay to be able to change the pulse colour of the remove button to match the button itself. Some accent colors previously caused an ugly clash with the red shade of the remove button.

https://github.com/user-attachments/assets/8f01cb3b-3d50-4b5d-b019-83999cf1778b

