### PR TITLE
(UX) Add captions to screenshot page

### DIFF
--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -96,6 +96,7 @@ typedef struct
   char            *developer_id;
   GListModel      *developer_apps;
   GListModel      *screenshot_paintables;
+  GListModel      *screenshot_captions;
   GListModel      *share_urls;
   char            *donation_url;
   char            *forge_url;
@@ -158,6 +159,7 @@ enum
   PROP_DEVELOPER_ID,
   PROP_DEVELOPER_APPS,
   PROP_SCREENSHOT_PAINTABLES,
+  PROP_SCREENSHOT_CAPTIONS,
   PROP_SHARE_URLS,
   PROP_DONATION_URL,
   PROP_FORGE_URL,
@@ -355,6 +357,9 @@ bz_entry_get_property (GObject    *object,
     case PROP_SCREENSHOT_PAINTABLES:
       g_value_set_object (value, priv->screenshot_paintables);
       break;
+    case PROP_SCREENSHOT_CAPTIONS:
+      g_value_set_object (value, priv->screenshot_captions);
+      break;
     case PROP_SHARE_URLS:
       g_value_set_object (value, priv->share_urls);
       break;
@@ -543,6 +548,10 @@ bz_entry_set_property (GObject      *object,
     case PROP_SCREENSHOT_PAINTABLES:
       g_clear_object (&priv->screenshot_paintables);
       priv->screenshot_paintables = g_value_dup_object (value);
+      break;
+    case PROP_SCREENSHOT_CAPTIONS:
+      g_clear_object (&priv->screenshot_captions);
+      priv->screenshot_captions = g_value_dup_object (value);
       break;
     case PROP_SHARE_URLS:
       g_clear_object (&priv->share_urls);
@@ -834,6 +843,13 @@ bz_entry_class_init (BzEntryClass *klass)
           G_TYPE_LIST_MODEL,
           G_PARAM_READWRITE);
 
+  props[PROP_SCREENSHOT_CAPTIONS] =
+      g_param_spec_object (
+          "screenshot-captions",
+          NULL, NULL,
+          G_TYPE_LIST_MODEL,
+          G_PARAM_READWRITE);
+
   props[PROP_SHARE_URLS] =
       g_param_spec_object (
           "share-urls",
@@ -1101,6 +1117,27 @@ bz_entry_real_serialize (BzSerializable  *serializable,
             }
 
           g_variant_builder_add (builder, "{sv}", "screenshot-paintables", g_variant_builder_end (sub_builder));
+        }
+    }
+  if (priv->screenshot_captions != NULL)
+    {
+      guint n_items = 0;
+
+      n_items = g_list_model_get_n_items (priv->screenshot_captions);
+      if (n_items > 0)
+        {
+          g_autoptr (GVariantBuilder) sub_builder = NULL;
+
+          sub_builder = g_variant_builder_new (G_VARIANT_TYPE ("as"));
+          for (guint i = 0; i < n_items; i++)
+            {
+              g_autoptr (GtkStringObject) string = NULL;
+
+              string = g_list_model_get_item (priv->screenshot_captions, i);
+              g_variant_builder_add (sub_builder, "s", gtk_string_object_get_string (string));
+            }
+
+          g_variant_builder_add (builder, "{sv}", "screenshot-captions", g_variant_builder_end (sub_builder));
         }
     }
   if (priv->share_urls != NULL)
@@ -1432,6 +1469,27 @@ bz_entry_real_deserialize (BzSerializable *serializable,
             }
 
           priv->screenshot_paintables = G_LIST_MODEL (g_steal_pointer (&store));
