### PR TITLE
(UX) Improve UI of transaction sidebar

### DIFF
--- a/src/bz-backend-transaction-op-progress-payload.c
+++ b/src/bz-backend-transaction-op-progress-payload.c
@@ -296,7 +296,7 @@ bz_backend_transaction_op_progress_payload_set_progress (BzBackendTransactionOpP
 {
   g_return_if_fail (BZ_IS_BACKEND_TRANSACTION_OP_PROGRESS_PAYLOAD (self));
 
-  self->progress = progress;
+  self->progress = CLAMP (progress, 0.0, 0.999999);
 
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_PROGRESS]);
 }

--- a/src/bz-transaction-entry-tracker.h
+++ b/src/bz-transaction-entry-tracker.h
@@ -26,6 +26,13 @@
 
 G_BEGIN_DECLS
 
+typedef enum
+{
+  BZ_TRANSACTION_TYPE_INSTALL,
+  BZ_TRANSACTION_TYPE_UPDATE,
+  BZ_TRANSACTION_TYPE_REMOVAL
+} BzTransactionType;
+
 #define BZ_TYPE_TRANSACTION_ENTRY_TRACKER (bz_transaction_entry_tracker_get_type ())
 G_DECLARE_FINAL_TYPE (BzTransactionEntryTracker, bz_transaction_entry_tracker, BZ, TRANSACTION_ENTRY_TRACKER, GObject)
 
@@ -41,6 +48,9 @@ bz_transaction_entry_tracker_get_current_ops (BzTransactionEntryTracker *self);
 GListModel *
 bz_transaction_entry_tracker_get_finished_ops (BzTransactionEntryTracker *self);
 
+BzTransactionType
+bz_transaction_entry_tracker_get_type_enum (BzTransactionEntryTracker *self);
+
 void
 bz_transaction_entry_tracker_set_entry (BzTransactionEntryTracker *self,
                                         BzEntry                   *entry);
@@ -53,6 +63,9 @@ void
 bz_transaction_entry_tracker_set_finished_ops (BzTransactionEntryTracker *self,
                                                GListModel                *finished_ops);
 
-G_END_DECLS
+void
+bz_transaction_entry_tracker_set_type_enum (BzTransactionEntryTracker *self,
+                                            BzTransactionType          type);
 
+G_END_DECLS
 /* End of bz-transaction-entry-tracker.h */

