### PR TITLE
Handle (partial) failures of the Flathub API better

### DIFF
--- a/src/bz-featured-carousel.c
+++ b/src/bz-featured-carousel.c
@@ -247,12 +247,14 @@ rebuild_carousel (BzFeaturedCarousel *self)
 
   if (self->model == NULL)
     {
+      gtk_widget_set_visible (GTK_WIDGET (self), FALSE);
       gtk_widget_set_visible (GTK_WIDGET (self->next_button), FALSE);
       gtk_widget_set_visible (GTK_WIDGET (self->previous_button), FALSE);
       return;
     }
 
   n_items = g_list_model_get_n_items (self->model);
+  gtk_widget_set_visible (GTK_WIDGET (self), n_items > 0);
 
   for (guint i = 0; i < n_items; i++)
     {

--- a/src/bz-flathub-category-section.blp
+++ b/src/bz-flathub-category-section.blp
@@ -3,6 +3,7 @@ using Gtk 4.0;
 template $BzFlathubCategorySection : Box {
   orientation: vertical;
   spacing: 10;
+  visible: bind $invert_boolean($is_null(template.category as <$BzFlathubCategory>) as <bool>) as <bool>;
 
   Box {
     orientation: horizontal;

--- a/src/bz-flathub-category-section.c
+++ b/src/bz-flathub-category-section.c
@@ -241,6 +241,13 @@ invert_boolean (gpointer object,
   return !value;
 }
 
+static gboolean
+is_null (gpointer object,
+         GObject *value)
+{
+  return value == NULL;
+}
+
 static void
 bz_flathub_category_section_class_init (BzFlathubCategorySectionClass *klass)
 {
@@ -289,6 +296,7 @@ bz_flathub_category_section_class_init (BzFlathubCategorySectionClass *klass)
   gtk_widget_class_bind_template_child (widget_class, BzFlathubCategorySection, more_button);
 
   gtk_widget_class_bind_template_callback (widget_class, invert_boolean);
+  gtk_widget_class_bind_template_callback (widget_class, is_null);
   gtk_widget_class_bind_template_callback (widget_class, on_more_button_clicked);
   gtk_widget_class_bind_template_callback (widget_class, bind_widget_cb);
   gtk_widget_class_bind_template_callback (widget_class, unbind_widget_cb);

--- a/src/bz-flathub-page.blp
+++ b/src/bz-flathub-page.blp
@@ -39,315 +39,339 @@ template $BzFlathubPage: Adw.Bin {
           name: "content";
           title: _("Browser");
 
-          child: ScrolledWindow {
-            styles [
-              "transparent",
-            ]
+          child: Box {
 
-            hscrollbar-policy: never;
+            Adw.StatusPage {
+              visible: bind template.state as <$BzFlathubState>.has-connection-error;
+              hexpand: true;
+              icon-name: "flathub-symbolic";
+              title: _("Flathub Unavailable");
+              description: _("We could not connect to Flathub. You can still manage and search for applications.");
 
-            child: Adw.ClampScrollable {
-              maximum-size: 1500;
-              tightening-threshold: 1400;
+              child: Button {
+                label: _("Search Apps");
+                halign: center;
+                clicked => $open_search_cb(template);
 
-              child: Viewport {
-                child: Box content_box {
-                  margin-start: 25;
-                  margin-end: 25;
-                  margin-top: 5;
-                  margin-bottom: 20;
-                  orientation: vertical;
-                  spacing: 15;
+                styles ["pill"]
+              };
+            }
 
-                  $BzFeaturedCarousel {
-                    margin-start: 8;
-                    margin-end: 8;
+            ScrolledWindow {
+              visible: bind $invert_boolean(template.state as <$BzFlathubState>.has-connection-error) as <bool>;
+              styles [
+                "transparent",
+              ]
 
-                    styles [
-                      "flathub-page-section",
-                    ]
+              hscrollbar-policy: never;
 
-                    margin-top: 16;
-                    hexpand: true;
-                    model: bind template.state as <$BzFlathubState>.apps_of_the_week;
-                    group-clicked => $featured_carousel_group_clicked_cb(template);
-                  }
+              child: Adw.ClampScrollable {
+                maximum-size: 1500;
+                tightening-threshold: 1400;
 
-                  Box section_toggles_box {
-                    halign: center;
-                    width-request: 800;
+                child: Viewport {
+                  child: Box content_box {
+                    margin-start: 25;
+                    margin-end: 25;
+                    margin-top: 5;
+                    margin-bottom: 20;
+                    orientation: vertical;
+                    spacing: 15;
 
-                    Adw.ToggleGroup section_toggles {
-                      hexpand: true;
-                      halign: fill;
-                      homogeneous: true;
+                    $BzFeaturedCarousel {
+                      margin-start: 8;
+                      margin-end: 8;
 
                       styles [
-                        "round",
+                        "flathub-page-section",
                       ]
 
-                      Adw.Toggle {
-                        label: _("Trending");
+                      margin-top: 16;
+                      hexpand: true;
+                      model: bind template.state as <$BzFlathubState>.apps_of_the_week;
+                      group-clicked => $featured_carousel_group_clicked_cb(template);
+                    }
+
+                    Box section_toggles_box {
+                      halign: center;
+                      width-request: 800;
+
+                      Adw.ToggleGroup section_toggles {
+                        hexpand: true;
+                        halign: fill;
+                        homogeneous: true;
+
+                        styles [
+                          "round",
+                        ]
+
+                        Adw.Toggle {
+                          label: _("Trending");
+                          name: "trending";
+                          enabled: bind $invert_boolean($is_null($get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "trending") as <$BzFlathubCategory>) as <bool>) as <bool>;
+                        }
+
+                        Adw.Toggle {
+                          label: _("Popular");
+                          name: "popular";
+                          enabled: bind $invert_boolean($is_null($get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "popular") as <$BzFlathubCategory>) as <bool>) as <bool>;
+                        }
+
+                        Adw.Toggle {
+                          label: _("New");
+                          name: "recently-added";
+                          enabled: bind $invert_boolean($is_null($get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "recently-added") as <$BzFlathubCategory>) as <bool>) as <bool>;
+                        }
+
+                        Adw.Toggle {
+                          label: _("Updated");
+                          name: "recently-updated";
+                          enabled: bind $invert_boolean($is_null($get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "recently-updated") as <$BzFlathubCategory>) as <bool>) as <bool>;
+                        }
+                      }
+                    }
+
+                    Adw.ViewStack sections_stack {
+                      enable-transitions: true;
+                      vhomogeneous: false;
+                      transition-duration: 300;
+                      visible-child-name: bind section_toggles.active-name;
+
+                      Adw.ViewStackPage {
                         name: "trending";
+                        title: _("Trending");
+
+                        child: $BzFlathubCategorySection section_trending {
+                          category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "trending") as <$BzFlathubCategory>;
+                          max-items: 12;
+                          group-selected => $category_section_group_selected_cb() swapped;
+                        };
                       }
 
-                      Adw.Toggle {
-                        label: _("Popular");
-                        name: "popular";
-                      }
-
-                      Adw.Toggle {
-                        label: _("New");
-                        name: "recently-added";
-                      }
-
-                      Adw.Toggle {
-                        label: _("Updated");
+                      Adw.ViewStackPage {
                         name: "recently-updated";
+                        title: _("Recently Updated");
+
+                        child: $BzFlathubCategorySection section_recently_updated {
+                          category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "recently-updated") as <$BzFlathubCategory>;
+                          max-items: 12;
+                          group-selected => $category_section_group_selected_cb() swapped;
+                        };
+                      }
+
+                      Adw.ViewStackPage {
+                        name: "recently-added";
+                        title: _("Recently Added");
+
+                        child: $BzFlathubCategorySection section_recently_added {
+                          category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "recently-added") as <$BzFlathubCategory>;
+                          max-items: 12;
+                          group-selected => $category_section_group_selected_cb() swapped;
+                        };
+                      }
+
+                      Adw.ViewStackPage {
+                        name: "popular";
+                        title: _("Popular");
+
+                        child: $BzFlathubCategorySection section_popular {
+                          category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "popular") as <$BzFlathubCategory>;
+                          max-items: 12;
+                          group-selected => $category_section_group_selected_cb() swapped;
+                        };
                       }
                     }
-                  }
 
-                  Adw.ViewStack sections_stack {
-                    enable-transitions: true;
-                    vhomogeneous: false;
-                    transition-duration: 300;
-                    visible-child-name: bind section_toggles.active-name;
-
-                    Adw.ViewStackPage {
-                      name: "trending";
-                      title: _("Trending");
-
-                      child: $BzFlathubCategorySection section_trending {
-                        category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "trending") as <$BzFlathubCategory>;
-                        max-items: 12;
-                        group-selected => $category_section_group_selected_cb() swapped;
-                      };
+                    $BzFlathubCategorySection section_productivity {
+                      category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "office") as <$BzFlathubCategory>;
+                      max-items: 12;
+                      group-selected => $category_section_group_selected_cb() swapped;
                     }
 
-                    Adw.ViewStackPage {
-                      name: "recently-updated";
-                      title: _("Recently Updated");
+                    $BzFeaturedCarousel {
+                      margin-start: 8;
+                      margin-end: 8;
 
-                      child: $BzFlathubCategorySection section_recently_updated {
-                        category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "recently-updated") as <$BzFlathubCategory>;
-                        max-items: 12;
-                        group-selected => $category_section_group_selected_cb() swapped;
+                      styles [
+                        "flathub-page-section",
+                      ]
+
+                      margin-top: 16;
+                      hexpand: true;
+
+                      model: SliceListModel {
+                        offset: 0;
+                        size: 1;
+                        model: bind template.state as <$BzFlathubState>.apps_of_the_day_week;
                       };
+
+                      is-aotd: true;
+                      group-clicked => $featured_carousel_group_clicked_cb(template);
                     }
 
-                    Adw.ViewStackPage {
-                      name: "recently-added";
-                      title: _("Recently Added");
-
-                      child: $BzFlathubCategorySection section_recently_added {
-                        category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "recently-added") as <$BzFlathubCategory>;
-                        max-items: 12;
-                        group-selected => $category_section_group_selected_cb() swapped;
-                      };
+                    $BzFlathubCategorySection section_graphics {
+                      category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "graphics") as <$BzFlathubCategory>;
+                      max-items: 12;
+                      group-selected => $category_section_group_selected_cb() swapped;
                     }
 
-                    Adw.ViewStackPage {
-                      name: "popular";
-                      title: _("Popular");
-
-                      child: $BzFlathubCategorySection section_popular {
-                        category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "popular") as <$BzFlathubCategory>;
-                        max-items: 12;
-                        group-selected => $category_section_group_selected_cb() swapped;
-                      };
+                    $BzFlathubCategorySection section_audiovideo {
+                      category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "audiovideo") as <$BzFlathubCategory>;
+                      max-items: 12;
+                      group-selected => $category_section_group_selected_cb() swapped;
                     }
-                  }
 
-                  $BzFlathubCategorySection section_productivity {
-                    category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "office") as <$BzFlathubCategory>;
-                    max-items: 12;
-                    group-selected => $category_section_group_selected_cb() swapped;
-                  }
+                    $BzFlathubCategorySection section_education {
+                      category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "education") as <$BzFlathubCategory>;
+                      max-items: 12;
+                      group-selected => $category_section_group_selected_cb() swapped;
+                    }
 
-                  $BzFeaturedCarousel {
-                    margin-start: 8;
-                    margin-end: 8;
+                    Box otg_box {
+                      visible: bind $invert_boolean($is_null($get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "mobile") as <$BzFlathubCategory>) as <bool>) as <bool>;
+                      margin-start: 8;
+                      margin-end: 8;
+                      margin-top: 8;
+                      margin-bottom: 8;
 
-                    styles [
-                      "flathub-page-section",
-                    ]
+                      styles [
+                        "otg",
+                        "card",
+                      ]
 
-                    margin-top: 16;
-                    hexpand: true;
+                      Box otg_padding_box {
+                        orientation: horizontal;
+                        margin-start: 24;
+                        margin-end: 24;
+                        margin-top: 24;
+                        margin-bottom: 24;
 
-                    model: SliceListModel {
-                      offset: 0;
-                      size: 1;
-                      model: bind template.state as <$BzFlathubState>.apps_of_the_day_week;
-                    };
+                        Box otg_title_box {
+                          orientation: vertical;
+                          spacing: 12;
+                          width-request: 285;
+                          valign: center;
 
-                    is-aotd: true;
-                    group-clicked => $featured_carousel_group_clicked_cb(template);
-                  }
+                          Image otg_image {
+                            icon-name: "on-the-go-symbolic";
+                            pixel-size: 256;
+                            halign: start;
 
-                  $BzFlathubCategorySection section_graphics {
-                    category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "graphics") as <$BzFlathubCategory>;
-                    max-items: 12;
-                    group-selected => $category_section_group_selected_cb() swapped;
-                  }
+                            styles [
+                              "otg-image",
+                            ]
+                          }
 
-                  $BzFlathubCategorySection section_audiovideo {
-                    category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "audiovideo") as <$BzFlathubCategory>;
-                    max-items: 12;
-                    group-selected => $category_section_group_selected_cb() swapped;
-                  }
+                          Label otg_title {
+                            label: _("On the go");
+                            halign: start;
+                            wrap: true;
+                            wrap-mode: word_char;
 
-                  $BzFlathubCategorySection section_education {
-                    category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "education") as <$BzFlathubCategory>;
-                    max-items: 12;
-                    group-selected => $category_section_group_selected_cb() swapped;
-                  }
+                            styles [
+                              "otg-title",
+                              "title-1",
+                            ]
+                          }
 
-                  Box otg_box {
-                    margin-start: 8;
-                    margin-end: 8;
-                    margin-top: 8;
-                    margin-bottom: 8;
+                          Label otg_subtitle {
+                            label: _("Apps for your Linux phones and tablets");
+                            halign: start;
+                            wrap: true;
+                            wrap-mode: word_char;
+                          }
 
-                    styles [
-                      "otg",
-                      "card",
-                    ]
+                          Button otg_more_button_top {
+                            styles [
+                              "pill",
+                            ]
 
-                    Box otg_padding_box {
-                      orientation: horizontal;
-                      margin-start: 24;
-                      margin-end: 24;
-                      margin-top: 24;
-                      margin-bottom: 24;
+                            label: _("More Mobile apps");
+                            halign: start;
+                            valign: center;
+                            clicked => $show_more_mobile_clicked_cb(template);
+                          }
+                        }
 
-                      Box otg_title_box {
-                        orientation: vertical;
-                        spacing: 12;
-                        width-request: 285;
-                        valign: center;
-
-                        Image otg_image {
-                          icon-name: "on-the-go-symbolic";
-                          pixel-size: 256;
-                          halign: start;
-
+                        $BzDynamicListView otg_list {
                           styles [
-                            "otg-image",
+                            "flathub-page-section",
                           ]
+
+                          hexpand: true;
+                          scroll: false;
+                          noscroll-kind: flow-box;
+                          child-type: "BzAppTile";
+                          child-prop: "group";
+                          max-children-per-line: 3;
+
+                          model: SliceListModel otg_slice {
+                            offset: 0;
+                            size: 9;
+                            model: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "mobile") as <$BzFlathubCategory>.applications;
+                          };
+
+                          bind-widget => $bind_widget_cb(template);
+                          unbind-widget => $unbind_widget_cb(template);
                         }
 
-                        Label otg_title {
-                          label: _("On the go");
-                          halign: start;
-                          wrap: true;
-                          wrap-mode: word_char;
-
-                          styles [
-                            "otg-title",
-                            "title-1",
-                          ]
-                        }
-
-                        Label otg_subtitle {
-                          label: _("Apps for your Linux phones and tablets");
-                          halign: start;
-                          wrap: true;
-                          wrap-mode: word_char;
-                        }
-
-                        Button otg_more_button_top {
+                        Button otg_more_button_bottom {
                           styles [
                             "pill",
                           ]
 
+                          visible: false;
                           label: _("More Mobile apps");
-                          halign: start;
+                          halign: center;
                           valign: center;
+                          margin-bottom: 12;
                           clicked => $show_more_mobile_clicked_cb(template);
                         }
                       }
-
-                      $BzDynamicListView otg_list{
-                        styles [
-                          "flathub-page-section",
-                        ]
-
-                        hexpand: true;
-                        scroll: false;
-                        noscroll-kind: flow-box;
-                        child-type: "BzAppTile";
-                        child-prop: "group";
-                        max-children-per-line: 3;
-
-                        model: SliceListModel otg_slice {
-                          offset: 0;
-                          size: 9;
-                          model: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "mobile") as <$BzFlathubCategory>.applications;
-                        };
-
-                        bind-widget => $bind_widget_cb(template);
-                        unbind-widget => $unbind_widget_cb(template);
-                      }
-
-                      Button otg_more_button_bottom {
-                        styles [
-                          "pill",
-                        ]
-
-                        visible: false;
-                        label: _("More Mobile apps");
-                        halign: center;
-                        valign: center;
-                        margin-bottom: 12;
-                        clicked => $show_more_mobile_clicked_cb(template);
-                      }
                     }
-                  }
 
-                  $BzFlathubCategorySection section_network {
-                    category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "network") as <$BzFlathubCategory>;
-                    max-items: 12;
-                    group-selected => $category_section_group_selected_cb() swapped;
-                  }
+                    $BzFlathubCategorySection section_network {
+                      category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "network") as <$BzFlathubCategory>;
+                      max-items: 12;
+                      group-selected => $category_section_group_selected_cb() swapped;
+                    }
 
-                  $BzFlathubCategorySection section_game {
-                    category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "game") as <$BzFlathubCategory>;
-                    max-items: 12;
-                    group-selected => $category_section_group_selected_cb() swapped;
-                  }
+                    $BzFlathubCategorySection section_game {
+                      category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "game") as <$BzFlathubCategory>;
+                      max-items: 12;
+                      group-selected => $category_section_group_selected_cb() swapped;
+                    }
 
