### PR TITLE
(UX) Add more padding to initial search page

### DIFF
--- a/src/bz-search-widget.blp
+++ b/src/bz-search-widget.blp
@@ -70,8 +70,8 @@ template $BzSearchWidget: Adw.Bin {
       condition ("max-width: 700sp")
 
       setters {
-        empty_box.margin-start: 7;
-        empty_box.margin-end: 7;
+        empty_box.margin-start: 10;
+        empty_box.margin-end: 10;
         search_box_clamp.margin-start: 12;
         search_box_clamp.margin-end: 12;
         grid_view.min-columns: 1;
@@ -160,9 +160,10 @@ template $BzSearchWidget: Adw.Bin {
                 valign: start;
 
                 child: Box empty_box {
-                  margin-start: 7;
-                  margin-end: 7;
+                  margin-start: 30;
+                  margin-end: 30;
                   margin-top: 20;
+                  margin-bottom: 50;
 
                   $BzDynamicListView {
                     styles [


### PR DESCRIPTION
Makes it more inline with the other pages

<img width="877" height="836" alt="image" src="https://github.com/user-attachments/assets/939f84ed-7d27-46ae-956b-83b13c0e9b49" />

<img width="442" height="836" alt="image" src="https://github.com/user-attachments/assets/2121e748-1107-4b91-ab90-7180fc7c0463" />
