### PR TITLE
(Bugfix) Minor screenshot dialog fixes

### DIFF
--- a/src/bz-screenshot-dialog.c
+++ b/src/bz-screenshot-dialog.c
@@ -93,7 +93,7 @@ static void
 populate_carousel (BzScreenshotDialog *self)
 {
   guint n_items = 0;
-  guint i = 0;
+  guint i       = 0;
 
   if (self->screenshots == NULL)
     return;
@@ -178,8 +178,8 @@ connect_zoom_signal (BzScreenshotDialog *self,
 static void
 bz_screenshot_dialog_constructed (GObject *object)
 {
-  BzScreenshotDialog *self    = BZ_SCREENSHOT_DIALOG (object);
-  GtkWidget          *page    = NULL;
+  BzScreenshotDialog *self = BZ_SCREENSHOT_DIALOG (object);
+  GtkWidget          *page = NULL;
 
   G_OBJECT_CLASS (bz_screenshot_dialog_parent_class)->constructed (object);
 
@@ -355,8 +355,8 @@ copy_clicked (BzScreenshotDialog *self)
   g_autoptr (BzAsyncTexture) async_texture = NULL;
   g_autoptr (GdkTexture) texture           = NULL;
   GdkClipboard *clipboard;
-  AdwToast     *toast   = NULL;
-  guint         n_items = 0;
+  AdwToast     *toast        = NULL;
+  guint         n_items      = 0;
   guint         actual_index = 0;
 
   if (self->screenshots == NULL)

--- a/src/bz-zoom.c
+++ b/src/bz-zoom.c
@@ -42,7 +42,7 @@ struct _BzZoom
   double drag_start_x;
   double drag_start_y;
 
-  gboolean   is_dragging;
+  gboolean is_dragging;
 
   AdwAnimation *zoom_animation;
   double        target_zoom;
@@ -194,10 +194,10 @@ on_scroll (BzZoom                   *self,
            double                    dy,
            GtkEventControllerScroll *controller)
 {
-  GdkEvent     *event;
-  GdkDevice    *device;
+  GdkEvent      *event;
+  GdkDevice     *device;
   GdkInputSource source;
-  double        zoom_factor;
+  double         zoom_factor;
 
   event = gtk_event_controller_get_current_event (GTK_EVENT_CONTROLLER (controller));
   if (event == NULL)


### PR DESCRIPTION
Fixes the swipe gesture on trackpads to no longer weirdly zoom but swipe the carousel instead (pinch to zoom should still work). 

Also fixes the race condition issue where the first screenshot was shown instead of the selected one by building the carousel around the index given.