-                  $BzFlathubCategorySection section_development {
-                    category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "development") as <$BzFlathubCategory>;
-                    max-items: 12;
-                    group-selected => $category_section_group_selected_cb() swapped;
-                  }
+                    $BzFlathubCategorySection section_development {
+                      category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "development") as <$BzFlathubCategory>;
+                      max-items: 12;
+                      group-selected => $category_section_group_selected_cb() swapped;
+                    }
 
-                  $BzFlathubCategorySection section_science {
-                    category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "science") as <$BzFlathubCategory>;
-                    max-items: 12;
-                    group-selected => $category_section_group_selected_cb() swapped;
-                  }
+                    $BzFlathubCategorySection section_science {
+                      category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "science") as <$BzFlathubCategory>;
+                      max-items: 12;
+                      group-selected => $category_section_group_selected_cb() swapped;
+                    }
 
-                  $BzFlathubCategorySection section_system {
-                    category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "system") as <$BzFlathubCategory>;
-                    max-items: 12;
-                    group-selected => $category_section_group_selected_cb() swapped;
-                  }
+                    $BzFlathubCategorySection section_system {
+                      category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "system") as <$BzFlathubCategory>;
+                      max-items: 12;
+                      group-selected => $category_section_group_selected_cb() swapped;
+                    }
 
