### PR TITLE
(UI) Remove "view" style from curated page

### DIFF
--- a/src/bz-curated-view.blp
+++ b/src/bz-curated-view.blp
@@ -39,10 +39,6 @@ template $BzCuratedView: Adw.Bin {
       title: _("Browser");
 
       child: ScrolledWindow {
-        styles [
-          "view",
-        ]
-
         hscrollbar-policy: never;
 
         child: Adw.ClampScrollable {
@@ -50,6 +46,7 @@ template $BzCuratedView: Adw.Bin {
           tightening-threshold: 1500;
 
           child: ListView {
+            css-name: "curated-list-view";
             model: NoSelection {
               model: bind template.state as <$BzStateInfo>.curated-provider;
             };

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -695,3 +695,8 @@ window.narrow .category-tile {
 .disable-adw-flow-box-styling {
     background-color: transparent;
 }
+
+curated-list-view,
+curated-list-view list {
+  background: var(--bg-color);
+}


### PR DESCRIPTION
If I understand correctly, the `view` style was added to this whole page to mask the inherited `view` style of some elements. This worked well enough in older versions of the app, but since we moved to the flat header bar, the background colour change has become really distracting. So I used some CSS to remove the darker background entirely.

<img width="1280" height="987" alt="image" src="https://github.com/user-attachments/assets/ff755269-cd8c-452b-a9a4-1ba7c0a5ff34" />
