### PR TITLE
Remove title char limit on the app tile

### DIFF
--- a/src/bz-app-tile.blp
+++ b/src/bz-app-tile.blp
@@ -45,7 +45,7 @@ template $BzAppTile: Button {
         Box {
           orientation: horizontal;
           spacing: 6;
-          margin-end: 12;
+          margin-end: 15;
 
           Label {
             css-name: "app-tile-title";
@@ -56,7 +56,6 @@ template $BzAppTile: Button {
             xalign: 0.0;
             ellipsize: end;
             label: bind template.group as <$BzEntryGroup>.title;
-            max-width-chars: 18;
           }
 
           Image {


### PR DESCRIPTION
I thought this limit would fix the inconsistency column thing, but it just made the title look weird on some occasions.