### PR TITLE
(Bug) Sort download statistics by date

### DIFF
--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -2237,10 +2237,13 @@ query_flathub (BzEntry *self,
       g_steal_pointer (&future));
 }
 
-static gint compare_dates (gconstpointer a, gconstpointer b, gpointer user_data)
+static gint
+compare_dates (BzDataPoint *a,
+               BzDataPoint *b)
 {
-  double date_a = bz_data_point_get_independent ((BzDataPoint *) a);
-  double date_b = bz_data_point_get_independent ((BzDataPoint *) b);
+  double date_a = bz_data_point_get_independent (a);
+  double date_b = bz_data_point_get_independent (b);
+
   return (date_a > date_b) - (date_a < date_b);
 }
 


### PR DESCRIPTION
Flathub seems to have started sending statistics data without sorting it by date anymore. This appears to be unintended, since the Flathub site also doesn’t seem to handle it properly. Either way, it’s probably better to sort it by date on our end.