### PR TITLE
(UX) Hide curated section when no config file is provided

### DIFF
--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -292,6 +292,7 @@ template $BzWindow: Adw.ApplicationWindow {
                           name: "browse";
                           title: _("Curated");
                           icon-name: "starred-symbolic";
+                          visible: bind template.state as <$BzStateInfo>.curated-provider as <$BzContentProvider>.has-inputs;
 
                           child: $BzCuratedView browse {
                             content-provider: bind template.state as <$BzStateInfo>.curated-provider;


### PR DESCRIPTION
This PR restores the behavior of hiding the "Curated" tab when no configuration file is provided.

Displaying the button seemed to cause more confusion than hiding it...

Fixes #651