### PR TITLE
Only display apps that meet quality guidelines in the featured carousel on category pages

### DIFF
--- a/src/bz-apps-page.blp
+++ b/src/bz-apps-page.blp
@@ -19,16 +19,17 @@ template $BzAppsPage: Adw.NavigationPage {
         margin-top: 24;
         margin-bottom: 24;
 
-       $BzFeaturedCarousel {
-          margin-start:8;
-          margin-end:8;
+        $BzFeaturedCarousel {
+          margin-start: 8;
+          margin-end: 8;
           margin-top: 16;
           hexpand: true;
+          visible: bind $is_not_null(template.carousel-applications) as <bool>;
           model: SliceListModel {
-             offset: 0;
-             size: 5;
-             model: bind template.applications;
-           };
+                   offset: 0;
+                   size: 7;
+                   model: bind template.carousel-applications;
+                 };
           group-clicked => $featured_carousel_group_clicked_cb(template);
         }
 

--- a/src/bz-apps-page.h
+++ b/src/bz-apps-page.h
@@ -32,4 +32,9 @@ AdwNavigationPage *
 bz_apps_page_new (const char *title,
                   GListModel *applications);
 
+AdwNavigationPage *
+bz_apps_page_new_with_carousel (const char *title,
+                                GListModel *applications,
+                                GListModel *carousel_applications);
+
 G_END_DECLS

--- a/src/bz-flathub-category.h
+++ b/src/bz-flathub-category.h
@@ -41,6 +41,9 @@ bz_flathub_category_get_name (BzFlathubCategory *self);
 GListModel *
 bz_flathub_category_dup_applications (BzFlathubCategory *self);
 
+GListModel *
+bz_flathub_category_dup_quality_applications (BzFlathubCategory *self);
+
 void
 bz_flathub_category_set_map_factory (BzFlathubCategory       *self,
                                      BzApplicationMapFactory *map_factory);
@@ -52,6 +55,10 @@ bz_flathub_category_set_name (BzFlathubCategory *self,
 void
 bz_flathub_category_set_applications (BzFlathubCategory *self,
                                       GListModel        *applications);
+
+void
+bz_flathub_category_set_quality_applications (BzFlathubCategory *self,
+                                              GListModel        *applications);
 
 const char *
 bz_flathub_category_get_display_name (BzFlathubCategory *self);

--- a/src/bz-flathub-page.c
+++ b/src/bz-flathub-page.c
@@ -323,12 +323,13 @@ static void
 category_clicked (BzFlathubCategory *category,
                   GtkButton         *button)
 {
-  GtkWidget         *self      = NULL;
-  GtkWidget         *window    = NULL;
-  GtkWidget         *nav_view  = NULL;
-  AdwNavigationPage *apps_page = NULL;
-  g_autoptr (GListModel) model = NULL;
-  const char *title            = NULL;
+  GtkWidget         *self               = NULL;
+  GtkWidget         *window             = NULL;
+  GtkWidget         *nav_view           = NULL;
+  AdwNavigationPage *apps_page          = NULL;
+  g_autoptr (GListModel) model          = NULL;
+  g_autoptr (GListModel) carousel_model = NULL;
+  const char *title                     = NULL;
 
   self = gtk_widget_get_ancestor (GTK_WIDGET (button), BZ_TYPE_FLATHUB_PAGE);
   g_assert (self != NULL);
@@ -338,10 +339,18 @@ category_clicked (BzFlathubCategory *category,
   nav_view = gtk_widget_get_ancestor (GTK_WIDGET (self), ADW_TYPE_NAVIGATION_VIEW);
   g_assert (nav_view != NULL);
 
-  title = bz_flathub_category_get_display_name (category);
-  model = bz_flathub_category_dup_applications (category);
+  title          = bz_flathub_category_get_display_name (category);
+  model          = bz_flathub_category_dup_applications (category);
+  carousel_model = bz_flathub_category_dup_quality_applications (category);
 
-  apps_page = bz_apps_page_new (title, model);
+  if (carousel_model != NULL && g_list_model_get_n_items (carousel_model) > 0)
+    {
+      apps_page = bz_apps_page_new_with_carousel (title, model, carousel_model);
+    }
+  else
+    {
+      apps_page = bz_apps_page_new (title, model);
+    }
 
   g_signal_connect_swapped (
       apps_page, "select",

--- a/src/bz-flathub-state.c
+++ b/src/bz-flathub-state.c
@@ -18,9 +18,10 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#define G_LOG_DOMAIN "BAZAAR::FLATHUB"
-#define COLLECTION_FETCH_SIZE 192
-#define CATEGORY_FETCH_SIZE 96
+#define G_LOG_DOMAIN                 "BAZAAR::FLATHUB"
+#define COLLECTION_FETCH_SIZE        192
+#define CATEGORY_FETCH_SIZE          96
+#define QUALITY_MODERATION_PAGE_SIZE 300
 
 #include <json-glib/json-glib.h>
 #include <libdex.h>
@@ -44,6 +45,7 @@ struct _BzFlathubState
   GtkStringList           *recently_added;
   GtkStringList           *popular;
   GtkStringList           *trending;
+  GtkStringList           *quality_moderation;
 
   DexFuture *initializing;
 };
@@ -67,6 +69,7 @@ enum
   PROP_RECENTLY_ADDED,
   PROP_POPULAR,
   PROP_TRENDING,
+  PROP_QUALITY_MODERATION,
 
   LAST_PROP
 };
@@ -94,6 +97,7 @@ bz_flathub_state_dispose (GObject *object)
   g_clear_pointer (&self->recently_added, g_object_unref);
   g_clear_pointer (&self->popular, g_object_unref);
   g_clear_pointer (&self->trending, g_object_unref);
+  g_clear_pointer (&self->quality_moderation, g_object_unref);
 
   G_OBJECT_CLASS (bz_flathub_state_parent_class)->dispose (object);
 }
@@ -141,6 +145,9 @@ bz_flathub_state_get_property (GObject    *object,
     case PROP_TRENDING:
       g_value_take_object (value, bz_flathub_state_dup_trending (self));
       break;
+    case PROP_QUALITY_MODERATION:
+      g_value_take_object (value, bz_flathub_state_dup_quality_moderation (self));
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -171,6 +178,7 @@ bz_flathub_state_set_property (GObject      *object,
     case PROP_RECENTLY_ADDED:
     case PROP_POPULAR:
     case PROP_TRENDING:
+    case PROP_QUALITY_MODERATION:
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -256,6 +264,13 @@ bz_flathub_state_class_init (BzFlathubStateClass *klass)
   props[PROP_TRENDING] =
       g_param_spec_object (
           "trending",
+          NULL, NULL,
+          G_TYPE_LIST_MODEL,
+          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+
+  props[PROP_QUALITY_MODERATION] =
+      g_param_spec_object (
+          "quality-moderation",
           NULL, NULL,
           G_TYPE_LIST_MODEL,
           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
@@ -445,6 +460,25 @@ bz_flathub_state_dup_trending (BzFlathubState *self)
     return NULL;
 }
 
+GListModel *
+bz_flathub_state_dup_quality_moderation (BzFlathubState *self)
+{
+  g_return_val_if_fail (BZ_IS_FLATHUB_STATE (self), NULL);
+  if (self->initializing != NULL)
+    return NULL;
+
+  if (self->quality_moderation != NULL)
+    {
+      if (self->map_factory != NULL)
+        return bz_application_map_factory_generate (
+            self->map_factory, G_LIST_MODEL (self->quality_moderation));
+      else
+        return G_LIST_MODEL (g_object_ref (self->quality_moderation));
+    }
+  else
+    return NULL;
+}
+
 void
 bz_flathub_state_set_for_day (BzFlathubState *self,
                               const char     *for_day)
@@ -461,6 +495,7 @@ bz_flathub_state_set_for_day (BzFlathubState *self,
   g_clear_pointer (&self->recently_added, g_object_unref);
   g_clear_pointer (&self->popular, g_object_unref);
   g_clear_pointer (&self->trending, g_object_unref);
+  g_clear_pointer (&self->quality_moderation, g_object_unref);
 
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_APP_OF_THE_DAY]);
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_APP_OF_THE_DAY_GROUP]);
@@ -471,18 +506,20 @@ bz_flathub_state_set_for_day (BzFlathubState *self,
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_RECENTLY_ADDED]);
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_POPULAR]);
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_TRENDING]);
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_QUALITY_MODERATION]);
 
   if (for_day != NULL)
     {
       g_autoptr (DexFuture) future = NULL;
 
-      self->for_day          = g_strdup (for_day);
-      self->apps_of_the_week = gtk_string_list_new (NULL);
-      self->categories       = g_list_store_new (BZ_TYPE_FLATHUB_CATEGORY);
-      self->recently_updated = gtk_string_list_new (NULL);
-      self->recently_added   = gtk_string_list_new (NULL);
-      self->popular          = gtk_string_list_new (NULL);
-      self->trending         = gtk_string_list_new (NULL);
+      self->for_day            = g_strdup (for_day);
+      self->apps_of_the_week   = gtk_string_list_new (NULL);
+      self->categories         = g_list_store_new (BZ_TYPE_FLATHUB_CATEGORY);
+      self->recently_updated   = gtk_string_list_new (NULL);
+      self->recently_added     = gtk_string_list_new (NULL);
+      self->popular            = gtk_string_list_new (NULL);
+      self->trending           = gtk_string_list_new (NULL);
+      self->quality_moderation = gtk_string_list_new (NULL);
 
       future = dex_scheduler_spawn (
           bz_get_io_scheduler (),
@@ -531,13 +568,15 @@ bz_flathub_state_set_map_factory (BzFlathubState          *self,
 static DexFuture *
 initialize_fiber (BzFlathubState *self)
 {
-  const char *for_day            = self->for_day;
-  g_autoptr (GError) local_error = NULL;
-  g_autoptr (GHashTable) futures = NULL;
-  g_autoptr (GHashTable) nodes   = NULL;
+  const char *for_day                = self->for_day;
+  g_autoptr (GError) local_error     = NULL;
+  g_autoptr (GHashTable) futures     = NULL;
+  g_autoptr (GHashTable) nodes       = NULL;
+  g_autoptr (GHashTable) quality_set = NULL;
 
-  futures = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, dex_unref);
-  nodes   = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, (GDestroyNotify) json_node_unref);
+  futures     = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, dex_unref);
+  nodes       = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, (GDestroyNotify) json_node_unref);
+  quality_set = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
 
 #define ADD_REQUEST(key, ...)                  \
   G_STMT_START                                 \