-                  $BzFlathubCategorySection section_utility {
-                    category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "utility") as <$BzFlathubCategory>;
-                    max-items: 12;
-                    group-selected => $category_section_group_selected_cb() swapped;
-                  }
+                    $BzFlathubCategorySection section_utility {
+                      category: bind $get_category_by_name_cb(template.state as <$BzFlathubState>.categories, "utility") as <$BzFlathubCategory>;
+                      max-items: 12;
+                      group-selected => $category_section_group_selected_cb() swapped;
+                    }
+                  };
                 };
               };
-            };
+            }
           };
         }
       };
-
 
       Adw.Breakpoint {
         condition ("max-width: 1150sp")

--- a/src/bz-flathub-page.c
+++ b/src/bz-flathub-page.c
@@ -60,6 +60,7 @@ static GParamSpec *props[LAST_PROP] = { 0 };
 enum
 {
   SIGNAL_GROUP_SELECTED,
+  SIGNAL_OPEN_SEARCH,
 
   LAST_SIGNAL,
 };
@@ -68,6 +69,20 @@ static guint signals[LAST_SIGNAL];
 static BzFlathubCategory *
 get_category_by_name (GListModel *categories,
                       const char *name);
+
+static gboolean
+invert_boolean (gpointer object,
+                gboolean value)
+{
+  return !value;
+}
+
+static gboolean
+is_null (gpointer object,
+         GObject *value)
+{
+  return value == NULL;
+}
 
 static void
 tile_clicked (BzEntryGroup *group,
@@ -224,6 +239,13 @@ get_category_by_name_cb (gpointer    object,
 }
 
 static void
+open_search_cb (BzFlathubPage *self,
+                   GtkButton      *button)
+{
+  g_signal_emit (self, signals[SIGNAL_OPEN_SEARCH], 0);
+}
+
+static void
 bz_flathub_page_class_init (BzFlathubPageClass *klass)
 {
   GObjectClass   *object_class = G_OBJECT_CLASS (klass);
@@ -264,8 +286,19 @@ bz_flathub_page_class_init (BzFlathubPageClass *klass)
       G_TYPE_FROM_CLASS (klass),
       g_cclosure_marshal_VOID__OBJECTv);
 
+  signals[SIGNAL_OPEN_SEARCH] =
+    g_signal_new (
+        "open-search",
+        G_OBJECT_CLASS_TYPE (klass),
+        G_SIGNAL_RUN_FIRST,
+        0,
+        NULL, NULL,
+        g_cclosure_marshal_VOID__VOID,
+        G_TYPE_NONE, 0);
+
   g_type_ensure (BZ_TYPE_SECTION_VIEW);
   g_type_ensure (BZ_TYPE_FLATHUB_CATEGORY_SECTION);
+  g_type_ensure (BZ_TYPE_FLATHUB_CATEGORY);
   g_type_ensure (BZ_TYPE_DETAILED_APP_TILE);
   g_type_ensure (BZ_TYPE_INHIBITED_SCROLLABLE);
   g_type_ensure (BZ_TYPE_DYNAMIC_LIST_VIEW);
@@ -274,12 +307,15 @@ bz_flathub_page_class_init (BzFlathubPageClass *klass)
 
   gtk_widget_class_set_template_from_resource (widget_class, "/io/github/kolunmi/Bazaar/bz-flathub-page.ui");
   gtk_widget_class_bind_template_child (widget_class, BzFlathubPage, stack);
+  gtk_widget_class_bind_template_callback (widget_class, invert_boolean);
+  gtk_widget_class_bind_template_callback (widget_class, is_null);
   gtk_widget_class_bind_template_callback (widget_class, bind_widget_cb);
   gtk_widget_class_bind_template_callback (widget_class, unbind_widget_cb);
   gtk_widget_class_bind_template_callback (widget_class, category_section_group_selected_cb);
   gtk_widget_class_bind_template_callback (widget_class, get_category_by_name_cb);
   gtk_widget_class_bind_template_callback (widget_class, show_more_mobile_clicked_cb);
   gtk_widget_class_bind_template_callback (widget_class, featured_carousel_group_clicked_cb);
+  gtk_widget_class_bind_template_callback (widget_class, open_search_cb);
 }
 
 static void

--- a/src/bz-flathub-state.c
+++ b/src/bz-flathub-state.c
@@ -42,6 +42,7 @@ struct _BzFlathubState
   char                    *app_of_the_day;
   GtkStringList           *apps_of_the_week;
   GListStore              *categories;
+  gboolean                 has_connection_error;
 
   DexFuture *initializing;
 };