--- a/src/bz-transaction-view.blp
+++ b/src/bz-transaction-view.blp
@@ -2,9 +2,7 @@ using Gtk 4.0;
 using Adw 1;
 
 template $BzTransactionView: Adw.Bin {
-  child: Box {
-    styles ["card"]
-
+  child:
     ListView {
       styles [
         "navigation-sidebar",
@@ -22,19 +20,26 @@ template $BzTransactionView: Adw.Bin {
           child: Button {
             styles [
               "flat",
-              "app-transaction-button"
+              "app-transaction-button",
+              "card"
             ]
+
+            margin-bottom: 12;
+            margin-start: 12;
+            margin-end: 12;
+
             clicked => $entry_clicked(template);
 
             child: Box {
               orientation: vertical;
+              margin-start: 5;
+              margin-top: 10;
+              margin-bottom: 10;
 
               Box {
-                margin-top: 2;
-                margin-bottom: 2;
-                
                 orientation: horizontal;
                 spacing: 10;
+                margin-start:5;
 
                 Overlay {
                   child: Image {
@@ -48,7 +53,7 @@ template $BzTransactionView: Adw.Bin {
                   [overlay]
                   Image {
                     icon-name: bind $get_sub_icon_name(template.item) as <string>;
-                    pixel-size: 32;
+                    pixel-size: 24;
                     valign: end;
                     halign: end;
                   }
@@ -57,7 +62,8 @@ template $BzTransactionView: Adw.Bin {
                 Box {
                   valign:center;
                   orientation: vertical;
-                  spacing:4;
+                  spacing: 8;
+
                   Label {
                     styles [
                       "title-2"
@@ -73,15 +79,43 @@ template $BzTransactionView: Adw.Bin {
                   Box {
                     halign: start;
                     spacing: 4;
-
                     styles [
                       "dimmed",
-                      "small-pill"
+                      "small-pill",
+                      "download-size-pill"
                     ]
+                    visible: bind $invert_boolean($is_transaction_type(template.item, 2) as <bool>) as <bool>;
 
                     Image {
                       icon-name: "drive-harddisk-symbolic";
-                      pixel-size: 16;
+                      pixel-size: 12;
+                    }
+
+                    Label {
+                      styles [
+                        "caption-heading"
+                      ]
+                      valign: center;
+                      xalign: 0.0;
+                      label: bind $format_download_size(template.item as <$BzTransactionEntryTracker>.entry as <$BzEntry>.size) as <string>;
+                      has-tooltip: true;
+                      tooltip-text: _("Install Size");
+                    }
+                  }
+
+                  Box {
+                    halign: start;
+                    spacing: 4;
+                    styles [
+                      "error",
+                      "small-pill",
+                      "download-size-pill"
+                    ]
+                    visible: bind $is_transaction_type(template.item, 2) as <bool>;
+
+                    Image {
+                      icon-name: "drive-harddisk-symbolic";
+                      pixel-size: 12;
                     }
 
                     Label {
@@ -103,54 +137,92 @@ template $BzTransactionView: Adw.Bin {
                   ]
 
                   valign: start;
+                  margin-end: 10;
                   icon-name: "folder-download-symbolic";
                   has-tooltip: true;
                   tooltip-text: _("Install");
+                  visible: bind $is_transaction_type(template.item, 0) as <bool>;
+                }
+
+                Image {
+                  styles [
+                    "accent",
+                  ]
+
+                  valign: start;
+                  margin-end: 10;
+                  icon-name: "software-update-available-symbolic";
+                  has-tooltip: true;
+                  tooltip-text: _("Update");
+                  visible: bind $is_transaction_type(template.item, 1) as <bool>;
+                }
+
+                Image {
+                  styles [
+                    "error",
+                  ]
+
+                  valign: start;
+                  margin-end: 10;
+                  icon-name: "user-trash-symbolic";
+                  has-tooltip: true;
+                  tooltip-text: _("Remove");
+                  visible: bind $is_transaction_type(template.item, 2) as <bool>;
                 }
               }
 
-              ListView {
-                styles [
-                  "navigation-sidebar",
-                  "transaction-sidebar-entry-list",
-                ]
+              Revealer {
+                reveal-child: bind $list_has_items(template.item as <$BzTransactionEntryTracker>.current-ops) as <bool>;
+                transition-type: slide_down;
 
-                model: NoSelection {
-                  model: bind template.item as <$BzTransactionEntryTracker>.current-ops;
-                };
+                child: ListView {
+                  styles [
+                    "navigation-sidebar",
+                    "transaction-sidebar-entry-list",
+                  ]
 
-                factory: BuilderListItemFactory {
-                  template ListItem {
-                    activatable: false;
+                  visible: bind $invert_boolean($is_transaction_type(template.item, 2) as <bool>) as <bool>;
 
-                    child: Box {
-                      margin-start: 3;
-                      margin-end: 3;
-                      margin-top: 5;
-                      margin-bottom: 15;
+                  model: NoSelection {
+                    model: bind template.item as <$BzTransactionEntryTracker>.current-ops;
+                  };
 
-                      orientation: vertical;
-                      spacing: 7;
+                  factory: BuilderListItemFactory {
+                    template ListItem {
+                      activatable: false;
 
-                      Label {
-                        styles [
-                          "dimmed",
-                          "caption-heading"
-                        ]
+                      child: Box {
+                        margin-start: 5;
+                        margin-end: 10;
+                        margin-top: 5;
+                        margin-bottom: 15;
 
-                        hexpand: true;
-                        xalign: 1;
-                        ellipsize: end;
-                        single-line-mode: true;
-                        label: bind template.item as <$BzTransactionTask>.last-progress as <$BzBackendTransactionOpProgressPayload>.status;
-                      }
+                        orientation: vertical;
+                        spacing: 7;
 
-                      $BzProgressBar {
-                        hexpand: "true";
-                        fraction: bind template.item as <$BzTransactionTask>.last-progress as <$BzBackendTransactionOpProgressPayload>.progress;
-                      }
-                    };
-                  }
+                        Label {
+                          styles [
+                            "dimmed",
+                            "caption-heading"
+                          ]
+
+                          hexpand: true;
+                          xalign: 1;
+                          ellipsize: end;
+                          single-line-mode: true;
+                          label: bind $format_download_progress(
+                                template.item as <$BzTransactionTask>.last-progress as <$BzBackendTransactionOpProgressPayload>.progress,
+                                template.item as <$BzTransactionTask>.op as <$BzBackendTransactionOpPayload>.download-size
+                              ) as <string>;
+                        }
+
+                        $BzProgressBar {
+                          hexpand: "true";
+                          fraction: bind template.item as <$BzTransactionTask>.last-progress as <$BzBackendTransactionOpProgressPayload>.progress;
+                        }
+                      };
+                    }
+                  };
                 };
               }
 
@@ -163,7 +235,10 @@ template $BzTransactionView: Adw.Bin {
                 ]
 
                 model: NoSelection {
-                  model: bind template.item as <$BzTransactionEntryTracker>.finished-ops;
+                  model: FilterListModel {
+                    model: bind template.item as <$BzTransactionEntryTracker>.finished-ops;
+                    filter: bind $create_app_id_filter(template.item) as <Filter>;
+                  };
                 };
 
                 factory: BuilderListItemFactory {
@@ -173,6 +248,8 @@ template $BzTransactionView: Adw.Bin {
                     child: Box {
                       orientation: horizontal;
                       spacing: 10;
+                      margin-start: 7;
+                      margin-end: 7;
 
                       Image {
                         styles [
@@ -235,7 +312,7 @@ template $BzTransactionView: Adw.Bin {
                           icon-name: "dialog-information-symbolic";
                           visible: bind $invert_boolean($is_null(template.item as <$BzTransactionTask>.error) as <bool>) as <bool>;
                           has-tooltip: true;
-                          tooltip-text: _("Error Details");
+                          tooltip-text: bind template.item as <$BzTransactionTask>.error;
 
                           popover: Popover {
                             child: Label {
@@ -263,6 +340,5 @@ template $BzTransactionView: Adw.Bin {
           };
         }
       };
-    }
   };
 }

--- a/src/bz-transaction-view.c
+++ b/src/bz-transaction-view.c
@@ -139,6 +139,101 @@ format_bytes_transferred (gpointer object,
   return g_strdup_printf (_ ("Transferred %s so far"), size);
 }
 
+static char *
+format_download_progress (gpointer object,
+                          double   progress,
+                          guint64  total_size)
+{
+  guint64          downloaded     = (guint64) (progress * total_size);
+  g_autofree char *downloaded_str = g_format_size (downloaded);
+  g_autofree char *total_str      = g_format_size (total_size);
+
+  return g_strdup_printf ("%s / %s", downloaded_str, total_str);
+}
+
+static gboolean
+filter_finished_ops_by_app_id (gpointer item,
+                               gpointer user_data)
+{
+  BzTransactionTask             *task     = BZ_TRANSACTION_TASK (item);
+  BzTransactionEntryTracker     *tracker  = BZ_TRANSACTION_ENTRY_TRACKER (user_data);
+  BzEntry                       *entry    = NULL;
+  const char                    *entry_id = NULL;
+  BzBackendTransactionOpPayload *op       = NULL;
+  const char                    *op_name  = NULL;
+  const char                    *error    = NULL;
+
+  if (task == NULL || tracker == NULL)
+    return TRUE;
+
+  error = bz_transaction_task_get_error (task);
+  if (error != NULL)
+    return TRUE;
+
+  entry = bz_transaction_entry_tracker_get_entry (tracker);
+  if (entry == NULL)
+    return TRUE;
+
+  entry_id = bz_entry_get_id (entry);
+  if (entry_id == NULL)
+    return TRUE;
+
+  op = bz_transaction_task_get_op (task);
+  if (op == NULL)
+    return TRUE;
+
+  op_name = bz_backend_transaction_op_payload_get_name (op);
+  if (op_name == NULL)
+    return TRUE;
+
+  return strstr (op_name, entry_id) == NULL;
+}
+
+static GtkFilter *
+create_app_id_filter (gpointer                   object,
+                      BzTransactionEntryTracker *tracker)
+{
+  GtkCustomFilter *filter = NULL;
+
+  if (tracker == NULL)
+    return NULL;
+
+  filter = gtk_custom_filter_new (filter_finished_ops_by_app_id,
+                                  g_object_ref (tracker),
+                                  g_object_unref);
+
+  return GTK_FILTER (filter);
+}
+
+static gboolean
+is_transaction_type (gpointer                   object,
+                     BzTransactionEntryTracker *tracker,
+                     int                        type)
+{
+  if (tracker == NULL)
+    return FALSE;
+
+  return bz_transaction_entry_tracker_get_type_enum (tracker) == type;
+}
+
+static gboolean
+list_has_items (gpointer    object,
+                GListModel *model)
+{
+  if (model == NULL)
+    return FALSE;
+
+  return g_list_model_get_n_items (model) > 0;
+}
+
+static gboolean
+is_both (gpointer object,
+         gboolean first,
+         gboolean second)
+{
+  return first && second;
+}
+
 static GdkPaintable *
 get_main_icon (GtkListItem               *list_item,
                BzTransactionEntryTracker *tracker)
@@ -254,9 +349,14 @@ bz_transaction_view_class_init (BzTransactionViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, format_download_size);
   gtk_widget_class_bind_template_callback (widget_class, format_installed_size);
   gtk_widget_class_bind_template_callback (widget_class, format_bytes_transferred);
+  gtk_widget_class_bind_template_callback (widget_class, format_download_progress);
   gtk_widget_class_bind_template_callback (widget_class, get_main_icon);
   gtk_widget_class_bind_template_callback (widget_class, get_sub_icon_name);
   gtk_widget_class_bind_template_callback (widget_class, entry_clicked);
+  gtk_widget_class_bind_template_callback (widget_class, create_app_id_filter);
+  gtk_widget_class_bind_template_callback (widget_class, is_transaction_type);
+  gtk_widget_class_bind_template_callback (widget_class, list_has_items);
+  gtk_widget_class_bind_template_callback (widget_class, is_both);
 }
 
 static void

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -73,12 +73,16 @@ template $BzWindow: Adw.ApplicationWindow {
           pin-sidebar: true;
           sidebar-position: end;
           sidebar-width-fraction: 0.25;
-          min-sidebar-width: 250;
+          min-sidebar-width: 300;
           max-sidebar-width: 400;
 
           sidebar: Adw.NavigationPage {
-            title: _("Transactions");
+            title: _("Tasks");
             tag: "transactions";
+
+            styles [
+              "sidebar-pane"
+            ]
 
             child: Adw.ToolbarView {
               [top]
@@ -167,7 +171,10 @@ template $BzWindow: Adw.ApplicationWindow {
                     child: ListView list_view {
                       styles [
                         "navigation-sidebar",
+                        "transaction-list-view"
                       ]
+
+                      margin-top: 6;
 
                       model: NoSelection no_selection {
                         model: bind template.state as <$BzStateInfo>.transaction-manager as <$BzTransactionManager>.transactions;
@@ -178,10 +185,6 @@ template $BzWindow: Adw.ApplicationWindow {
                           activatable: false;
 
                           child: $BzTransactionView {
-                            margin-start: "5";
-                            margin-end: "5";
-                            margin-top: "10";
-                            margin-bottom: "10";
                             transaction: bind template.item;
                           };
                         }

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -807,11 +807,16 @@ void
 bz_window_show_group (BzWindow     *self,
                       BzEntryGroup *group)
 {
+  AdwNavigationPage *visible_page = NULL;
+
   g_return_if_fail (BZ_IS_WINDOW (self));
   g_return_if_fail (BZ_IS_ENTRY_GROUP (group));
 
   bz_full_view_set_entry_group (self->full_view, group);
-  adw_navigation_view_push_by_tag (self->main_stack, "view");
+
+  visible_page = adw_navigation_view_get_visible_page (self->main_stack);
+  if (visible_page != adw_navigation_view_find_page (self->main_stack, "view"))
+    adw_navigation_view_push_by_tag (self->main_stack, "view");
   gtk_widget_set_visible (GTK_WIDGET (self->go_back), TRUE);
   gtk_widget_set_visible (GTK_WIDGET (self->search), FALSE);
   gtk_revealer_set_reveal_child (self->title_revealer, FALSE);

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -96,13 +96,21 @@
     background-color: alpha(@error_bg_color, 0.15);
 }
 
+.download-size-pill{
+  padding: 2px 8px;
+}
 
 .flathub-page-section {
     border-radius: 10px;
 }
 
 .app-transaction-button{
-    padding: 5px;
+    padding: 0;
+}
+
+.transaction-list-view row {
+    margin: 0;
+    padding: 0;
 }
 
 /* Context tile from full-view, modified from GNOME Software */


### PR DESCRIPTION
This PR tries to make the transaction sidebar nicer to look at by making margins and padding more consistent, hiding unnecessary elements like successful finished operations that are part of the app itself and the technical operation status.

This should hopefully make the sidebar less claustrophobic.

It also adds back the distinctions between the 3 transaction types in the UI.

<img width="1150" height="807" alt="Screenshot From 2025-10-18 16-45-36" src="https://github.com/user-attachments/assets/4d7a7e62-ca48-4d70-8f5b-29bd06859cda" />
