### PR TITLE
Rework the progress bar theme selection

### DIFF
--- a/src/bz-preferences-dialog.blp
+++ b/src/bz-preferences-dialog.blp
@@ -4,6 +4,16 @@ using Adw 1;
 template $BzPreferencesDialog: Adw.PreferencesDialog {
   content-height: 500;
   search-enabled: true;
+  width-request: 350;
+  height-request: 500;
+
+  Adw.Breakpoint {
+    condition ("max-width: 625sp")
+
+    setters {
+      flag_buttons_box.max-children-per-line: 6;
+    }
+  }
 
   Adw.PreferencesPage {
     title: _("Preferences");
@@ -12,7 +22,7 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
     Adw.PreferencesGroup {
       title: _("Application Details");
 
-      Adw.SwitchRow git_forge_star_counts_switch{
+      Adw.SwitchRow git_forge_star_counts_switch {
         title: _("Git Forge Star Counts");
         subtitle: _("Not having a GitHub access token may trigger rate limits");
       }
@@ -21,45 +31,43 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
     Adw.PreferencesGroup {
       title: _("Search");
 
-      Adw.SwitchRow search_only_foss_switch{
+      Adw.SwitchRow search_only_foss_switch {
         title: _("Only Show Free Software");
         subtitle: _("Hide proprietary applications from search results");
       }
 
-      Adw.SwitchRow search_only_flathub_switch{
+      Adw.SwitchRow search_only_flathub_switch {
         title: _("Show Only Flathub Apps");
         subtitle: _("Limit search results to applications available on Flathub");
       }
 
-      Adw.SwitchRow search_debounce_switch{
+      Adw.SwitchRow search_debounce_switch {
         title: _("Debounce Search Results");
         subtitle: _("Wait for a brief pause to reduce system load");
       }
     }
 
     Adw.PreferencesGroup {
-      title: _("Global Progress Bar");
+      title: _("Progress Bar");
+      description: _("Choose a theme for the progress bar!");
 
-      Adw.ComboRow progress_bar_theme {
-        title: _("Theme");
-        subtitle: _("Choose a fun theme for the global progress bar!");
-        model: StringList {
-          strings [
-            _("Accent Color"),
-            _("Pride Rainbow Flag"),
-            _("Lesbian Pride Flag"),
-            _("Transgender Flag"),
-            _("Nonbinary Flag"),
-            _("Bisexual Flag"),
-            _("Asexual Flag"),
-            _("Pansexual Flag"),
-            _("Aromantic Flag"),
-            _("Genderfluid Flag"),
-            _("Polysexual Flag"),
-            _("Omnisexual Flag"),
-          ]
+      Adw.ActionRow {
+        child: Box {
+          margin-top: 6;
+          margin-bottom: 6;
+          halign: center;
+
+          FlowBox flag_buttons_box {
+            styles ["accent-button-box"]
+            orientation: horizontal;
+            column-spacing: 4;
+            row-spacing: 4;
+            halign: center;
+            homogeneous: true;
+            max-children-per-line: 12;
+            selection-mode: none;
+          }
         };
-        notify::selected => $global_progress_theme_widget_changed(template);
       }
     }
   }

--- a/src/bz-preferences-dialog.c
+++ b/src/bz-preferences-dialog.c
@@ -19,20 +19,28 @@
  */
 
 #include "bz-preferences-dialog.h"
+#include <glib/gi18n.h>
 
-static const char *bar_themes_ordered[] = {
-  "accent-color",
-  "pride-rainbow-flag",
-  "lesbian-pride-flag",
-  "transgender-flag",
-  "nonbinary-flag",
-  "bisexual-flag",
-  "asexual-flag",
-  "pansexual-flag",
-  "aromantic-flag",
-  "genderfluid-flag",
-  "polysexual-flag",
-  "omnisexual-flag",
+typedef struct
+{
+  const char *id;
+  const char *style_class;
+  const char *tooltip;
+} BarTheme;
+
+static const BarTheme bar_themes[] = {
+  {       "accent-color",  "accent-color-theme",       N_ ("Accent Color") },
+  { "pride-rainbow-flag", "pride-rainbow-theme", N_ ("Pride Rainbow Flag") },
+  { "lesbian-pride-flag", "lesbian-pride-theme", N_ ("Lesbian Pride Flag") },
+  {   "transgender-flag",   "transgender-theme",   N_ ("Transgender Flag") },
+  {     "nonbinary-flag",     "nonbinary-theme",     N_ ("Nonbinary Flag") },
+  {      "bisexual-flag",      "bisexual-theme",      N_ ("Bisexual Flag") },
+  {       "asexual-flag",       "asexual-theme",       N_ ("Asexual Flag") },
+  {     "pansexual-flag",     "pansexual-theme",     N_ ("Pansexual Flag") },
+  {     "aromantic-flag",     "aromantic-theme",     N_ ("Aromantic Flag") },
+  {   "genderfluid-flag",   "genderfluid-theme",   N_ ("Genderfluid Flag") },
+  {    "polysexual-flag",    "polysexual-theme",    N_ ("Polysexual Flag") },
+  {    "omnisexual-flag",    "omnisexual-theme",    N_ ("Omnisexual Flag") },
 };
 
 struct _BzPreferencesDialog
@@ -46,12 +54,15 @@ struct _BzPreferencesDialog
   AdwSwitchRow *search_only_foss_switch;
   AdwSwitchRow *search_only_flathub_switch;
   AdwSwitchRow *search_debounce_switch;
-  AdwComboRow  *progress_bar_theme;
+  GtkFlowBox   *flag_buttons_box;
+
+  GtkToggleButton *flag_buttons[G_N_ELEMENTS (bar_themes)];
 };
 
 G_DEFINE_FINAL_TYPE (BzPreferencesDialog, bz_preferences_dialog, ADW_TYPE_PREFERENCES_DIALOG)
 
 static void bind_settings (BzPreferencesDialog *self);
+static void create_flag_buttons (BzPreferencesDialog *self);
 
 static void
 bz_preferences_dialog_dispose (GObject *object)
@@ -64,16 +75,19 @@ bz_preferences_dialog_dispose (GObject *object)
 }
 
 static void
-global_progress_theme_widget_changed (BzPreferencesDialog *self,
-                                      GParamSpec          *pspec,
-                                      AdwComboRow         *combo)
+flag_button_toggled (GtkToggleButton     *button,
+                     BzPreferencesDialog *self)
 {
-  guint selected = 0;
+  const char *theme_id = NULL;
 
-  selected = adw_combo_row_get_selected (self->progress_bar_theme);
-  g_assert (selected < G_N_ELEMENTS (bar_themes_ordered));
+  if (!gtk_toggle_button_get_active (button))
+    return;
 
-  g_settings_set_string (self->settings, "global-progress-bar-theme", bar_themes_ordered[selected]);
+  theme_id = g_object_get_data (G_OBJECT (button), "theme-id");
+  if (theme_id != NULL)
+    {
+      g_settings_set_string (self->settings, "global-progress-bar-theme", theme_id);
+    }
 }
 
 static void
@@ -82,19 +96,54 @@ global_progress_theme_settings_changed (BzPreferencesDialog *self,
                                         GSettings           *settings)
 {
   const char *theme = NULL;
-  guint       idx   = 0;
 
   theme = g_settings_get_string (self->settings, "global-progress-bar-theme");
-  for (guint i = 0; i < G_N_ELEMENTS (bar_themes_ordered); i++)
+
+  for (guint i = 0; i < G_N_ELEMENTS (bar_themes); i++)
     {
-      if (g_strcmp0 (theme, bar_themes_ordered[i]) == 0)
+      if (g_strcmp0 (theme, bar_themes[i].id) == 0)
         {
-          idx = i;
+          gtk_toggle_button_set_active (self->flag_buttons[i], TRUE);
           break;
         }
     }
+}
 
-  adw_combo_row_set_selected (self->progress_bar_theme, idx);
+static void
+create_flag_buttons (BzPreferencesDialog *self)
+{
+  GtkToggleButton *first_button = NULL;
+
+  for (guint i = 0; i < G_N_ELEMENTS (bar_themes); i++)
+    {
+      GtkToggleButton *button = NULL;
+
+      button = GTK_TOGGLE_BUTTON (gtk_toggle_button_new ());
+
+      gtk_widget_set_tooltip_text (GTK_WIDGET (button), bar_themes[i].tooltip);
+      gtk_widget_add_css_class (GTK_WIDGET (button), "accent-button");
+      gtk_widget_add_css_class (GTK_WIDGET (button), bar_themes[i].style_class);
+
+      g_object_set_data_full (G_OBJECT (button),
+                              "theme-id",
+                              g_strdup (bar_themes[i].id),
+                              g_free);
+
+      if (i == 0)
+        {
+          first_button = button;
+        }
+      else
+        {
+          gtk_toggle_button_set_group (button, first_button);
+        }
+
+      g_signal_connect (button, "toggled",
+                        G_CALLBACK (flag_button_toggled), self);
+
+      self->flag_buttons[i] = button;
+      gtk_flow_box_append (self->flag_buttons_box, GTK_WIDGET (button));
+    }
 }
 
 static void
@@ -142,14 +191,14 @@ bz_preferences_dialog_class_init (BzPreferencesDialogClass *klass)
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, search_only_foss_switch);
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, search_only_flathub_switch);
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, search_debounce_switch);
-  gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, progress_bar_theme);
-  gtk_widget_class_bind_template_callback (widget_class, global_progress_theme_widget_changed);
+  gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, flag_buttons_box);
 }
 
 static void
 bz_preferences_dialog_init (BzPreferencesDialog *self)
 {
   gtk_widget_init_template (GTK_WIDGET (self));
+  create_flag_buttons (self);
 }
 
 AdwDialog *

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -261,6 +261,78 @@ window.flathub {
   background-color: #1d1d20;
 }
 
+.accent-button {
+  border-radius: 9999px;
+  padding: 3px;
+  background: var(--flag-gradient, var(--accent-bg-color));
+  min-width: 32px;
+  min-height: 32px;
+  outline: none;
+  background-clip: content-box;
+  background-origin: content-box;
+  box-shadow: none;
+}
+
+.accent-button-box > flowboxchild {
+  padding: 0;
+  background-color: transparent;
+}
+
+.accent-button:checked {
+  box-shadow: 0 0 0 3px var(--accent-bg-color);
+}
+.accent-button:focus:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-color) 30%, transparent);
+}
+.accent-button:checked:focus:focus-visible {
+  box-shadow: 0 0 0 3px var(--accent-bg-color),
+              0 0 0 6px color-mix(in srgb, var(--accent-color) 30%, transparent);
+}
+
+.accent-button.pride-rainbow-theme {
+  --flag-gradient: linear-gradient(to bottom, #E40303 0%, #E40303 16.666%, #FF8C00 16.666%, #FF8C00 33.333%, #FFED00 33.333%, #FFED00 50%, #008026 50%, #008026 66.666%, #24408E 66.666%, #24408E 83.333%, #732982 83.333%, #732982 100%);
+}
+
+.accent-button.lesbian-pride-theme {
+  --flag-gradient: linear-gradient(to bottom, #D62800 0%, #D62800 20%, #FF9B56 20%, #FF9B56 40%, #FFFFFF 40%, #FFFFFF 60%, #D462A6 60%, #D462A6 80%, #A40062 80%, #A40062 100%);
+}
+
+.accent-button.transgender-theme {
+  --flag-gradient: linear-gradient(to bottom, #5BCEFA 0%, #5BCEFA 20%, #F5A9B8 20%, #F5A9B8 40%, #FFFFFF 40%, #FFFFFF 60%, #F5A9B8 60%, #F5A9B8 80%, #5BCEFA 80%, #5BCEFA 100%);
+}
+
+.accent-button.nonbinary-theme {
+  --flag-gradient: linear-gradient(to bottom, #FCF434 0%, #FCF434 25%, #FFFFFF 25%, #FFFFFF 50%, #9C59D1 50%, #9C59D1 75%, #2C2C2C 75%, #2C2C2C 100%);
+}
+
+.accent-button.bisexual-theme {
+  --flag-gradient: linear-gradient(to bottom, #D60270 0%, #D60270 40%, #9B4F96 40%, #9B4F96 60%, #0038A8 60%, #0038A8 100%);
+}
+
+.accent-button.asexual-theme {
+  --flag-gradient: linear-gradient(to bottom, #000000 0%, #000000 25%, #A3A3A3 25%, #A3A3A3 50%, #FFFFFF 50%, #FFFFFF 75%, #810081 75%, #810081 100%);
+}
+
+.accent-button.pansexual-theme {
+  --flag-gradient: linear-gradient(to bottom, #FF218C 0%, #FF218C 33.333%, #FFD800 33.333%, #FFD800 66.666%, #21B1FF 66.666%, #21B1FF 100%);
+}
+
+.accent-button.aromantic-theme {
+  --flag-gradient: linear-gradient(to bottom, #3DA542 0%, #3DA542 20%, #A7D379 20%, #A7D379 40%, #FFFFFF 40%, #FFFFFF 60%, #A9A9A9 60%, #A9A9A9 80%, #000000 80%, #000000 100%);
+}
+
+.accent-button.genderfluid-theme {
+  --flag-gradient: linear-gradient(to bottom, #FF76A4 0%, #FF76A4 20%, #FFFFFF 20%, #FFFFFF 40%, #C011D7 40%, #C011D7 60%, #000000 60%, #000000 80%, #2F3CBE 80%, #2F3CBE 100%);
+}
+
+.accent-button.polysexual-theme {
+  --flag-gradient: linear-gradient(to bottom, #F61CB9 0%, #F61CB9 33.333%, #07D569 33.333%, #07D569 66.666%, #1C92F6 66.666%, #1C92F6 100%);
+}
+
+.accent-button.omnisexual-theme {
+  --flag-gradient: linear-gradient(to bottom, #FF9CCE 0%, #FF9CCE 20%, #FF52BF 20%, #FF52BF 40%, #200044 40%, #200044 60%, #675FFF 60%, #675FFF 80%, #8DA7FF 80%, #8DA7FF 100%);
+}
+
 /* Category buttons styling modified from GNOME Software*/
 .category-tile {
 	font-weight: 900;


### PR DESCRIPTION
This PR reworks the theme/flag selection in the preferences menu. It implements @snwh's design and takes inspiration from the accent color picker in GNOME Settings for the implementation.

It should also be mobile width ready™.

<img width="1202" height="836" alt="Screenshot From 2025-10-24 20-56-19" src="https://github.com/user-attachments/assets/788e5fbc-54c2-4840-a35c-b262c8e3ce3a" />

<img width="427" height="836" alt="Screenshot From 2025-10-24 20-54-14" src="https://github.com/user-attachments/assets/c06fae32-115c-4724-b33a-673050f4736c" />
