### PR TITLE
(bug) Section toggles don't have an initial state

### DIFF
--- a/src/bz-flathub-page.blp
+++ b/src/bz-flathub-page.blp
@@ -136,7 +136,7 @@ template $BzFlathubPage: Adw.Bin {
                       enable-transitions: true;
                       vhomogeneous: false;
                       transition-duration: 300;
-                      visible-child-name: bind section_toggles.active-name;
+                      visible-child-name: bind section_toggles.active-name bidirectional;
 
                       Adw.ViewStackPage {
                         name: "trending";


### PR DESCRIPTION
Before:
<img width="421" height="270" alt="image" src="https://github.com/user-attachments/assets/e2a5f3ed-a733-4049-a1e2-50739bbed56e" />

After: 
<img width="421" height="270" alt="image" src="https://github.com/user-attachments/assets/29d7d841-108a-4d3e-82cf-275d91b8ab57" />