@@ -555,14 +594,14 @@ initialize_fiber (BzFlathubState *self)
   }                                            \
   G_STMT_END
 
-
-  ADD_REQUEST ("/app-picks/app-of-the-day",     "/app-picks/app-of-the-day/%s",                     for_day);
-  ADD_REQUEST ("/app-picks/apps-of-the-week",   "/app-picks/apps-of-the-week/%s",                   for_day);
-  ADD_REQUEST ("/collection/category",          "/collection/category");
-  ADD_REQUEST ("/collection/recently-updated",  "/collection/recently-updated?page=0&per_page=%d",  COLLECTION_FETCH_SIZE);
-  ADD_REQUEST ("/collection/recently-added",    "/collection/recently-added?page=0&per_page=%d",    COLLECTION_FETCH_SIZE);
-  ADD_REQUEST ("/collection/popular",           "/collection/popular?page=0&per_page=%d",           COLLECTION_FETCH_SIZE);
-  ADD_REQUEST ("/collection/trending",          "/collection/trending?page=0&per_page=%d",          COLLECTION_FETCH_SIZE);
+  ADD_REQUEST ("/app-picks/app-of-the-day", "/app-picks/app-of-the-day/%s", for_day);
+  ADD_REQUEST ("/app-picks/apps-of-the-week", "/app-picks/apps-of-the-week/%s", for_day);
+  ADD_REQUEST ("/collection/category", "/collection/category");
+  ADD_REQUEST ("/collection/recently-updated", "/collection/recently-updated?page=0&per_page=%d", COLLECTION_FETCH_SIZE);
+  ADD_REQUEST ("/collection/recently-added", "/collection/recently-added?page=0&per_page=%d", COLLECTION_FETCH_SIZE);
+  ADD_REQUEST ("/collection/popular", "/collection/popular?page=0&per_page=%d", COLLECTION_FETCH_SIZE);
+  ADD_REQUEST ("/collection/trending", "/collection/trending?page=0&per_page=%d", COLLECTION_FETCH_SIZE);
+  ADD_REQUEST ("/quality-moderation/passing-apps", "/quality-moderation/passing-apps?page=1&page_size=%d", QUALITY_MODERATION_PAGE_SIZE);
 
   while (g_hash_table_size (futures) > 0)
     {
@@ -582,6 +621,27 @@ initialize_fiber (BzFlathubState *self)
           return dex_future_new_for_error (g_steal_pointer (&local_error));
         }
       g_hash_table_replace (nodes, g_steal_pointer (&request), g_steal_pointer (&node));
