### PR TITLE
(UX) Featured Banner: show screenshot at smaller sizes

### DIFF
--- a/src/bz-featured-tile.blp
+++ b/src/bz-featured-tile.blp
@@ -21,7 +21,7 @@ template $BzFeaturedTile: Button {
     Box content_box {
       halign: center;
       orientation: horizontal;
-      margin-start: 50;
+      margin-start: 10;
       margin-end: 10;
 
       Box {

--- a/src/bz-featured-tile.c
+++ b/src/bz-featured-tile.c
@@ -91,9 +91,9 @@ bz_featured_tile_layout_allocate (GtkLayoutManager *layout_manager,
   gboolean              narrow_mode;
   int                   spacing;
   const int             NARROW_THRESHOLD = 950;
-  const int             MIN_SPACING = 15;
-  const int             MAX_SPACING = 128;
-  const int             MAX_WIDTH = 1300;
+  const int             MIN_SPACING      = 15;
+  const int             MAX_SPACING      = 128;
+  const int             MAX_WIDTH        = 1300;
 
   self = BZ_FEATURED_TILE_LAYOUT (layout_manager);
 
@@ -469,7 +469,7 @@ bz_featured_tile_class_init (BzFeaturedTileClass *klass)
 static void
 bz_featured_tile_init (BzFeaturedTile *self)
 {
-  GtkLayoutManager *layout_manager;
+  GtkLayoutManager     *layout_manager;
   BzFeaturedTileLayout *tile_layout;
 
   gtk_widget_init_template (GTK_WIDGET (self));
@@ -480,7 +480,7 @@ bz_featured_tile_init (BzFeaturedTile *self)
   layout_manager = gtk_widget_get_layout_manager (GTK_WIDGET (self));
   g_warn_if_fail (layout_manager != NULL);
 
-  tile_layout = BZ_FEATURED_TILE_LAYOUT (layout_manager);
+  tile_layout              = BZ_FEATURED_TILE_LAYOUT (layout_manager);
   tile_layout->content_box = self->content_box;
 
   g_signal_connect_object (layout_manager, "narrow-mode-changed",


### PR DESCRIPTION
This PR allows the top halves of screenshots to appear at smaller window widths (around ~950 px). I already had a fix in the pipeline for this, but it previously caused layout warnings, which now seem to have disappeared, likely due to the recent navigation rework.

https://github.com/user-attachments/assets/f80128d6-c15f-4cce-820d-cd45031d1ef6



Fixes #476