### PR TITLE
(UX) Remove close button from screenshot page

### DIFF
--- a/src/bz-screenshot-page.blp
+++ b/src/bz-screenshot-page.blp
@@ -21,19 +21,8 @@ template $BzScreenshotPage: Adw.NavigationPage {
         ]
 
         show-title: false;
-
-        [end]
-        Box {
-          Button copy_button {
-            icon-name: "edit-copy-symbolic";
-            tooltip-text: _("Copy Image");
-            clicked => $copy_clicked() swapped;
-
-            styles [
-              "flat",
-            ]
-          }
-        }
+        show-end-title-buttons: false;
+        show-start-title-buttons: false;
       }
 
       content: Overlay {
@@ -75,6 +64,23 @@ template $BzScreenshotPage: Adw.NavigationPage {
               ]
             }
           }
+
+          Box {
+            styles [
+              "osd-box",
+            ]
+
+            Button copy_button {
+              icon-name: "edit-copy-symbolic";
+              tooltip-text: _("Copy Image");
+              clicked => $copy_clicked() swapped;
+
+              styles [
+                "flat",
+              ]
+            }
+          }
+
         }
 
         [overlay]


### PR DESCRIPTION
This should hopefully stop people from accidentally closing the app.

<img width="1189" height="981" alt="image" src="https://github.com/user-attachments/assets/57d2d12c-8547-421b-b897-5f6065a8a119" />
