### PR TITLE
(Bug) handle apps without stats better

### DIFF
--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -2141,6 +2141,15 @@ query_flathub_fiber (QueryFlathubData *data)
         JsonObject *per_day          = NULL;
         g_autoptr (GListStore) store = NULL;
 
+        if (!JSON_NODE_HOLDS_OBJECT (node))
+          {
+            g_debug ("No data for property %s for %s from flathub",
+                       props[prop]->name, id);
+            return dex_future_new_for_error (
+                g_error_new (G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+                             "Unexpected JSON response format"));
+          }
+
         per_day = json_object_get_object_member (
             json_node_get_object (node),
             "installs_per_day");

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -452,9 +452,10 @@ template $BzFullView: Adw.Bin {
 
                           $BzContextTile {
                             can-target: bind $invert_boolean($is_null(template.debounced-ui-entry) as <bool>) as <bool>;
+                            sensitive: bind  $invert_boolean($is_null(template.debounced-ui-entry as <$BzResult>.object as <$BzEntry>.recent-downloads) as <bool>) as <bool>;
                             clicked => $dl_stats_cb(template);
                             label: _("Downloads /mo");
-                            has-tooltip: true;
+                            has-tooltip: bind  $invert_boolean($is_null(template.debounced-ui-entry as <$BzResult>.object as <$BzEntry>.recent-downloads) as <bool>) as <bool>;
                             tooltip-text: bind $format_recent_downloads_tooltip(template.debounced-ui-entry as <$BzResult>.object as <$BzEntry>.recent-downloads) as <string>;
                             lozenge-style: "grey";
 


### PR DESCRIPTION
This PR properly disables the stats button when no JSON data is found, like with brand new apps. Previously you were able to open an empty dialog.

<img width="811" height="261" alt="image" src="https://github.com/user-attachments/assets/1b0507ff-06cd-4f2e-907e-7278474b0f84" />
