### PR TITLE
Make search 2 columns on mobile

### DIFF
--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -565,7 +565,7 @@ window.flathub {
 /* Category buttons styling modified from GNOME Software*/
 .category-tile {
   font-weight: 700;
-  font-size: 14pt;
+  font-size: 13pt;
   color: white;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
   padding-left: 32px;


### PR DESCRIPTION
"Trending" was slightly too long causing a 1 column to appear on mobile

<img width="410" height="805" alt="image" src="https://github.com/user-attachments/assets/7dccb46f-7689-4647-befa-30046b045db3" />
