### PR TITLE
flatpak: Fix tags in the manifest

### DIFF
--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.json
@@ -4,7 +4,7 @@
   "runtime-version": "49",
   "sdk": "org.gnome.Sdk",
   "command": "bazaar",
-  "tags": "nightly",
+  "tags": [ "nightly" ],
   "desktop-file-name-suffix": " (Nightly)",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.llvm20"


### PR DESCRIPTION
The type of the tags in the manifest in the schema is an array.

https://github.com/flatpak/flatpak-builder/blob/main/data/flatpak-manifest.schema.json