+    }
+
+  if (g_hash_table_contains (nodes, "/quality-moderation/passing-apps"))
+    {
+      JsonObject *object = NULL;
+      JsonArray  *array  = NULL;
+      guint       length = 0;
+
+      object = json_node_get_object (g_hash_table_lookup (nodes, "/quality-moderation/passing-apps"));
+      array  = json_object_get_array_member (object, "apps");
+      length = json_array_get_length (array);
+
+      for (guint i = 0; i < length; i++)
+        {
+          const char *app_id = NULL;
+
+          app_id = json_array_get_string_element (array, i);
+
+          gtk_string_list_append (self->quality_moderation, app_id);
+          g_hash_table_add (quality_set, g_strdup (app_id));
+        }
     }
 
   if (g_hash_table_contains (nodes, "/app-picks/app-of-the-day"))
@@ -629,14 +689,15 @@ initialize_fiber (BzFlathubState *self)
 
       while (g_hash_table_size (futures) > 0)
         {
-          GHashTableIter   iter                  = { 0 };
-          g_autofree char *name                  = NULL;
-          g_autoptr (DexFuture) future           = NULL;
-          g_autoptr (JsonNode) node              = NULL;
-          g_autoptr (BzFlathubCategory) category = NULL;
-          g_autoptr (GtkStringList) store        = NULL;
-          JsonArray *category_array              = NULL;
-          guint      category_length             = 0;
+          GHashTableIter   iter                   = { 0 };
+          g_autofree char *name                   = NULL;
+          g_autoptr (DexFuture) future            = NULL;
+          g_autoptr (JsonNode) node               = NULL;
+          g_autoptr (BzFlathubCategory) category  = NULL;
+          g_autoptr (GtkStringList) store         = NULL;
+          g_autoptr (GtkStringList) quality_store = NULL;
+          JsonArray *category_array               = NULL;
+          guint      category_length              = 0;
 
           g_hash_table_iter_init (&iter, futures);
           g_hash_table_iter_next (&iter, (gpointer *) &name, (gpointer *) &future);
@@ -649,8 +710,9 @@ initialize_fiber (BzFlathubState *self)
               return dex_future_new_for_error (g_steal_pointer (&local_error));
             }
 
