### PR TITLE
Minor screenshot carousel clean ups

### DIFF
--- a/src/bz-decorated-screenshot.c
+++ b/src/bz-decorated-screenshot.c
@@ -113,9 +113,29 @@ bz_decorated_screenshot_class_init (BzDecoratedScreenshotClass *klass)
 }
 
 static void
+on_enter_notify (GtkEventController *controller, gpointer user_data)
+{
+  g_autoptr (GdkCursor) cursor = gdk_cursor_new_from_name ("pointer", NULL);
+  gtk_widget_set_cursor (GTK_WIDGET (user_data), cursor);
+}
+
+static void
+on_leave_notify (GtkEventController *controller, gpointer user_data)
+{
+  gtk_widget_set_cursor (GTK_WIDGET (user_data), NULL);
+}
+
+static void
 bz_decorated_screenshot_init (BzDecoratedScreenshot *self)
 {
+  GtkEventController *enter_leave = gtk_event_controller_motion_new ();
+
   gtk_widget_init_template (GTK_WIDGET (self));
+
+  g_signal_connect (enter_leave, "enter", G_CALLBACK (on_enter_notify), GTK_WIDGET (self));
+  g_signal_connect (enter_leave, "leave", G_CALLBACK (on_leave_notify), GTK_WIDGET (self));
+
+  gtk_widget_add_controller (GTK_WIDGET (self), enter_leave);
 }
 
 BzDecoratedScreenshot *

--- a/src/bz-screenshots-carousel.blp
+++ b/src/bz-screenshots-carousel.blp
@@ -6,7 +6,7 @@ template $BzScreenshotsCarousel : Gtk.Widget {
     label: _("Screenshots Carousel");
   }
 
-  styles ["screenshot-carousel", "view" ,"frame"]
+  styles ["screenshot-carousel", "view", "frame"]
 
   layout-manager: Gtk.BinLayout {};
 
@@ -14,47 +14,10 @@ template $BzScreenshotsCarousel : Gtk.Widget {
     halign: fill;
     valign: fill;
 
-    [overlay]
-    Gtk.Box {
-      orientation: horizontal;
-      halign: fill;
-      valign: center;
-      spacing: 12;
-
-      Gtk.Revealer prev_button_revealer {
-        transition-type: crossfade;
-        reveal-child: false;
-        hexpand: true;
-
-        Gtk.Button prev_button {
-          icon-name: "go-previous-symbolic";
-          valign: center;
-          halign: start;
-          clicked => $on_prev_clicked() swapped;
-
-          styles ["circular", "osd"]
-        }
-      }
-
-      Gtk.Revealer next_button_revealer {
-        transition-type: crossfade;
-        reveal-child: false;
-
-        Gtk.Button next_button {
-          icon-name: "go-next-symbolic";
-          valign: center;
-          clicked => $on_next_clicked() swapped;
-
-          styles ["circular", "osd"]
-        }
-      }
-    }
-
     child: Gtk.Box {
       orientation: vertical;
       halign: fill;
       valign: fill;
-
       styles ["carousel-box"]
 
       Adw.Carousel carousel {
@@ -65,33 +28,60 @@ template $BzScreenshotsCarousel : Gtk.Widget {
         allow-mouse-drag: true;
         allow-scroll-wheel: false;
         allow-long-swipes: true;
-
         notify::position => $on_notify_position() swapped;
         notify::n-pages => $on_notify_n_pages() swapped;
       }
-      Box {
-        styles ["indicator-box"]
 
-        Adw.CarouselIndicatorDots carousel_indicator {
-          carousel: carousel;
-          opacity: 0;
-          hexpand:true;
-
-          halign: center;
-
-          styles ["boxed-indicator"]
-        }
-
-        Button {
-          halign: end;
-          icon-name: "four-arrows-pointing-outward-symbolic";
-          tooltip-text: _("Open in Dialog Viewer");
-
-          clicked => $on_expand_clicked() swapped;
-
-          styles ["flat"]
-        }
+      Adw.CarouselIndicatorDots carousel_indicator {
+        carousel: carousel;
+        opacity: 0;
+        hexpand: true;
+        halign: center;
+        styles ["boxed-indicator", "indicator-box"]
       }
     };
+
+    [overlay]
+    Gtk.Revealer prev_button_revealer {
+      transition-type: crossfade;
+      reveal-child: false;
+      halign: start;
+      valign: center;
+
+      Gtk.Button prev_button {
+        icon-name: "go-previous-symbolic";
+        valign: center;
+        halign: start;
+        clicked => $on_prev_clicked() swapped;
+        styles ["circular", "osd"]
+      }
+    }
+
+    [overlay]
+    Gtk.Revealer next_button_revealer {
+      transition-type: crossfade;
+      reveal-child: false;
+      halign: end;
+      valign: center;
+
+      Gtk.Button next_button {
+        icon-name: "go-next-symbolic";
+        valign: center;
+        clicked => $on_next_clicked() swapped;
+        styles ["circular", "osd"]
+      }
+    }
+
+    [overlay]
+    Gtk.Button {
+      halign: end;
+      valign: end;
+      icon-name: "four-arrows-pointing-outward-symbolic";
+      tooltip-text: _("Open in Dialog Viewer");
+      clicked => $on_expand_clicked() swapped;
+      styles ["flat"]
+      margin-end: 3;
+      margin-bottom: 5;
+    }
   }
 }

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -205,8 +205,8 @@
 
 .decorated-screenshot {
   margin: 0;
-  padding: 5px;
-  border-radius: 0;
+  padding: 0;
+  background-color: transparent;
 }
 
 .indicator-box button {


### PR DESCRIPTION
This PR cleans up some weird things i found in screenshot carousel:

- Previous and next buttons where one overlay causing a bar between the two that could not be clicked..
- Moved the "Open Dialog" button to its own overlay to make better to make better use of given vertical space.
- Removed the ugly highlight effect of the decorated screenshot button and replaced it with a different cursor shape on hover (like seen on Flathub).