@@ -61,6 +62,7 @@ enum
   PROP_APPS_OF_THE_WEEK,
   PROP_APPS_OF_THE_DAY_WEEK,
   PROP_CATEGORIES,
+  PROP_HAS_CONNECTION_ERROR,
 
   LAST_PROP
 };
@@ -71,6 +73,8 @@ initialize_fiber (GWeakRef *wr);
 static DexFuture *
 initialize_finally (DexFuture *future,
                     GWeakRef  *wr);
+static gboolean
+bz_flathub_state_get_has_connection_error (BzFlathubState *self);
 
 static void
 bz_flathub_state_dispose (GObject *object)
@@ -119,6 +123,9 @@ bz_flathub_state_get_property (GObject    *object,
     case PROP_CATEGORIES:
       g_value_set_object (value, bz_flathub_state_get_categories (self));
       break;
+    case PROP_HAS_CONNECTION_ERROR:
+      g_value_set_boolean (value, bz_flathub_state_get_has_connection_error (self));
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -145,6 +152,7 @@ bz_flathub_state_set_property (GObject      *object,
     case PROP_APPS_OF_THE_WEEK:
     case PROP_APPS_OF_THE_DAY_WEEK:
     case PROP_CATEGORIES:
+    case PROP_HAS_CONNECTION_ERROR:
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -204,6 +212,12 @@ bz_flathub_state_class_init (BzFlathubStateClass *klass)
           "categories",
           NULL, NULL,
           G_TYPE_LIST_MODEL,
+          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+  props[PROP_HAS_CONNECTION_ERROR] =
+      g_param_spec_boolean (
+          "has-connection-error",
+          NULL, NULL,
+          FALSE,
           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
   g_object_class_install_properties (object_class, LAST_PROP, props);
@@ -315,6 +329,13 @@ bz_flathub_state_get_categories (BzFlathubState *self)
   return G_LIST_MODEL (self->categories);
 }
 
+static gboolean
+bz_flathub_state_get_has_connection_error (BzFlathubState *self)
+{
+  g_return_val_if_fail (BZ_IS_FLATHUB_STATE (self), FALSE);
+  return self->has_connection_error;
+}
+
 void
 bz_flathub_state_set_for_day (BzFlathubState *self,
                               const char     *for_day)
@@ -327,6 +348,7 @@ bz_flathub_state_set_for_day (BzFlathubState *self,
   g_clear_pointer (&self->app_of_the_day, g_free);
   g_clear_pointer (&self->apps_of_the_week, g_object_unref);
   g_clear_pointer (&self->categories, g_object_unref);
+  self->has_connection_error = FALSE;
 
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_APP_OF_THE_DAY]);
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_APP_OF_THE_DAY_GROUP]);
@@ -355,6 +377,7 @@ bz_flathub_state_set_for_day (BzFlathubState *self,
     }
 
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_FOR_DAY]);
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_HAS_CONNECTION_ERROR]);
 }
 
 void
