### PR TITLE
Fix keyboard not looping screenshot carousel

### DIFF
--- a/src/bz-screenshot-dialog.blp
+++ b/src/bz-screenshot-dialog.blp
@@ -106,6 +106,7 @@ template $BzScreenshotDialog: Adw.Dialog {
           }
         }
         child: Adw.Carousel carousel {
+          can-focus: false;
           interactive: bind $invert_boolean(template.is-zoomed) as <bool>;
           allow-scroll-wheel: bind $invert_boolean(template.is-zoomed) as <bool>;
           allow-mouse-drag: bind $invert_boolean(template.is-zoomed) as <bool>;


### PR DESCRIPTION
It was focusing on the carousel widget, causing the logic overrides for the left and right arrow keys not to be run.