### PR TITLE
fix: use full category name on more button on flathub view

### DIFF
--- a/src/bz-flathub-page.blp
+++ b/src/bz-flathub-page.blp
@@ -182,7 +182,7 @@ template $BzFlathubPage: Adw.Bin {
                   "pill"
                   ]
 
-                   label: _("More Updated");
+                   label: _("More Recently Updated");
                    halign: center;
                    valign: center;
                    clicked => $show_more_recently_updated_clicked_cb(template);
@@ -234,7 +234,7 @@ template $BzFlathubPage: Adw.Bin {
                   "pill"
                   ]
 
-                   label: _("More Added");
+                   label: _("More Recently Added");
                    halign: center;
                    valign: center;
                    clicked => $show_more_recently_added_clicked_cb(template);


### PR DESCRIPTION
I think this is a little awkward

<img width="1904" height="1076" alt="image" src="https://github.com/user-attachments/assets/f248febe-3f50-487d-b7f7-c3f00b23a450" />
