### PR TITLE
Hide screenshot box for apps without any screenshots

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -554,7 +554,10 @@ template $BzFullView: Adw.Bin {
                     $BzScreenshotsCarousel screenshots {
                       vexpand: true;
                       hexpand: true;
-                      visible: bind template.ui-entry as <$BzResult>.resolved as <bool>;
+                      visible: bind $logical_and(
+                        template.ui-entry as <$BzResult>.resolved as <bool>,
+                        $invert_boolean($is_empty(template.ui-entry as <$BzResult>.object as <$BzEntry>.screenshot-paintables) as <bool>) as <bool>
+                      ) as <bool>;
                       clicked => $screenshot_clicked_cb() swapped;
                       light-accent-color: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.light-accent-color;
                       dark-accent-color: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.dark-accent-color;

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -236,6 +236,15 @@ is_null (gpointer object,
 }
 
 static gboolean
+is_empty (gpointer    object,
+          GListModel *model)
+{
+  if (model == NULL)
+    return TRUE;
+  return g_list_model_get_n_items (model) == 0;
+}
+
+static gboolean
 logical_and (gpointer object,
              gboolean value1,
              gboolean value2)
@@ -1152,6 +1161,7 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, is_zero);
   gtk_widget_class_bind_template_callback (widget_class, is_positive);
   gtk_widget_class_bind_template_callback (widget_class, is_null);
+  gtk_widget_class_bind_template_callback (widget_class, is_empty);
   gtk_widget_class_bind_template_callback (widget_class, logical_and);
   gtk_widget_class_bind_template_callback (widget_class, is_longer);
   gtk_widget_class_bind_template_callback (widget_class, bool_to_string);


### PR DESCRIPTION
Also looked into hiding the placeholder app icon, but that didn't look too hot.

<img width="1327" height="987" alt="image" src="https://github.com/user-attachments/assets/297dfc1e-290f-424b-8d9e-81c802f31893" />
