### PR TITLE
Show app page instead of search page when using search provider

### DIFF
--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -629,6 +629,28 @@ bz_application_search_action (GSimpleAction *action,
 }
 
 static void
+bz_application_show_app_id_action (GSimpleAction *action,
+                                   GVariant      *parameter,
+                                   gpointer       user_data)
+{
+  BzApplication *self = user_data;
+  GtkWindow     *window = NULL;
+  const char    *app_id = NULL;
+
+  g_assert (BZ_IS_APPLICATION (self));
+
+  window = gtk_application_get_active_window (GTK_APPLICATION (self));
+  if (window == NULL)
+    window = new_window (self);
+
+  if (parameter != NULL)
+    {
+      app_id = g_variant_get_string (parameter, NULL);
+      bz_window_show_app_id (BZ_WINDOW (window), app_id);
+    }
+}
+
+static void
 bz_application_sync_remotes_action (GSimpleAction *action,
                                     GVariant      *parameter,
                                     gpointer       user_data)
@@ -791,6 +813,7 @@ static const GActionEntry app_actions[] = {
   {               "about",               bz_application_about_action, NULL },
   {        "sync-remotes",        bz_application_sync_remotes_action, NULL },
   {              "search",              bz_application_search_action,  "s" },
+  {         "show-app-id",         bz_application_show_app_id_action,  "s" },
   { "toggle-transactions", bz_application_toggle_transactions_action, NULL },
   {              "donate",              bz_application_donate_action, NULL },
   {            "flatseal",            bz_application_flatseal_action, NULL },

--- a/src/bz-gnome-shell-search-provider.c
+++ b/src/bz-gnome-shell-search-provider.c
@@ -241,7 +241,7 @@ activate_result (BzShellSearchProvider2     *skeleton,
 {
   g_action_group_activate_action (
       G_ACTION_GROUP (g_application_get_default ()),
-      "search",
+      "show-app-id",
       g_variant_new ("s", result));
 
   bz_shell_search_provider2_complete_activate_result (skeleton, invocation);
@@ -260,7 +260,7 @@ launch_search (BzShellSearchProvider2     *skeleton,
   string = g_strjoinv (" ", terms);
   g_action_group_activate_action (
       G_ACTION_GROUP (g_application_get_default ()),
-      "search",
+      "show-app-id",
       g_variant_new ("s", string));
 
   bz_shell_search_provider2_complete_launch_search (skeleton, invocation);

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -344,6 +344,23 @@ installed_page_show_cb (BzWindow   *self,
     bz_window_show_group (self, group);
 }
 
+void
+bz_window_show_app_id (BzWindow   *self,
+                       const char *app_id)
+{
+  g_autoptr (BzEntryGroup) group = NULL;
+
+  g_return_if_fail (BZ_IS_WINDOW (self));
+  g_return_if_fail (app_id != NULL);
+
+  group = bz_application_map_factory_convert_one (
+      bz_state_info_get_application_factory (self->state),
+      gtk_string_object_new (app_id));
+
+  if (group != NULL)
+    bz_window_show_group (self, group);
+}
+
 static void
 page_toggled_cb (BzWindow       *self,
                  GParamSpec     *pspec,

--- a/src/bz-window.h
+++ b/src/bz-window.h
@@ -51,6 +51,10 @@ bz_window_show_group (BzWindow     *self,
                       BzEntryGroup *group);
 
 void
+bz_window_show_app_id (BzWindow     *self,
+                       const char *app_id);
+
+void
 bz_window_push_page(BzWindow *self,
                     AdwNavigationPage *page);
 


### PR DESCRIPTION
Added a new action to show an entry group on the full view with a specific app ID instead of just searching for that app ID.

I have changed it for the GNOME Shell search provider, but I do not know how to do it for the KRunner plugin. However, it should not break anything and it should be as simple as changing the used action name.

[Screencast From 2025-12-25 21-28-13.webm](https://github.com/user-attachments/assets/d743e8db-d6e2-4319-b7ab-9f5f771eb1c3)
