### PR TITLE
Make installed badge look better with Flathub style

### DIFF
--- a/src/bz-app-tile.blp
+++ b/src/bz-app-tile.blp
@@ -73,7 +73,7 @@ template $BzAppTile: Button {
           halign: start;
           spacing: 4;
           visible: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable) as <bool>) as <bool>;
-          styles ["small-pill", "installed-pill", "success"]
+          styles ["small-pill", "installed-pill"]
 
           Image {
             icon-name: "app-installed-symbolic";

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -252,9 +252,17 @@ button.context-tile:active .lozenge {
 
 .installed-pill {
 	background-color: alpha(@success_bg_color, 0.15);
+	color: @success_color;
 	font-weight: 500;
 	font-size: 0.9em;
  	padding: 2px 7px 2px 4.5px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .flathub .installed-pill {
+    background-color: alpha(@window_fg_color, 0.10);
+    color: alpha(@window_fg_color, 0.75);
+  }
 }
 
 .download-size-pill{


### PR DESCRIPTION
The green clashed to much with the purples of the Flathub page in dark mode.

<img width="721" height="323" alt="image" src="https://github.com/user-attachments/assets/31d63ed7-69a7-4691-b543-3d6d7debe73c" />
