### PR TITLE
(bug) Disable flow box styling for touch

### DIFF
--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -668,9 +668,6 @@ window.narrow .category-tile {
     padding: 0;
 }
 
-.disable-adw-flow-box-styling:hover {
-    background-color: transparent;
-}
-.disable-adw-flow-box-styling:focus {
+.disable-adw-flow-box-styling {
     background-color: transparent;
 }


### PR DESCRIPTION
Fixes the issue were `disable-adw-flow-box-styling` didn't disable hover or active background styles when using touch. 