### PR TITLE
Hide the header bar task label 

### DIFF
--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -338,11 +338,6 @@ template $BzWindow: Adw.ApplicationWindow {
                       visible: bind $invert_boolean($is_null(template.state as <$BzStateInfo>.background-task-label) as <bool>) as <bool>;
 
                       Adw.Spinner {}
-
-                      Label background_task_label {
-                        visible: true;
-                        label: bind template.state as <$BzStateInfo>.background-task-label as <string>;
-                      }
                     }
 
                     [title]
@@ -432,7 +427,6 @@ template $BzWindow: Adw.ApplicationWindow {
           condition ("max-width: 700px")
 
           setters {
-            background_task_label.visible: false;
             download_bar.expand-size: 60;
             top_header_bar.title-widget: null;
             toolbar_view.reveal-bottom-bars: true;


### PR DESCRIPTION
Like on the loading screen, I believe it’s best to hide this label as well. It also caused issues on mobile-sized windows

:shipit: