### PR TITLE
chore: don't hardcode bazaar configs on build

### DIFF
--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.json
@@ -35,9 +35,7 @@
       "name": "bazaar",
       "buildsystem": "meson",
       "config-opts": [
-        "-Dsandboxed_libflatpak=true",
-        "-Dhardcoded_content_config_path=/run/host/etc/bazaar/config.yaml",
-        "-Dhardcoded_blocklist_path=/run/host/etc/bazaar/blocklist.txt"
+        "-Dsandboxed_libflatpak=true"
       ],
       "sources": [
         {


### PR DESCRIPTION
tested with bluefins and auroras config + blocklist and it still behaves the same as before.