### PR TITLE
feat: add nightly suffix to desktop file

### DIFF
--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.json
@@ -4,6 +4,8 @@
   "runtime-version": "49",
   "sdk": "org.gnome.Sdk",
   "command": "bazaar",
+  "tags": "nightly",
+  "desktop-file-name-suffix": " (Nightly)",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.rust-stable",
     "org.freedesktop.Sdk.Extension.llvm20"


### PR DESCRIPTION
adds this thingy here, makes it easier to differentiate between the version from CI and the regular one from flathub

<img width="278" height="101" alt="image" src="https://github.com/user-attachments/assets/470a73d9-0f56-4c83-a9b8-d0eeb4224120" />
