### PR TITLE
Strip trailing slashes from forge URLs when fetching stars

### DIFF
--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -771,15 +771,16 @@ debounce_timeout (BzFullView *self)
 static DexFuture *
 retrieve_star_string_fiber (GWeakRef *wr)
 {
-  g_autoptr (BzFullView) self    = NULL;
-  g_autoptr (GError) local_error = NULL;
-  g_autoptr (BzEntry) entry      = NULL;
-  const char      *forge_link    = NULL;
-  g_autofree char *star_url      = NULL;
-  g_autoptr (JsonNode) node      = NULL;
-  JsonObject      *object        = NULL;
-  gint64           star_count    = 0;
-  g_autofree char *fmt           = NULL;
+  g_autoptr (BzFullView) self         = NULL;
+  g_autoptr (GError) local_error      = NULL;
+  g_autoptr (BzEntry) entry           = NULL;
+  const char      *forge_link         = NULL;
+  g_autofree char *forge_link_trimmed = NULL;
+  g_autofree char *star_url           = NULL;
+  g_autoptr (JsonNode) node           = NULL;
+  JsonObject      *object             = NULL;
+  gint64           star_count         = 0;
+  g_autofree char *fmt                = NULL;
 
   bz_weak_get_or_return_reject (self, wr);
 
@@ -793,7 +794,10 @@ retrieve_star_string_fiber (GWeakRef *wr)
 
   // Remove trailing `/` from forge URLs if it exists
   if (g_str_has_suffix (forge_link, "/"))
-    forge_link = g_strndup (forge_link, strlen (forge_link) - 1);
+    {
+      forge_link_trimmed = g_strndup (forge_link, strlen (forge_link) - 1);
+      forge_link         = forge_link_trimmed;
+    }
 
   if (g_regex_match_simple (
           "https://github.com/.*/.*",


### PR DESCRIPTION
This PR fixes a small bug I found where apps with trailing `/` characters in their forge URL would not have their stars displayed correctly (they would always be `0`). An example with [Sessions](https://flathub.org/en/apps/com.pojtinger.felicitas.Sessions):

<img width="2656" height="1966" alt="Bazaar showing Sessions having 0 stars in the store page" src="https://github.com/user-attachments/assets/9cca77fb-4966-4626-ab5a-3170584f9ceb" />

After this PR, the issue is gone:

<img width="2656" height="1966" alt="Bazaar showing Sessions having 6 stars in the store page" src="https://github.com/user-attachments/assets/d81095e0-004e-4f05-b2bb-69041aa4de46" />