### PR TITLE
Add "only show verified" option

### DIFF
--- a/data/io.github.kolunmi.Bazaar.gschema.xml
+++ b/data/io.github.kolunmi.Bazaar.gschema.xml
@@ -16,6 +16,11 @@
       <summary>Show Only Flathub Content</summary>
       <description>Hide applications which do not originate from Flathub</description>
     </key>
+    <key name="show-only-verified" type="b">
+      <default>false</default>
+      <summary>Show Only Verified Content</summary>
+      <description>Hide applications which are not verified on Flathub</description>
+    </key>
     <key name="search-debounce" type="b">
       <default>true</default>
       <summary>Debounce Search Inputs</summary>

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -2086,6 +2086,7 @@ show_hide_app_setting_changed (BzApplication *self,
   bz_state_info_set_hide_eol (self->state, g_settings_get_boolean (self->settings, "hide-eol"));
   bz_state_info_set_show_only_foss (self->state, g_settings_get_boolean (self->settings, "show-only-foss"));
   bz_state_info_set_show_only_flathub (self->state, g_settings_get_boolean (self->settings, "show-only-flathub"));
+  bz_state_info_set_show_only_verified (self->state, g_settings_get_boolean (self->settings, "show-only-verified"));
 
   gtk_filter_changed (GTK_FILTER (self->group_filter), GTK_FILTER_CHANGE_DIFFERENT);
   gtk_filter_changed (GTK_FILTER (self->appid_filter), GTK_FILTER_CHANGE_DIFFERENT);
@@ -2595,6 +2596,15 @@ init_service_struct (BzApplication *self,
       G_CALLBACK (show_hide_app_setting_changed),
       self);
 
+  bz_state_info_set_show_only_verified (
+    self->state,
+    g_settings_get_boolean (self->settings, "show-only-verified"));
+  g_signal_connect_swapped (
+      self->settings,
+      "changed::show-only-verified",
+      G_CALLBACK (show_hide_app_setting_changed),
+      self);
+
   self->blocklist_regexes = g_ptr_array_new_with_free_func (
       (GDestroyNotify) g_ptr_array_unref);
   self->blocklists_provider = bz_content_provider_new ();
@@ -2937,6 +2947,9 @@ validate_group_for_ui (BzApplication *self,
     return FALSE;
   if (bz_state_info_get_show_only_flathub (self->state) &&
       !bz_entry_group_get_is_flathub (group))
+    return FALSE;
+  if (bz_state_info_get_show_only_verified (self->state) &&
+      !bz_entry_group_get_is_verified (group))
     return FALSE;
 
   id = bz_entry_group_get_id (group);

--- a/src/bz-preferences-dialog.blp
+++ b/src/bz-preferences-dialog.blp
@@ -32,6 +32,11 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
         subtitle: _("Limit search and browse results to applications only available on Flathub");
       }
 
+      Adw.SwitchRow only_verified_switch {
+        title: _("Verified Results Only");
+        subtitle: _("Hide results that are not verified on Flathub");
+      }
+
       Adw.SwitchRow hide_eol_switch {
         title: _("Hide EOL Apps");
         subtitle: _("Hide apps which are no longer supported by their developers");

--- a/src/bz-preferences-dialog.c
+++ b/src/bz-preferences-dialog.c
@@ -59,6 +59,7 @@ struct _BzPreferencesDialog
   /* Template widgets */
   AdwSwitchRow *only_foss_switch;
   AdwSwitchRow *only_flathub_switch;
+  AdwSwitchRow *only_verified_switch;
   AdwSwitchRow *search_debounce_switch;
   GtkFlowBox   *flag_buttons_box;
   AdwSwitchRow *hide_eol_switch;
@@ -168,6 +169,10 @@ bind_settings (BzPreferencesDialog *self)
                    self->only_flathub_switch, "active",
                    G_SETTINGS_BIND_DEFAULT);
 
+  g_settings_bind (self->settings, "show-only-verified",
+                   self->only_verified_switch, "active",
+                   G_SETTINGS_BIND_DEFAULT);
+
   g_settings_bind (self->settings, "search-debounce",
                    self->search_debounce_switch, "active",
                    G_SETTINGS_BIND_DEFAULT);
@@ -196,6 +201,7 @@ bz_preferences_dialog_class_init (BzPreferencesDialogClass *klass)
 
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, only_foss_switch);
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, only_flathub_switch);
+  gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, only_verified_switch);
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, search_debounce_switch);
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, flag_buttons_box);
   gtk_widget_class_bind_template_child (widget_class, BzPreferencesDialog, hide_eol_switch);

--- a/src/bz-search-widget.c
+++ b/src/bz-search-widget.c
@@ -518,6 +518,11 @@ bz_search_widget_set_state (BzSearchWidget *self,
           "notify::show-only-flathub",
           G_CALLBACK (invalidating_state_prop_changed),
           self);
+      g_signal_connect_swapped (
+          state,
+          "notify::show-only-verified",
+          G_CALLBACK (invalidating_state_prop_changed),
+          self);
 
       g_object_get (
           state,

--- a/src/bz-state-info.txt
+++ b/src/bz-state-info.txt
@@ -46,6 +46,7 @@ property=search_engine BzSearchEngine BZ_TYPE_SEARCH_ENGINE object
 property=settings GSettings G_TYPE_SETTINGS object
 property=show_only_flathub gboolean G_TYPE_BOOLEAN boolean
 property=show_only_foss gboolean G_TYPE_BOOLEAN boolean
+property=show_only_verified gboolean G_TYPE_BOOLEAN boolean
 property=syncing gboolean G_TYPE_BOOLEAN boolean
 property=transaction_manager BzTransactionManager BZ_TYPE_TRANSACTION_MANAGER object
 property=txt_blocklists GListModel G_TYPE_LIST_MODEL object


### PR DESCRIPTION
Some users prefer to only install verified apps. This filter option caters to that preference and was also easy to implement given our current filter mechanism.

I might also add mobile filtering, but I need to think of some way to only show this option on mobile to reduce preference clutter where possible.

<img width="1335" height="912" alt="image" src="https://github.com/user-attachments/assets/45513c0e-f5bb-457b-8bad-463764931cd2" />
