### PR TITLE
Add Disability Pride flag

### DIFF
--- a/data/io.github.kolunmi.Bazaar.gschema.xml
+++ b/data/io.github.kolunmi.Bazaar.gschema.xml
@@ -41,6 +41,7 @@
         <choice value="intersex-flag"/>
         <choice value="demigender-flag"/>
         <choice value="biromantic-flag"/>
+        <choice value="disability-flag"/>
       </choices>
       <default>'accent-color'</default>
       <summary>Global Progress Bar Theme</summary>

--- a/src/bz-global-progress.c
+++ b/src/bz-global-progress.c
@@ -330,7 +330,8 @@ bz_global_progress_snapshot (GtkWidget   *widget,
                g_strcmp0 (theme, "genderqueer-flag") == 0 ||
                g_strcmp0 (theme, "intersex-flag") == 0 ||
                g_strcmp0 (theme, "demigender-flag") == 0 ||
-               g_strcmp0 (theme, "biromantic-flag") == 0)
+               g_strcmp0 (theme, "biromantic-flag") == 0 ||
+               g_strcmp0 (theme, "disability-flag") == 0)
         append_pride_flag (snapshot, &fraction_clip.bounds, theme);
       else
         gtk_snapshot_append_color (snapshot, accent_color, &fraction_clip.bounds);

--- a/src/bz-preferences-dialog.c
+++ b/src/bz-preferences-dialog.c
@@ -47,6 +47,7 @@ static const BarTheme bar_themes[] = {
   {      "intersex-flag",      "intersex-theme",    N_ ("Intersex Pride Colors") },
   {    "demigender-flag",    "demigender-theme",  N_ ("Demigender Pride Colors") },
   {    "biromantic-flag",    "biromantic-theme",  N_ ("Biromantic Pride Colors") },
+  {    "disability-flag",    "disability-theme",  N_ ("Disability Pride Colors") },
 };
 
 struct _BzPreferencesDialog

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -540,6 +540,10 @@ window.flathub {
   --flag-gradient: linear-gradient(to bottom, #8869A5 0%, #8869A5 20%, #D8A7D8 20%, #D8A7D8 40%, #FFFFFF 40%, #FFFFFF 60%, #FDB18D 60%, #FDB18D 80%, #151638 80%, #151638 100%);
 }
 
+.accent-button.disability-theme {
+  --flag-gradient: linear-gradient(to bottom, #595959 0%, #595959 14.285714286%, #CF7280 14.285714286%, #CF7280 28.571428571%, #EEDE77 28.571428571%, #EEDE77 42.857142857%, #E8E8E8 42.857142857%, #E8E8E8 57.142857143%, #7BC2E0 57.142857143%, #7BC2E0 57.142857143%, #3BB07D 71.428571429%, #3BB07D 85.714285714%, #595959 85.714285714%, #595959 100%);
+}
+
 /* Category buttons styling modified from GNOME Software*/
 .category-tile {
   font-weight: 700;

--- a/src/progress-bar-designs/pride.c
+++ b/src/progress-bar-designs/pride.c
@@ -439,6 +439,37 @@ append_pride_flag (GtkSnapshot     *snapshot,
       };
       append_striped_flag (snapshot, colors, offsets, sizes, G_N_ELEMENTS (colors), bounds);
     }
+  else if (g_strcmp0 (name, "disability-flag") == 0)
+    {
+      const GdkRGBA colors[] = {
+        {  89.0 / 255.0,  89.0 / 255.0,  89.0 / 255.0, 1.0 },
+        { 207.0 / 255.0, 114.0 / 255.0, 128.0 / 255.0, 1.0 },
+        { 238.0 / 255.0, 222.0 / 255.0, 119.0 / 255.0, 1.0 },
+        { 232.0 / 255.0, 232.0 / 255.0, 232.0 / 255.0, 1.0 },
+        { 123.0 / 255.0, 194.0 / 255.0, 224.0 / 255.0, 1.0 },
+        {  59.0 / 255.0, 176.0 / 255.0, 125.0 / 255.0, 1.0 },
+        {  89.0 / 255.0,  89.0 / 255.0,  89.0 / 255.0, 1.0 },
+      };
+      const float offsets[G_N_ELEMENTS (colors)] = {
+        0.0 / 7.0,
+        1.0 / 7.0,
+        2.0 / 7.0,
+        3.0 / 7.0,
+        4.0 / 7.0,
+        5.0 / 7.0,
+        6.0 / 7.0,
+      };
+      const float sizes[G_N_ELEMENTS (colors)] = {
+        1.0 / 7.0,
+        1.0 / 7.0,
+        1.0 / 7.0,
+        1.0 / 7.0,
+        1.0 / 7.0,
+        1.0 / 7.0,
+        1.0 / 7.0,
+      };
+      append_striped_flag (snapshot, colors, offsets, sizes, G_N_ELEMENTS (colors), bounds);
+    }
   else
     g_warning ("Invalid pride flag id \"%s\"", name);
 }


### PR DESCRIPTION
This commit adds the disability flag, as described here (https://en.wikipedia.org/wiki/Disability_flag) as the optional theme for the global progress bar.

Duplicate of #824, since it was closed by some GitHub Pull App syncing shenangins.