### PR TITLE
i18n(el): fix translator credits  update translator name

### DIFF
--- a/po/el.po
+++ b/po/el.po
@@ -591,7 +591,7 @@ msgstr "Adam Masciola"
 #. Translators: Put one translator per line, in the form NAME <EMAIL>, YEAR1, YEAR2
 #: src/bz-application.c:685
 msgid "translator-credits"
-msgstr "μεταφραστής-συντελεστές"
+msgstr "Xarishark-Zacharias Xenakis"
 
 #: src/bz-application.c:749
 msgid "Logged Out Successfully!"


### PR DESCRIPTION
Corrects the translator credits entry in [el.po] to reflect the correct name (Xarishark-Zacharias Xenakis).