@@ -441,6 +464,8 @@ initialize_fiber (GWeakRef *wr)
   g_autoptr (GHashTable) futures     = NULL;
   g_autoptr (GHashTable) nodes       = NULL;
   g_autoptr (GHashTable) quality_set = NULL;
+  guint total_requests               = 0;
+  guint successful_requests          = 0;
 
   bz_weak_get_or_return_reject (self, wr);
   for_day = self->for_day;
@@ -475,6 +500,8 @@ initialize_fiber (GWeakRef *wr)
   ADD_REQUEST ("/collection/mobile", "/collection/mobile?page=0&per_page=%d", COLLECTION_FETCH_SIZE);
   ADD_REQUEST ("/quality-moderation/passing-apps", "/quality-moderation/passing-apps?page=1&page_size=%d", QUALITY_MODERATION_PAGE_SIZE);
 
+  total_requests = g_hash_table_size (futures);
+
   while (g_hash_table_size (futures) > 0)
     {
       GHashTableIter   iter        = { 0 };
@@ -490,9 +517,11 @@ initialize_fiber (GWeakRef *wr)
       if (node == NULL)
         {
           g_warning ("Failed to complete request '%s' from flathub: %s", request, local_error->message);
-          return dex_future_new_for_error (g_steal_pointer (&local_error));
+          g_clear_error (&local_error);
+          continue;
         }
       g_hash_table_replace (nodes, g_steal_pointer (&request), g_steal_pointer (&node));
+      successful_requests++;
     }
 
   if (g_hash_table_contains (nodes, "/quality-moderation/passing-apps"))