+        }
+      else if (g_strcmp0 (key, "screenshot-captions") == 0)
+        {
+          g_autoptr (GListStore) store          = NULL;
+          g_autoptr (GVariantIter) caption_iter = NULL;
+
+          store = g_list_store_new (GTK_TYPE_STRING_OBJECT);
+
+          caption_iter = g_variant_iter_new (value);
+          for (;;)
+            {
+              g_autofree char *caption           = NULL;
+              g_autoptr (GtkStringObject) string = NULL;
+
+              if (!g_variant_iter_next (caption_iter, "s", &caption))
+                break;
+              string = gtk_string_object_new (caption);
+              g_list_store_append (store, string);
+            }
+
+          priv->screenshot_captions = G_LIST_MODEL (g_steal_pointer (&store));
         }
       else if (g_strcmp0 (key, "share-urls") == 0)
         {
@@ -2401,13 +2459,13 @@ download_stats_per_day_foreach (JsonObject  *object,
   g_autofree char *formatted_label = NULL;
   g_autofree char *iso_with_tz     = NULL;
 
-  dependent   = json_node_get_int (member_node);
+  dependent = json_node_get_int (member_node);
 
   iso_with_tz = g_strdup_printf ("%sT00:00:00Z", member_name);
   date        = g_date_time_new_from_iso8601 (iso_with_tz, NULL);
 
   formatted_label = g_date_time_format (date, "%-d %b");
-  independent = (double) g_date_time_to_unix (date);
+  independent     = (double) g_date_time_to_unix (date);
 
   point = g_object_new (
       BZ_TYPE_DATA_POINT,
@@ -2693,6 +2751,7 @@ clear_entry (BzEntry *self)
   g_clear_pointer (&priv->developer_id, g_free);
   g_clear_object (&priv->developer_apps);
   g_clear_object (&priv->screenshot_paintables);
+  g_clear_object (&priv->screenshot_captions);
   g_clear_object (&priv->share_urls);
   g_clear_pointer (&priv->donation_url, g_free);
   g_clear_pointer (&priv->forge_url, g_free);

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -813,14 +813,25 @@ screenshot_clicked_cb (BzFullView            *self,
                        BzScreenshotsCarousel *carousel)
 {
   GListModel        *screenshots = NULL;
+  GListModel        *captions    = NULL;
   AdwNavigationPage *page        = NULL;
   GtkWidget         *nav_view    = NULL;
+  BzEntry           *entry       = NULL;
 
   screenshots = bz_screenshots_carousel_get_model (carousel);
   if (screenshots == NULL)
     return;
 
-  page = bz_screenshot_page_new (screenshots, index);
+  if (self->ui_entry != NULL)
+    {
+      entry = bz_result_get_object (self->ui_entry);
+      if (entry != NULL)
+        g_object_get (entry, "screenshot-captions", &captions, NULL);
+    }
+
+  page = bz_screenshot_page_new (screenshots, captions, index);
+
+  g_clear_object (&captions);
 
   nav_view = gtk_widget_get_ancestor (GTK_WIDGET (self), ADW_TYPE_NAVIGATION_VIEW);
   if (nav_view != NULL)

--- a/src/bz-screenshot-page.blp
+++ b/src/bz-screenshot-page.blp
@@ -4,108 +4,72 @@ using Adw 1;
 template $BzScreenshotPage: Adw.NavigationPage {
   title: _("Screenshots");
 
-  child: Adw.ToastOverlay toast_overlay {
-    child: Adw.ToolbarView {
-      top-bar-style: flat;
-      extend-content-to-top-edge: true;
+  child: Adw.BreakpointBin {
+    width-request: 360;
+    height-request: 450;
 
-      styles [
-        "view-dark",
-      ]
+    Adw.Breakpoint {
+      condition ("max-width: 700px")
 
-      [top]
-      Adw.HeaderBar {
+      setters {
+        mobile_caption_box.margin-bottom: 70;
+      }
+    }
+
+    child: Adw.ToastOverlay toast_overlay {
+      child: Adw.ToolbarView {
+        top-bar-style: flat;
+        extend-content-to-top-edge: true;
+
         styles [
-          "flat",
-          "header-osd",
+          "view-dark",
         ]
 
-        show-title: false;
-        show-end-title-buttons: false;
-        show-start-title-buttons: false;
-      }
+        [top]
+        Adw.HeaderBar header_bar {
+          styles [
+            "flat",
+            "header-osd",
+          ]
 
-      content: Overlay {
-        [overlay]
-        Box {
-          orientation: horizontal;
-          halign: start;
-          valign: end;
-          margin-bottom: 12;
-          margin-start: 12;
-          spacing: 6;
-
-          Box navigation_controls {
-            orientation: horizontal;
-            spacing: 6;
-            visible: bind $has_multiple_screenshots(template.screenshots) as <bool>;
-
-            styles [
-              "osd-box",
-            ]
-
-            Button previous_button {
-              icon-name: "go-previous-symbolic";
-              tooltip-text: _("Previous Screenshot");
-              clicked => $previous_clicked() swapped;
-
-              styles [
-                "flat",
-              ]
-            }
-
-            Button next_button {
-              icon-name: "go-next-symbolic";
-              tooltip-text: _("Next Screenshot");
-              clicked => $next_clicked() swapped;
-
-              styles [
-                "flat",
-              ]
-            }
-          }
-
-          Box {
-            styles [
-              "osd-box",
-            ]
-
-            Button copy_button {
-              icon-name: "edit-copy-symbolic";
-              tooltip-text: _("Copy Image");
-              clicked => $copy_clicked() swapped;
-
-              styles [
-                "flat",
-              ]
-            }
-          }
-
+          show-end-title-buttons: false;
+          show-start-title-buttons: false;
+          show-title: false;
         }
 
-        [overlay]
-        Box {
-          orientation: horizontal;
-          halign: end;
-          valign: end;
-          margin-bottom: 12;
-          margin-end: 12;
-
-          Box zoom_controls {
+        content: Overlay {
+          [overlay]
+          Box {
             orientation: horizontal;
+            halign: start;
+            valign: end;
+            margin-bottom: 12;
+            margin-start: 12;
+            spacing: 6;
 
-            styles [
-              "osd-box",
-            ]
+            Box navigation_controls {
+              orientation: horizontal;
+              spacing: 6;
+              visible: bind $has_multiple_screenshots(template.screenshots) as <bool>;
 
-            Revealer {
-              reveal-child: bind template.is-zoomed as <bool>;
-              transition-type: slide_right;
+              styles [
+                "osd-box",
+              ]
 
-              Button reset_zoom_button {
-                icon-name: "zoom-original-symbolic";
-                tooltip-text: _("Reset View");
-                clicked => $reset_zoom_clicked() swapped;
+              Button previous_button {
+                icon-name: "go-previous-symbolic";
+                tooltip-text: _("Previous Screenshot");
+                clicked => $previous_clicked() swapped;
+
+                styles [
+                  "flat",
+                ]
+              }
+
+              Button next_button {
+                icon-name: "go-next-symbolic";
+                tooltip-text: _("Next Screenshot");
+                clicked => $next_clicked() swapped;
 
                 styles [
                   "flat",
@@ -113,35 +77,112 @@ template $BzScreenshotPage: Adw.NavigationPage {
               }
             }
 
-            Button zoom_out_button {
-              icon-name: "zoom-minus-symbolic";
-              tooltip-text: _("Zoom Out");
-              clicked => $zoom_out_clicked() swapped;
-
+            Box {
               styles [
-                "flat",
+                "osd-box",
               ]
-            }
 
-            Button zoom_in_button {
-              icon-name: "zoom-plus-symbolic";
-              tooltip-text: _("Zoom In");
-              clicked => $zoom_in_clicked() swapped;
+              Button copy_button {
+                icon-name: "edit-copy-symbolic";
+                tooltip-text: _("Copy Image");
+                clicked => $copy_clicked() swapped;
 
-              styles [
-                "flat",
-              ]
+                styles [
+                  "flat",
+                ]
+              }
             }
           }
-        }
 
-        child: Adw.Carousel carousel {
-          can-focus: false;
-          interactive: bind $invert_boolean(template.is-zoomed) as <bool>;
-          allow-scroll-wheel: bind $invert_boolean(template.is-zoomed) as <bool>;
-          allow-mouse-drag: bind $invert_boolean(template.is-zoomed) as <bool>;
-          allow-long-swipes: false;
-          notify::position => $on_carousel_position_changed();
+          [overlay]
+          Revealer {
+            halign: center;
+            valign: end;
+            reveal-child: bind $is_valid_string(template.current-caption) as <bool>;
+            transition-type: crossfade;
+            can-target: false;
+
+            child: Box mobile_caption_box {
+              margin-bottom: 20;
+              styles [
+                "osd-box",
+              ]
+
+              Label {
+                halign: center;
+                hexpand: true;
+                label: bind template.current-caption;
+                justify: center;
+                max-width-chars: 30;
+                wrap: true;
+                wrap-mode: word_char;
+                styles [
+                  "heading"
+                ]
+              }
+            };
+          }
+
+          [overlay]
+          Box {
+            orientation: horizontal;
+            halign: end;
+            valign: end;
+            margin-bottom: 12;
+            margin-end: 12;
+
+            Box zoom_controls {
+              orientation: horizontal;
+
+              styles [
+                "osd-box",
+              ]
+
+              Revealer {
+                reveal-child: bind template.is-zoomed as <bool>;
+                transition-type: slide_right;
+
+                Button reset_zoom_button {
+                  icon-name: "zoom-original-symbolic";
+                  tooltip-text: _("Reset View");
+                  clicked => $reset_zoom_clicked() swapped;
+
+                  styles [
+                    "flat",
+                  ]
+                }
+              }
+
+              Button zoom_out_button {
+                icon-name: "zoom-minus-symbolic";
+                tooltip-text: _("Zoom Out");
+                clicked => $zoom_out_clicked() swapped;
+
+                styles [
+                  "flat",
+                ]
+              }
+
+              Button zoom_in_button {
+                icon-name: "zoom-plus-symbolic";
+                tooltip-text: _("Zoom In");
+                clicked => $zoom_in_clicked() swapped;
+
+                styles [
+                  "flat",
+                ]
+              }
+            }
+          }
+
+          child: Adw.Carousel carousel {
+            can-focus: false;
+            interactive: bind $invert_boolean(template.is-zoomed) as <bool>;
+            allow-scroll-wheel: bind $invert_boolean(template.is-zoomed) as <bool>;
+            allow-mouse-drag: bind $invert_boolean(template.is-zoomed) as <bool>;
+            allow-long-swipes: false;
+            notify::position => $on_carousel_position_changed();
+          };
         };
       };
     };

--- a/src/bz-screenshot-page.c
+++ b/src/bz-screenshot-page.c
@@ -31,6 +31,7 @@ struct _BzScreenshotPage
   AdwToastOverlay *toast_overlay;
 
   GListModel *screenshots;
+  GListModel *captions;
   guint       current_index;
   guint       initial_index;
 
@@ -43,12 +44,15 @@ static void on_zoom_level_changed (BzZoom           *zoom,
                                    GParamSpec       *pspec,
                                    BzScreenshotPage *self);
 
+const char *bz_screenshot_page_get_current_caption (BzScreenshotPage *self);
+
 enum
 {
   PROP_0,
 
   PROP_SCREENSHOTS,
   PROP_CURRENT_INDEX,
+  PROP_CURRENT_CAPTION,
   PROP_IS_ZOOMED,
 
   LAST_PROP
@@ -61,6 +65,7 @@ bz_screenshot_page_dispose (GObject *object)
   BzScreenshotPage *self = BZ_SCREENSHOT_PAGE (object);
 
   g_clear_object (&self->screenshots);
+  g_clear_object (&self->captions);
 
   G_OBJECT_CLASS (bz_screenshot_page_parent_class)->dispose (object);
 }
@@ -80,6 +85,12 @@ bz_screenshot_page_get_property (GObject    *object,
       break;
     case PROP_CURRENT_INDEX:
       g_value_set_uint (value, self->current_index);
+      break;
+    case PROP_CURRENT_CAPTION:
+      {
+        const char *caption = bz_screenshot_page_get_current_caption (self);
+        g_value_set_string (value, caption);
+      }
       break;
     case PROP_IS_ZOOMED:
       g_value_set_boolean (value, self->is_zoomed);
@@ -206,6 +217,7 @@ bz_screenshot_page_constructed (GObject *object)
     connect_zoom_signal (self, page);
 
   update_is_zoomed (self);
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_CURRENT_CAPTION]);
 }
 
 static void
@@ -224,6 +236,7 @@ bz_screenshot_page_set_property (GObject      *object,
     case PROP_CURRENT_INDEX:
       self->initial_index = g_value_get_uint (value);
       break;
+    case PROP_CURRENT_CAPTION:
     case PROP_IS_ZOOMED:
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -361,6 +374,7 @@ on_carousel_position_changed (AdwCarousel      *carousel,
 
   update_is_zoomed (self);
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_CURRENT_INDEX]);
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_CURRENT_CAPTION]);
 }
 
 static void
@@ -436,6 +450,13 @@ invert_boolean (gpointer object,
   return !value;
 }
 
+static gboolean
+is_valid_string (gpointer    object,
+                 const char *value)
+{
+  return value != NULL && *value != '\0';
+}
+
 static void
 bz_screenshot_page_class_init (BzScreenshotPageClass *klass)
 {
@@ -461,6 +482,13 @@ bz_screenshot_page_class_init (BzScreenshotPageClass *klass)
           0, G_MAXUINT, 0,
           G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY);
 
+  props[PROP_CURRENT_CAPTION] =
+      g_param_spec_string (
+          "current-caption",
+          NULL, NULL,
+          NULL,
+          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+
   props[PROP_IS_ZOOMED] =
       g_param_spec_boolean (
           "is-zoomed",
@@ -484,6 +512,7 @@ bz_screenshot_page_class_init (BzScreenshotPageClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, next_clicked);
   gtk_widget_class_bind_template_callback (widget_class, has_multiple_screenshots);
   gtk_widget_class_bind_template_callback (widget_class, invert_boolean);
+  gtk_widget_class_bind_template_callback (widget_class, is_valid_string);
 }
 
 static void
@@ -499,13 +528,54 @@ bz_screenshot_page_init (BzScreenshotPage *self)
   gtk_widget_add_controller (GTK_WIDGET (self), key_controller);
 }
 
+const char *
+bz_screenshot_page_get_current_caption (BzScreenshotPage *self)
+{
+  g_autoptr (GtkStringObject) caption_obj = NULL;
+  guint n_items                           = 0;
+  guint actual_index                      = 0;
+
+  g_return_val_if_fail (BZ_IS_SCREENSHOT_PAGE (self), NULL);
+
+  if (self->captions == NULL)
+    return "";
+
+  n_items = g_list_model_get_n_items (self->captions);
+  if (n_items == 0)
+    return "";
+
+  actual_index = (self->initial_index + self->current_index) % n_items;
+
+  caption_obj = g_list_model_get_item (self->captions, actual_index);
+  if (caption_obj == NULL)
+    return "";
+
+  return gtk_string_object_get_string (caption_obj);
+}
+
+void
+bz_screenshot_page_set_captions (BzScreenshotPage *self,
+                                 GListModel       *captions)
+{
+  g_return_if_fail (BZ_IS_SCREENSHOT_PAGE (self));
+
+  g_set_object (&self->captions, captions);
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_CURRENT_CAPTION]);
+}
+
 AdwNavigationPage *
 bz_screenshot_page_new (GListModel *screenshots,
+                        GListModel *captions,
                         guint       initial_index)
 {
-  return g_object_new (
+  BzScreenshotPage *page = g_object_new (
       BZ_TYPE_SCREENSHOT_PAGE,
       "screenshots", screenshots,
       "current-index", initial_index,
       NULL);
+
+  if (captions != NULL)
+    bz_screenshot_page_set_captions (page, captions);
+
+  return ADW_NAVIGATION_PAGE (page);
 }

--- a/src/bz-screenshot-page.h
+++ b/src/bz-screenshot-page.h
@@ -30,6 +30,7 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (BzScreenshotPage, bz_screenshot_page, BZ, SCREENSHOT_PAGE, AdwNavigationPage)
 
 AdwNavigationPage *bz_screenshot_page_new (GListModel *screenshots,
+                                           GListModel *captions,
                                            guint       initial_index);
 
 G_END_DECLS


### PR DESCRIPTION
This PR adds screenshot captions to the screenshot page. I have decided not to add them to the full view to spare the vertical space.

I also had to make it a separate list next to the list of screenshot paintables to avoid breaking the caching.

<img width="984" height="929" alt="Screenshot From 2025-12-04 21-52-47" src="https://github.com/user-attachments/assets/f5014149-c30b-4c43-8e59-7b454b1ecc65" />
<img width="433" height="822" alt="image" src="https://github.com/user-attachments/assets/cd341e2f-4f58-480c-ba81-d31df613821c" />
