### PR TITLE
(UI) Remove dark mode Flathub styling

### DIFF
--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -227,7 +227,6 @@ template $BzWindow: Adw.ApplicationWindow {
           content: Adw.ToastOverlay toasts {
             child: Adw.NavigationView navigation_view {
               pop-on-escape: false;
-              notify::visible-page => $visible_page_changed_cb(template);
 
               Adw.NavigationPage {
                 tag: "main";
@@ -266,7 +265,6 @@ template $BzWindow: Adw.ApplicationWindow {
                       name: "main";
 
                       child: Adw.ViewStack main_view_stack {
-                        notify::visible-child-name => $main_view_stack_changed_cb(template);
 
                         Adw.ViewStackPage {
                           name: "browse";

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -370,55 +370,6 @@ page_toggled_cb (BzWindow       *self,
 }
 
 static void
-update_flathub_style (BzWindow *self)
-{
-  AdwNavigationPage *visible_page = NULL;
-  const char        *page_tag     = NULL;
-  const char        *stack_page   = NULL;
-
-  visible_page = adw_navigation_view_get_visible_page (self->navigation_view);
-
-  if (visible_page != NULL)
-    {
-      page_tag = adw_navigation_page_get_tag (visible_page);
-
-      if (page_tag != NULL && strstr (page_tag, "flathub") != NULL)
-        {
-          gtk_widget_add_css_class (GTK_WIDGET (self), "flathub");
-          return;
-        }
-
-      if (g_strcmp0 (page_tag, "main") == 0)
-        {
-          stack_page = adw_view_stack_get_visible_child_name (self->main_view_stack);
-          if (g_strcmp0 (stack_page, "flathub") == 0)
-            {
-              gtk_widget_add_css_class (GTK_WIDGET (self), "flathub");
-              return;
-            }
-        }
-    }
-
-  gtk_widget_remove_css_class (GTK_WIDGET (self), "flathub");
-}
-
-static void
-visible_page_changed_cb (BzWindow          *self,
-                         GParamSpec        *pspec,
-                         AdwNavigationView *navigation_view)
-{
-  update_flathub_style (self);
-}
-
-static void
-main_view_stack_changed_cb (BzWindow     *self,
-                            GParamSpec   *pspec,
-                            AdwViewStack *stack)
-{
-  update_flathub_style (self);
-}
-
-static void
 browse_flathub_cb (BzWindow      *self,
                    BzCuratedView *widget)
 {
@@ -647,8 +598,6 @@ bz_window_class_init (BzWindowClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, update_cb);
   gtk_widget_class_bind_template_callback (widget_class, update_amount_tooltip);
   gtk_widget_class_bind_template_callback (widget_class, transactions_clear_cb);
-  gtk_widget_class_bind_template_callback (widget_class, visible_page_changed_cb);
-  gtk_widget_class_bind_template_callback (widget_class, main_view_stack_changed_cb);
   gtk_widget_class_bind_template_callback (widget_class, browse_flathub_cb);
   gtk_widget_class_bind_template_callback (widget_class, open_search_cb);
   gtk_widget_class_bind_template_callback (widget_class, format_progress);

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -165,6 +165,11 @@
 	--accent-bg-color: @window_fg_color;
 }
 
+.flathub {
+	--accent-color: alpha(@window_fg_color,0.75);
+	--accent-bg-color: @window_fg_color;
+}
+
 @media (prefers-color-scheme: dark) {
   .flathub {
     --accent-color: alpha(#fafafa,0.75);
@@ -258,11 +263,9 @@ button.context-tile:active .lozenge {
  	padding: 2px 7px 2px 4.5px;
 }
 
-@media (prefers-color-scheme: dark) {
-  .flathub .installed-pill {
-    background-color: alpha(@window_fg_color, 0.10);
-    color: alpha(@window_fg_color, 0.75);
-  }
+.sp-section .installed-pill {
+  background-color: alpha(@window_fg_color, 0.10);
+  color: alpha(@window_fg_color, 0.75);
 }
 
 .download-size-pill{
@@ -404,35 +407,6 @@ window,
 headerbar,
 .global-search {
   transition: background-color 0.2s ease;
-}
-
-.flathub {
-  --flathub-bg-hue: 301.44;
-}
-
-.flathub .global-search,
-window.flathub {
-  background-color: oklch(from var(--window-bg-color) l calc(c * 4) var(--flathub-bg-hue));
-}
-
-.flathub .toplevel-headerbar {
-  background-color: oklch(from var(--window-bg-color) l calc(c * 4) var(--flathub-bg-hue));
-}
-
-.flathub .sidebar-pane {
-  background-color: oklch(from var(--sidebar-bg-color) l calc(c * 4) var(--flathub-bg-hue));
-}
-
-.flathub banner  > * > * {
-  background-color: oklch(from var(--card-bg-color) l calc(c * 4) var(--flathub-bg-hue));
-}
-
-.flathub-lotion {
-  color: #fafafa;
-}
-
-.flathub-gunmetal {
-  color:#251f32;
 }
 
 .header-osd windowcontrols button image {


### PR DESCRIPTION
Reasons:

- It’s kind of weird to have a different color palette on just one page.
- The layout of the Flathub page now more closely matches the Flathub site, so we don’t need to be superficial anymore to make the connection obvious.
- It caused the full view to lag when opening from the Flathub page.
- It looks kind of weird with the new icon.
- Its easier to maintain.

Fixes #750 
Fixes #700
