### PR TITLE
(UI) Minor Statistics screen improvements

### DIFF
--- a/src/bz-data-graph.c
+++ b/src/bz-data-graph.c
@@ -27,7 +27,8 @@
 #include <math.h>
 
 #define LABEL_MARGIN        75.0
-#define CARD_EDGE_THRESHOLD 160
+#define LABEL_MARGIN_RIGHT  35.0
+#define CARD_EDGE_THRESHOLD 120
 
 struct _BzDataGraph
 {
@@ -186,7 +187,7 @@ bz_data_graph_size_allocate (GtkWidget *widget,
 {
   BzDataGraph *self = BZ_DATA_GRAPH (widget);
 
-  refresh_path (self, (double) width - LABEL_MARGIN * 2.0, (double) height - LABEL_MARGIN);
+  refresh_path (self, (double) width - LABEL_MARGIN - LABEL_MARGIN_RIGHT, (double) height - LABEL_MARGIN);
   gtk_widget_queue_draw (widget);
 }
 
@@ -260,7 +261,7 @@ bz_data_graph_snapshot (GtkWidget   *widget,
 
   if (self->motion_x >= LABEL_MARGIN &&
       self->motion_y >= 0.0 &&
-      self->motion_x < widget_width - LABEL_MARGIN &&
+      self->motion_x < widget_width - LABEL_MARGIN_RIGHT &&
       self->motion_y < widget_height - LABEL_MARGIN)
     {
       guint n_items                          = 0;
@@ -291,7 +292,7 @@ bz_data_graph_snapshot (GtkWidget   *widget,
       const char      *prefix                = NULL;
 
       n_items     = g_list_model_get_n_items (self->model);
-      graph_width = widget_width - LABEL_MARGIN * 2.0;
+      graph_width = widget_width - LABEL_MARGIN - LABEL_MARGIN_RIGHT;
       fraction    = (self->motion_x - LABEL_MARGIN) / graph_width;
       hovered_idx = floor ((double) n_items * fraction);
       if (hovered_idx >= n_items)
@@ -508,7 +509,7 @@ update_cursor (BzDataGraph *self,
   if (x >= LABEL_MARGIN &&
       y >= 0.0 &&
       x < widget_width - LABEL_MARGIN &&
-      y < widget_height - LABEL_MARGIN)
+      y < widget_height - LABEL_MARGIN_RIGHT)
     gtk_widget_set_cursor_from_name (GTK_WIDGET (self), "crosshair");
   else
     gtk_widget_set_cursor (GTK_WIDGET (self), NULL);
@@ -832,7 +833,7 @@ refresh_path (BzDataGraph *self,
   font_height = (double) (int) PANGO_PIXELS_CEIL (pango_font_metrics_get_height (metrics));
   g_clear_pointer (&metrics, pango_font_metrics_unref);
 
-  num_ticks = floor (height / (font_height + 10.0));
+  num_ticks = floor (height / (font_height + 25.0));
   if (num_ticks < 2)
     num_ticks = 2;
 
@@ -843,7 +844,7 @@ refresh_path (BzDataGraph *self,
   rounded_axis_max       = ceil (max_dependent / tick_spacing) * tick_spacing;
   self->rounded_axis_max = rounded_axis_max;
 
-  independent_label_step = MAX (1, n_items / MAX (1, floor (width / MAX (font_height + 10.0, LABEL_MARGIN))));
+  independent_label_step = MAX (1, n_items / MAX (1, floor (width / MAX (font_height + 10.0, LABEL_MARGIN)))) * 1.5 ;
 
   curve_builder = gsk_path_builder_new ();
   snapshot      = gtk_snapshot_new ();
@@ -874,6 +875,7 @@ refresh_path (BzDataGraph *self,
           const char *label              = NULL;
           char        buf[32]            = { 0 };
           g_autoptr (PangoLayout) layout = NULL;
+          PangoRectangle          extents;
 
           label = bz_data_point_get_label (point);
           if (label == NULL)
@@ -902,9 +904,12 @@ refresh_path (BzDataGraph *self,
           layout = pango_layout_new (pango);
           pango_layout_set_text (layout, label, -1);
 
+          pango_layout_get_pixel_extents (layout, NULL, &extents);
+
           gtk_snapshot_save (snapshot);
           gtk_snapshot_translate (snapshot, &GRAPHENE_POINT_INIT (x, height + LABEL_MARGIN / 10.0));
-          gtk_snapshot_rotate (snapshot, 25.0);
+          gtk_snapshot_rotate (snapshot, -LABEL_MARGIN_RIGHT);
+          gtk_snapshot_translate (snapshot, &GRAPHENE_POINT_INIT (-extents.width, 0));
           gtk_snapshot_append_layout (snapshot, layout, &(GdkRGBA) { 1.0, 1.0, 1.0, 1.0 });
           gtk_snapshot_restore (snapshot);
 

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -619,12 +619,13 @@ dl_stats_cb (BzFullView *self,
 
   ui_entry = bz_result_get_object (self->ui_entry);
 
-  dialog = bz_stats_dialog_new (NULL, NULL);
+  dialog = bz_stats_dialog_new (NULL, NULL, 0);
   adw_dialog_set_content_width (dialog, 2000);
   adw_dialog_set_content_height (dialog, 1500);
 
   g_object_bind_property (ui_entry, "download-stats", dialog, "model", G_BINDING_SYNC_CREATE);
   g_object_bind_property (ui_entry, "download-stats-per-country", dialog, "country-model", G_BINDING_SYNC_CREATE);
+  g_object_bind_property (ui_entry, "total-downloads", dialog, "total-downloads", G_BINDING_SYNC_CREATE);
 
   adw_dialog_present (dialog, GTK_WIDGET (self));
   bz_stats_dialog_animate_open (BZ_STATS_DIALOG (dialog));

--- a/src/bz-stats-dialog.blp
+++ b/src/bz-stats-dialog.blp
@@ -26,9 +26,25 @@ template $BzStatsDialog: Adw.Dialog {
           title: _("Timeline");
           icon-name: "graph2-symbolic";
 
-          child: $BzDataGraph graph {
-            model: bind template.model;
-            tooltip-prefix: _("Installs:");
+          child: Box {
+            orientation: vertical;
+
+              Label {
+                label: bind $format_total_downloads(template.total-downloads) as <string>;
+                halign: end;
+                hexpand: true;
+                margin-end: 34;
+                margin-bottom: 2;
+
+                styles ["dimmed"]
+              }
+
+            $BzDataGraph graph {
+              model: bind template.model;
+              tooltip-prefix: _("Installs:");
+              vexpand: true;
+              hexpand: true;
+            }
           };
         }
 

--- a/src/bz-stats-dialog.h
+++ b/src/bz-stats-dialog.h
@@ -29,7 +29,8 @@ G_DECLARE_FINAL_TYPE (BzStatsDialog, bz_stats_dialog, BZ, STATS_DIALOG, AdwDialo
 
 AdwDialog *
 bz_stats_dialog_new (GListModel *model,
-                     GListModel *country_model);
+                     GListModel *country_model,
+                     int         total_downloads);
 
 void
 bz_stats_dialog_animate_open (BzStatsDialog *self);


### PR DESCRIPTION
This PR tweaks the layout of the main stats screen to work better on mobile, it also adds "Total Installs" on the top right.

<img width="780" height="798" alt="image" src="https://github.com/user-attachments/assets/f463e6aa-9a6a-4238-825d-9decd3eb396c" />