-          category = bz_flathub_category_new ();
-          store    = gtk_string_list_new (NULL);
+          category      = bz_flathub_category_new ();
+          store         = gtk_string_list_new (NULL);
+          quality_store = gtk_string_list_new (NULL);
           bz_flathub_category_set_name (category, name);
           bz_flathub_category_set_applications (category, G_LIST_MODEL (store));
 
@@ -660,12 +722,19 @@ initialize_fiber (BzFlathubState *self)
           for (guint i = 0; i < category_length; i++)
             {
               JsonObject *element = NULL;
+              const char *app_id  = NULL;
 
               element = json_array_get_object_element (category_array, i);
-              gtk_string_list_append (
-                  store,
-                  json_object_get_string_member (element, "app_id"));
+              app_id  = json_object_get_string_member (element, "app_id");
+              gtk_string_list_append (store, app_id);
+
+              if (g_hash_table_contains (quality_set, app_id))
+                {
+                  gtk_string_list_append (quality_store, app_id);
+                }
             }
+
+          bz_flathub_category_set_quality_applications (category, G_LIST_MODEL (quality_store));
 
           g_list_store_append (self->categories, category);
         }
@@ -781,6 +850,7 @@ initialize_finally (DexFuture      *future,
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_RECENTLY_ADDED]);
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_POPULAR]);
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_TRENDING]);
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_QUALITY_MODERATION]);
 
   return NULL;
 }

--- a/src/bz-flathub-state.h
+++ b/src/bz-flathub-state.h
@@ -71,6 +71,9 @@ bz_flathub_state_dup_popular (BzFlathubState *self);
 GListModel *
 bz_flathub_state_dup_trending (BzFlathubState *self);
 
+GListModel *
+bz_flathub_state_dup_quality_moderation (BzFlathubState *self);
+
 void
 bz_flathub_state_update_to_today (BzFlathubState *self);
 


### PR DESCRIPTION
This is done by using the `/quality-moderation/passing-apps` api route to filter category entries.

I also disabled the carousel on the non-category app listing pages, as it didn’t really make sense to have it there.