@@ -584,6 +613,8 @@ initialize_fiber (GWeakRef *wr)
           ADD_REQUEST (category, "/collection/category/%s?page=0&per_page=%d", category, CATEGORY_FETCH_SIZE);
         }
 
+      total_requests += g_hash_table_size (futures);
+
       while (g_hash_table_size (futures) > 0)
         {
           GHashTableIter   iter                   = { 0 };
@@ -606,8 +637,11 @@ initialize_fiber (GWeakRef *wr)
           if (node == NULL)
             {
               g_warning ("Failed to retrieve category '%s' from flathub: %s", name, local_error->message);
-              return dex_future_new_for_error (g_steal_pointer (&local_error));
+              g_clear_error (&local_error);
+              continue;
             }
+
+          successful_requests++;
 
           category      = bz_flathub_category_new ();
           store         = gtk_string_list_new (NULL);
@@ -639,6 +673,14 @@ initialize_fiber (GWeakRef *wr)
 
           g_list_store_append (self->categories, category);
         }
+    }
+
+  if (successful_requests == 0)
+    {
+      self->has_connection_error = TRUE;
+      return dex_future_new_for_error (
+          g_error_new (G_IO_ERROR, G_IO_ERROR_FAILED,
+                       "All Flathub API requests failed"));
     }
 
   return dex_future_new_true ();

