### PR TITLE
(UI) Change kind indicator from sub icon to coloured pill

### DIFF
--- a/src/bz-transaction-view.blp
+++ b/src/bz-transaction-view.blp
@@ -41,22 +41,12 @@ template $BzTransactionView: Adw.Bin {
                 spacing: 10;
                 margin-start:5;
 
-                Overlay {
-                  child: Image {
-                    paintable: bind $get_main_icon(template.item) as <$GdkPaintable>;
-                    pixel-size: 64;
-                    valign: center;
+               Image {
+                  paintable: bind $get_main_icon(template.item) as <$GdkPaintable>;
+                  pixel-size: 64;
+                  valign: center;
 
-                    styles ["icon-dropshadow"]
-                  };
-
-                  [overlay]
-                  Image {
-                    icon-name: bind $get_sub_icon_name(template.item) as <string>;
-                    pixel-size: 24;
-                    valign: end;
-                    halign: end;
-                  }
+                  styles ["icon-dropshadow"]
                 }
 
                 Box {
@@ -77,56 +67,109 @@ template $BzTransactionView: Adw.Bin {
                     tooltip-text: bind template.item as <$BzTransactionEntryTracker>.entry as <$BzEntry>.id as <string>;
                   }
                   Box {
-                    halign: start;
+                    orientation: horizontal;
                     spacing: 4;
-                    styles [
-                      "dimmed",
-                      "small-pill",
-                      "download-size-pill"
-                    ]
-                    visible: bind $invert_boolean($is_transaction_type(template.item, 2) as <bool>) as <bool>;
-
-                    Image {
-                      icon-name: "drive-harddisk-symbolic";
-                      pixel-size: 12;
-                    }
-
-                    Label {
+                    Box {
+                      visible: bind $is_entry_kind(template.item, 4) as <bool>;
+                      halign: start;
+                      spacing: 4;
                       styles [
-                        "caption-heading"
+                        "green",
+                        "colored",
+                        "small-pill",
+                        "download-size-pill"
                       ]
-                      valign: center;
-                      xalign: 0.0;
-                      label: bind $format_download_size(template.item as <$BzTransactionEntryTracker>.entry as <$BzEntry>.size) as <string>;
-                      has-tooltip: true;
-                      tooltip-text: _("Install Size");
+
+                      Image {
+                        icon-name: "puzzle-piece-symbolic";
+                        pixel-size: 12;
+                      }
+
+                      Label {
+                        styles [
+                          "caption-heading"
+                        ]
+                        valign: center;
+                        xalign: 0.0;
+                        label: _("App Add-on");
+                      }
                     }
-                  }
-
-                  Box {
-                    halign: start;
-                    spacing: 4;
-                    styles [
-                      "error",
-                      "small-pill",
-                      "download-size-pill"
-                    ]
-                    visible: bind $is_transaction_type(template.item, 2) as <bool>;
-
-                    Image {
-                      icon-name: "drive-harddisk-symbolic";
-                      pixel-size: 12;
-                    }
-
-                    Label {
+                    Box {
+                      visible: bind $is_entry_kind(template.item, 2) as <bool>;
+                      halign: start;
+                      spacing: 4;
                       styles [
-                        "caption-heading"
+                        "blue",
+                        "colored",
+                        "small-pill",
+                        "download-size-pill"
                       ]
-                      valign: center;
-                      xalign: 0.0;
-                      label: bind $format_download_size(template.item as <$BzTransactionEntryTracker>.entry as <$BzEntry>.size) as <string>;
-                      has-tooltip: true;
-                      tooltip-text: _("Install Size");
+
+                      Image {
+                        icon-name: "application-x-sharedlib-symbolic";
+                        pixel-size: 12;
+                      }
+
+                      Label {
+                        styles [
+                          "caption-heading"
+                        ]
+                        valign: center;
+                        xalign: 0.0;
+                        label: _("Runtime");
+                      }
+                    }
+                    Box {
+                      halign: start;
+                      spacing: 4;
+                      styles [
+                        "dimmed",
+                        "small-pill",
+                        "download-size-pill"
+                      ]
+                      visible: bind $invert_boolean($is_transaction_type(template.item, 2) as <bool>) as <bool>;
+
+                      Image {
+                        icon-name: "drive-harddisk-symbolic";
+                        pixel-size: 12;
+                      }
+
+                      Label {
+                        styles [
+                          "caption-heading"
+                        ]
+                        valign: center;
+                        xalign: 0.0;
+                        label: bind $format_download_size(template.item as <$BzTransactionEntryTracker>.entry as <$BzEntry>.size) as <string>;
+                        has-tooltip: true;
+                        tooltip-text: _("Install Size");
+                      }
+                    }
+                    Box {
+                      halign: start;
+                      spacing: 4;
+                      styles [
+                        "error",
+                        "small-pill",
+                        "download-size-pill"
+                      ]
+                      visible: bind $is_transaction_type(template.item, 2) as <bool>;
+
+                      Image {
+                        icon-name: "drive-harddisk-symbolic";
+                        pixel-size: 12;
+                      }
+
+                      Label {
+                        styles [
+                          "caption-heading"
+                        ]
+                        valign: center;
+                        xalign: 0.0;
+                        label: bind $format_download_size(template.item as <$BzTransactionEntryTracker>.entry as <$BzEntry>.size) as <string>;
+                        has-tooltip: true;
+                        tooltip-text: _("Install Size");
+                      }
                     }
                   }
                 }

--- a/src/bz-transaction-view.c
+++ b/src/bz-transaction-view.c
@@ -280,25 +280,21 @@ return_generic:
       GTK_ICON_LOOKUP_NONE);
 }
 
-static char *
-get_sub_icon_name (gpointer                   object,
-                   BzTransactionEntryTracker *tracker)
+static gboolean
+is_entry_kind (gpointer                   object,
+               BzTransactionEntryTracker *tracker,
+               int                        kind)
 {
   BzEntry *entry = NULL;
 
   if (tracker == NULL)
-    return NULL;
+    return FALSE;
 
   entry = bz_transaction_entry_tracker_get_entry (tracker);
   if (entry == NULL)
-    return NULL;
+    return FALSE;
 
-  if (bz_entry_is_of_kinds (entry, BZ_ENTRY_KIND_APPLICATION))
-    return NULL;
-  else if (bz_entry_is_of_kinds (entry, BZ_ENTRY_KIND_RUNTIME))
-    return g_strdup ("application-x-sharedlib");
-  else
-    return g_strdup ("application-x-addon");
+  return bz_entry_is_of_kinds (entry, kind);
 }
 
 static void
@@ -351,7 +347,7 @@ bz_transaction_view_class_init (BzTransactionViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, format_bytes_transferred);
   gtk_widget_class_bind_template_callback (widget_class, format_download_progress);
   gtk_widget_class_bind_template_callback (widget_class, get_main_icon);
-  gtk_widget_class_bind_template_callback (widget_class, get_sub_icon_name);
+  gtk_widget_class_bind_template_callback (widget_class, is_entry_kind);
   gtk_widget_class_bind_template_callback (widget_class, entry_clicked);
   gtk_widget_class_bind_template_callback (widget_class, create_app_id_filter);
   gtk_widget_class_bind_template_callback (widget_class, is_transaction_type);

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -53,6 +53,37 @@
     --accent-color: @warning_color;
 }
 
+.support {
+    --accent-fg-color : #f06292;
+    --accent-bg-color : alpha(#f06292, 0.25);
+    --accent-color : #f06292;
+}
+
+.green {
+    --accent-fg-color : #8ff0a4;
+    --accent-bg-color : alpha(#2ec27e, 0.25);
+    --accent-color : #8ff0a4;
+}
+
+.blue {
+    --accent-fg-color : #99c1f1;
+    --accent-bg-color : alpha(#1a5fb4, 0.25);
+    --accent-color : #99c1f1;
+}
+
+@media (prefers-color-scheme: light) {
+    .green {
+        --accent-fg-color : #2ec27e;
+        --accent-bg-color : alpha(#8ff0a4, 0.25);
+        --accent-color : #2ec27e;
+    }
+    .blue {
+        --accent-fg-color : #1a5fb4;
+        --accent-bg-color : alpha(#99c1f1, 0.25);
+        --accent-color : #1a5fb4;
+    }
+}
+
 .grey {
 	--accent-color: alpha(@window_fg_color,0.75);
 	--accent-bg-color: @window_fg_color;
@@ -86,6 +117,11 @@
 .small-pill {
     padding: 2px 12px;
     border-radius: 99999px;
+}
+
+.colored {
+    background-color: var(--accent-bg-color);
+    color: var(--accent-color);
 }
 
 .small-pill.dimmed {


### PR DESCRIPTION
Having a little icon in the bottom right of the app icon looks weird to me. That's why I changed it to a pill to be more inline with other UI elements and GNOME UI patterns in general.

<img width="406" height="122" alt="image" src="https://github.com/user-attachments/assets/8ea53860-ed37-4400-8da8-bc77e38d375f" />

(Both are shown here for the showcase)
