### PR TITLE
Rich tile install fixes

### DIFF
--- a/src/bz-rich-app-tile.blp
+++ b/src/bz-rich-app-tile.blp
@@ -114,7 +114,7 @@ template $BzRichAppTile: Adw.Bin {
 
       Box {
         Button {
-          visible: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.installable) as <bool>) as <bool>;
+          visible: bind $is_zero(template.group as <$BzEntryGroup>.removable) as <bool>;
           sensitive: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.installable-and-available) as <bool>) as <bool>;
 
           styles [

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -230,7 +230,7 @@ search_widget_select_cb (BzWindow       *self,
           "removable", &removable,
           NULL);
 
-      remove = installable == 0 && removable > 0;
+      remove = removable > 0;
       try_transact (self, NULL, group, remove, FALSE, NULL);
     }
   else


### PR DESCRIPTION
Having multiple remotes for the same app caused the rich tile to sometimes display both the install and remove buttons at the same time. Then,  if you press the remove button, it would ask to install the other version.

fixes #667