### PR TITLE
screenshot description fixed in metainfo

### DIFF
--- a/data/io.github.kolunmi.Bazaar.metainfo.xml.in
+++ b/data/io.github.kolunmi.Bazaar.metainfo.xml.in
@@ -50,11 +50,11 @@
 
   <screenshots>
     <screenshot type="default">
-      <image>https://github.com/user-attachments/assets/635b19fb-5130-4797-91ce-f358339f260a</image>
+      <image>https://github.com/user-attachments/assets/4bf0cf77-f4c6-4ea6-afbd-f74acfc992ef</image>
       <caption>The home page displaying Flathub apps</caption>
     </screenshot>
     <screenshot>
-      <image>https://github.com/user-attachments/assets/4bf0cf77-f4c6-4ea6-afbd-f74acfc992ef</image>
+      <image>https://github.com/user-attachments/assets/635b19fb-5130-4797-91ce-f358339f260a</image>
       <caption>Nucleus app page</caption>
     </screenshot>
     <screenshot>


### PR DESCRIPTION
Screenshots on flathub have mixed up descriptions, Nucleus app says "home page" and vice versa. This should fix it 