### PR TITLE
(UI) Improve outline of context buttons

### DIFF
--- a/src/bz-context-tile.blp
+++ b/src/bz-context-tile.blp
@@ -6,18 +6,29 @@ template $BzContextTile: Button {
     "flat",
   ]
 
+  focusable: false;
+
   Box {
     orientation: vertical;
     spacing: 4;
     hexpand: true;
 
-    Box lozenge {
+    Button ring_button {
+      styles [
+        "lozenge-ring-button",
+      ]
+
       halign: center;
+      valign: center;
       margin-bottom: 4;
 
-      styles [
-        "lozenge",
-      ]
+      child: Box lozenge {
+        styles [
+          "lozenge",
+        ]
+
+        halign: center;
+      };
     }
 
     Label label {

--- a/src/bz-context-tile.c
+++ b/src/bz-context-tile.c
@@ -28,6 +28,7 @@ struct _BzContextTile
   char *lozenge_style;
 
   /* Template widgets */
+  GtkButton *ring_button;
   GtkBox   *lozenge;
   GtkLabel *label;
 };
@@ -142,6 +143,7 @@ bz_context_tile_class_init (BzContextTileClass *klass)
   gtk_widget_class_set_template_from_resource (widget_class, "/io/github/kolunmi/Bazaar/bz-context-tile.ui");
   gtk_widget_class_bind_template_child (widget_class, BzContextTile, lozenge);
   gtk_widget_class_bind_template_child (widget_class, BzContextTile, label);
+  gtk_widget_class_bind_template_child (widget_class, BzContextTile, ring_button);
 }
 
 static void
@@ -158,11 +160,23 @@ on_leave_notify (GtkEventController *controller, gpointer user_data)
 }
 
 static void
+on_ring_button_clicked (GtkButton *ring_button,
+                        gpointer   user_data)
+{
+  BzContextTile *self = BZ_CONTEXT_TILE (user_data);
+  g_signal_emit_by_name (self, "clicked");
+}
+
+static void
 bz_context_tile_init (BzContextTile *self)
 {
   GtkEventController *enter_leave = gtk_event_controller_motion_new ();
 
   gtk_widget_init_template (GTK_WIDGET (self));
+
+  g_signal_connect (self->ring_button, "clicked",
+                    G_CALLBACK (on_ring_button_clicked),
+                    self);
 
   g_signal_connect (enter_leave, "enter", G_CALLBACK (on_enter_notify), GTK_WIDGET (self));
   g_signal_connect (enter_leave, "leave", G_CALLBACK (on_leave_notify), GTK_WIDGET (self));

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -166,6 +166,12 @@ global-progress image {
 	  transition: background-color 150ms ease;
 }
 
+.lozenge-ring-button {
+	padding: 0;
+	border-radius: 999999px;
+	background: transparent;
+}
+
 .circular-lozenge {
 	font-weight: bold;
 	border-radius: 99999px;


### PR DESCRIPTION
Changed it so the outline follows the lozenge instead of the actual clickable area.

<img width="1189" height="981" alt="image" src="https://github.com/user-attachments/assets/40705161-5951-4aef-aba1-16f45142c78b" />
