### PR TITLE
fix(po): look for share list in POTFILES

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -73,8 +73,8 @@ src/bz-search-widget.c
 src/bz-section-view.blp
 src/bz-section-view.c
 src/bz-serializable.c
-src/bz-share-dialog.blp
-src/bz-share-dialog.c
+src/bz-share-list.blp
+src/bz-share-list.c
 src/bz-state-info.c
 src/bz-stats-dialog.blp
 src/bz-stats-dialog.c


### PR DESCRIPTION
Fixes an issue where "src/bz-share-dialog.blp" couldn't be found while updating .po files.