--- a/src/bz-search-widget.blp
+++ b/src/bz-search-widget.blp
@@ -141,37 +141,47 @@ template $BzSearchWidget: Adw.Bin {
         StackPage {
           name: "empty";
 
-          child: ScrolledWindow {
-            hscrollbar-policy: never;
+          child: Box {
+            Adw.StatusPage {
+              visible: bind $is_empty(template.state as <$BzStateInfo>.flathub as <$BzFlathubState>.categories) as <bool>;
+              hexpand: true;
+              icon-name: "system-search-symbolic";
+              title: _("Categories Unavailable");
+              description: _("Search for apps using the search bar above.");
+            }
 
-            child: Adw.Clamp {
-              maximum-size: 1000;
-              tightening-threshold: 900;
-              valign: start;
+            ScrolledWindow {
+              hscrollbar-policy: never;
+              visible: bind $invert_boolean($is_empty(template.state as <$BzStateInfo>.flathub as <$BzFlathubState>.categories) as <bool>) as <bool>;
 
-              child: Box empty_box {
-                margin-start: 7;
-                margin-end: 7;
+              child: Adw.Clamp {
+                maximum-size: 1000;
+                tightening-threshold: 900;
+                valign: start;
 
-                margin-top: 20;
+                child: Box empty_box {
+                  margin-start: 7;
+                  margin-end: 7;
+                  margin-top: 20;
 
-                $BzDynamicListView {
-                  styles [
-                    "flathub-page-section",
-                  ]
+                  $BzDynamicListView {
+                    styles [
+                      "flathub-page-section",
+                    ]
 
-                  hexpand: true;
-                  max-children-per-line: 4;
-                  scroll: false;
-                  noscroll-kind: flow-box;
-                  child-type: "BzCategoryTile";
-                  child-prop: "category";
-                  model: bind template.state as <$BzStateInfo>.flathub as <$BzFlathubState>.categories;
-                  bind-widget => $bind_category_tile_cb(template);
-                  unbind-widget => $unbind_category_tile_cb(template);
-                }
+                    hexpand: true;
+                    max-children-per-line: 4;
+                    scroll: false;
+                    noscroll-kind: flow-box;
+                    child-type: "BzCategoryTile";
+                    child-prop: "category";
+                    model: bind template.state as <$BzStateInfo>.flathub as <$BzFlathubState>.categories;
+                    bind-widget => $bind_category_tile_cb(template);
+                    unbind-widget => $unbind_category_tile_cb(template);
+                  }
+                };
               };
-            };
+            }
           };
         }
 

--- a/src/bz-search-widget.c
+++ b/src/bz-search-widget.c
@@ -188,6 +188,15 @@ is_null (gpointer object,
 }
 
 static gboolean
+is_empty (gpointer object,
+          GListModel *model)
+{
+  if (model == NULL)
+    return TRUE;
+  return g_list_model_get_n_items (model) == 0;
+}
+
+static gboolean
 is_valid_string (gpointer    object,
                  const char *value)
 {
@@ -415,6 +424,7 @@ bz_search_widget_class_init (BzSearchWidgetClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, invert_boolean);
   gtk_widget_class_bind_template_callback (widget_class, is_zero);
   gtk_widget_class_bind_template_callback (widget_class, is_null);
+  gtk_widget_class_bind_template_callback (widget_class, is_empty);
   gtk_widget_class_bind_template_callback (widget_class, is_valid_string);
   gtk_widget_class_bind_template_callback (widget_class, idx_to_string);
   gtk_widget_class_bind_template_callback (widget_class, score_to_string);

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -310,6 +310,7 @@ template $BzWindow: Adw.ApplicationWindow {
                             state: bind template.state as <$BzStateInfo>.flathub;
                             online: bind template.state as <$BzStateInfo>.online;
                             group-selected => $browser_group_selected_cb(template);
+                            open-search => $open_search_cb(template);
                           };
                         }
 

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -351,6 +351,13 @@ browse_flathub_cb (BzWindow       *self,
 }
 
 static void
+open_search_cb (BzWindow       *self,
+                BzSearchWidget *widget)
+{
+  adw_view_stack_set_visible_child_name (self->main_view_stack, "search");
+}
+
+static void
 breakpoint_apply_cb (BzWindow      *self,
                      AdwBreakpoint *breakpoint)
 {
@@ -526,6 +533,7 @@ bz_window_class_init (BzWindowClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, visible_page_changed_cb);
   gtk_widget_class_bind_template_callback (widget_class, main_view_stack_changed_cb);
   gtk_widget_class_bind_template_callback (widget_class, browse_flathub_cb);
+  gtk_widget_class_bind_template_callback (widget_class, open_search_cb);
   gtk_widget_class_bind_template_callback (widget_class, format_progress);
   gtk_widget_class_bind_template_callback (widget_class, debug_id_inspect_cb);
 


### PR DESCRIPTION
This PR handles cases where the Flathub API fails for some reason, but the user is still online.
If only some requests fail, the affected widgets should now be properly hidden/disabled.
If all requests fail, special empty states are shown on the Flathub and search pages informing the user what they are still able to do.

<img width="921" height="920" alt="Screenshot From 2025-11-10 13-44-02" src="https://github.com/user-attachments/assets/2b2e0020-fb9d-4b9e-8c9c-4ce2d5057740" />

<img width="860" height="909" alt="Screenshot From 2025-11-10 14-18-23" src="https://github.com/user-attachments/assets/0947a3b9-44a5-4139-8e43-370548cce238" />
