### PR TITLE
chore: updated the dockerfile Ubuntu image and dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:25.04
+FROM ubuntu:25.10
 
 RUN userdel -f -r ubuntu
 
@@ -12,13 +12,14 @@ RUN apt-get update && apt-get install -y \
     libadwaita-1-dev \
     libdex-dev \
     libflatpak-dev \
-    libglycin-1-dev \
-    libglycin-gtk4-1-dev \
+    libglycin-2-dev \
+    libglycin-gtk4-2-dev \
     libgtk-4-dev \
     liblcms2-dev \
     libxmlb-dev \
     libyaml-dev \
     libsoup-3.0-dev \
     libjson-glib-dev \
+    libmd4c-dev \
     meson \
     ninja-build


### PR DESCRIPTION
Hi ! 

I updated the Dockerfile to work with Bazaar's current dependencies !

So you know, it's able to create the container, run the meson command, but it fails building with ninja - and I'm not sure if I'm the one making a mistake or if Bazaar is currently in heavy development  :sweat_smile: 

But here you go, have a nice day ! 