### PR TITLE
Add "What's New" section

### DIFF
--- a/src/bazaar.gresource.xml
+++ b/src/bazaar.gresource.xml
@@ -6,6 +6,7 @@
 
     <file preprocess="xml-stripblanks">main-config-schema.xml</file>
     <file preprocess="xml-stripblanks">bz-content-provider-config-schema.xml</file>
+    <file>release-notes.xml</file>
 
     <file>countries.json</file>
 

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -474,6 +474,8 @@ bz_application_about_action (GSimpleAction *action,
   BzApplication *self   = user_data;
   GtkWindow     *window = NULL;
   AdwDialog     *dialog = NULL;
+  g_autoptr(GBytes) release_notes_bytes = NULL;
+  const char *release_notes_text = NULL;
 
   const char *developers[] = {
     C_ ("About Dialog Developer Credit", "Adam Masciola <kolunmi@posteo.net>"),
@@ -486,6 +488,14 @@ bz_application_about_action (GSimpleAction *action,
 
   window = gtk_application_get_active_window (GTK_APPLICATION (self));
   dialog = adw_about_dialog_new ();
+
+  release_notes_bytes = g_resources_lookup_data (
+      "/io/github/kolunmi/Bazaar/release-notes.xml",
+      G_RESOURCE_LOOKUP_FLAGS_NONE,
+      NULL);
+
+  if (release_notes_bytes != NULL)
+    release_notes_text = g_bytes_get_data (release_notes_bytes, NULL);
 
   g_object_set (
       dialog,
@@ -500,6 +510,7 @@ bz_application_about_action (GSimpleAction *action,
       "license-type", GTK_LICENSE_GPL_3_0,
       "website", "https://github.com/kolunmi/bazaar",
       "issue-url", "https://github.com/kolunmi/bazaar/issues",
+      "release-notes", release_notes_text,
       NULL);
 
   adw_dialog_present (dialog, GTK_WIDGET (window));

--- a/src/release-notes.xml
+++ b/src/release-notes.xml
@@ -1,0 +1,8 @@
+<p>This release comes with the following improvements:</p>
+<ul>
+  <li>Add "On the go" section and mobile category</li>
+  <li>Greatly decrease reported memory usage</li>
+  <li>Rework search UI</li>
+  <li>Rework page stack navigation</li>
+  <li>Change screenshot dialog to page</li>
+</ul>


### PR DESCRIPTION
Adds the `release-notes.xml` file where the last version notes are supposed to be placed and updated. This will then show up parsed in the About Dialog of the app.

<img width="1920" height="1048" alt="Screenshot From 2025-11-12 15-43-21" src="https://github.com/user-attachments/assets/d20eb489-a1ed-41b7-a3bc-7c31655edc32" />


Closes #630