### PR TITLE
Change the "Install Now" button string

### DIFF
--- a/src/bz-update-dialog.blp
+++ b/src/bz-update-dialog.blp
@@ -4,7 +4,7 @@ using Adw 1;
 template $BzUpdateDialog: Adw.AlertDialog {
   responses [
     ignore: _("Later"),
-    install: _("Install Now") suggested,
+    install: _("Update Now") suggested,
   ]
 
   heading: _("Updates Are Available");


### PR DESCRIPTION
The dialog title says "Updates Are Available," but the suggested button says "Install Now," which is a bit confusing. This patch changes "Install Now" to "Update Now."