### PR TITLE
(UI) Update app tile installed indicator

### DIFF
--- a/src/bz-app-tile.blp
+++ b/src/bz-app-tile.blp
@@ -7,19 +7,6 @@ template $BzAppTile: Button {
   ]
 
   child: Overlay {
-    [overlay]
-    Image {
-      css-name: "app-tile-installed-indicator";
-
-      halign: end;
-      valign: start;
-      icon-name: "app-installed-symbolic";
-      icon-size: normal;
-      visible: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable) as <bool>) as <bool>;
-      margin-top: 10;
-      margin-end: 10;
-    }
-
     Box {
       margin-start: 12;
       margin-end: 12;
@@ -40,12 +27,11 @@ template $BzAppTile: Button {
         valign: center;
         hexpand: true;
         orientation: vertical;
-        spacing: 5;
+        spacing: 4;
 
         Box {
           orientation: horizontal;
           spacing: 6;
-          margin-end: 12;
 
           Label {
             css-name: "app-tile-title";
@@ -77,10 +63,27 @@ template $BzAppTile: Button {
           wrap: true;
           ellipsize: end;
           vexpand: true;
-          lines: 2;
+          lines: bind $description_line_amount($is_zero(template.group as <$BzEntryGroup>.removable) as <bool>) as <int>;
           max-width-chars: 15;
           single-line-mode: true;
           label: bind template.group as <$BzEntryGroup>.description;
+        }
+
+        Box {
+          halign: start;
+          spacing: 4;
+          visible: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable) as <bool>) as <bool>;
+          styles ["small-pill", "installed-pill", "success"]
+
+          Image {
+            icon-name: "app-installed-symbolic";
+            pixel-size: 12;
+          }
+
+          Label {
+            label: _("Installed");
+
+          }
         }
       }
     }

--- a/src/bz-app-tile.c
+++ b/src/bz-app-tile.c
@@ -106,6 +106,13 @@ is_zero (gpointer object,
   return value == 0;
 }
 
+static gboolean
+description_line_amount(gpointer object,
+                        bool     value)
+{
+  return value ? 2 : 1;
+}
+
 static void
 bz_app_tile_class_init (BzAppTileClass *klass)
 {
@@ -129,6 +136,7 @@ bz_app_tile_class_init (BzAppTileClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, invert_boolean);
   gtk_widget_class_bind_template_callback (widget_class, is_null);
   gtk_widget_class_bind_template_callback (widget_class, is_zero);
+  gtk_widget_class_bind_template_callback (widget_class, description_line_amount);
 }
 
 static void

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -244,6 +244,13 @@ button.context-tile:active .lozenge {
     background-color: alpha(@error_bg_color, 0.15);
 }
 
+.installed-pill {
+	background-color: alpha(@success_bg_color, 0.15);
+	font-weight: 500;
+	font-size: 0.9em;
+ 	padding: 2px 7px 2px 4.5px;
+}
+
 .download-size-pill{
   padding: 2px 8px;
 }


### PR DESCRIPTION
This should hopefully fix the weirdness of having 2 check mark icons right next to each other.

<img width="813" height="341" alt="Screenshot From 2025-12-16 16-54-58" src="https://github.com/user-attachments/assets/69e745e2-f419-4868-9daf-8c3abffdca2f" />
