### PR TITLE
Rework safety mechanisms

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -102,6 +102,7 @@ src/bz-share-list.c
 src/bz-stats-dialog.blp
 src/bz-stats-dialog.c
 src/bz-tag-list.c
+src/bz-transaction-dialog.c
 src/bz-transaction-manager.c
 src/bz-transaction-view.blp
 src/bz-transaction-view.c

--- a/src/bz-app-permissions.c
+++ b/src/bz-app-permissions.c
@@ -215,6 +215,42 @@ bz_filesystem_path_to_display_string (const BzFilesystemPath *path)
     }
 }
 
+const char *
+bz_filesystem_path_to_icon_name (const BzFilesystemPath *path)
+{
+  switch (path->type)
+    {
+    case BZ_FILESYSTEM_PATH_SYSTEM_ROOT:
+      return "drive-harddisk-symbolic";
+    case BZ_FILESYSTEM_PATH_HOST_OS:
+      return "computer-symbolic";
+    case BZ_FILESYSTEM_PATH_HOST_ETC:
+      return "emblem-system-symbolic";
+    case BZ_FILESYSTEM_PATH_XDG_DESKTOP:
+      return "user-desktop-symbolic";
+    case BZ_FILESYSTEM_PATH_XDG_DOCUMENTS:
+      return "folder-documents-symbolic";
+    case BZ_FILESYSTEM_PATH_XDG_MUSIC:
+      return "folder-music-symbolic";
+    case BZ_FILESYSTEM_PATH_XDG_PICTURES:
+      return "folder-pictures-symbolic";
+    case BZ_FILESYSTEM_PATH_XDG_PUBLIC_SHARE:
+      return "folder-publicshare-symbolic";
+    case BZ_FILESYSTEM_PATH_XDG_VIDEOS:
+      return "folder-videos-symbolic";
+    case BZ_FILESYSTEM_PATH_XDG_CONFIG:
+      return "emblem-system-symbolic";
+    case BZ_FILESYSTEM_PATH_HOME_SUBDIR:
+    case BZ_FILESYSTEM_PATH_XDG_TEMPLATES:
+    case BZ_FILESYSTEM_PATH_XDG_CACHE:
+    case BZ_FILESYSTEM_PATH_XDG_DATA:
+    case BZ_FILESYSTEM_PATH_XDG_RUN:
+    case BZ_FILESYSTEM_PATH_CUSTOM:
+    default:
+      return "folder-symbolic";
+    }
+}
+
 BzBusPolicy *
 bz_bus_policy_new (GBusType              bus_type,
                    const char           *bus_name,

--- a/src/bz-app-permissions.h
+++ b/src/bz-app-permissions.h
@@ -107,66 +107,93 @@ GType bz_safety_rating_get_type (void) G_GNUC_CONST;
 GType bz_filesystem_path_type_get_type (void) G_GNUC_CONST;
 GType bz_bus_policy_permission_get_type (void) G_GNUC_CONST;
 
-BzFilesystemPath *bz_filesystem_path_new (BzFilesystemPathType type,
-                                          const char          *subpath);
-void              bz_filesystem_path_free (BzFilesystemPath *self);
-char             *bz_filesystem_path_to_display_string (const BzFilesystemPath *path);
+BzFilesystemPath *
+bz_filesystem_path_new (BzFilesystemPathType type,
+                        const char          *subpath);
+void
+bz_filesystem_path_free (BzFilesystemPath *self);
 
-BzBusPolicy *bz_bus_policy_new (GBusType              bus_type,
-                                const char           *bus_name,
-                                BzBusPolicyPermission permission);
-void         bz_bus_policy_free (BzBusPolicy *self);
+char *
+bz_filesystem_path_to_display_string (const BzFilesystemPath *path);
+
+const char *
+bz_filesystem_path_to_icon_name (const BzFilesystemPath *path);
+
+BzBusPolicy *
+bz_bus_policy_new (GBusType              bus_type,
+                   const char           *bus_name,
+                   BzBusPolicyPermission permission);
+
+void
+bz_bus_policy_free (BzBusPolicy *self);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (BzFilesystemPath, bz_filesystem_path_free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (BzBusPolicy, bz_bus_policy_free)
 
-BzAppPermissions *bz_app_permissions_new (void);
+BzAppPermissions *
+bz_app_permissions_new (void);
 
-BzAppPermissions *bz_app_permissions_new_from_metadata (GKeyFile *keyfile,
-                                                        GError  **error);
+BzAppPermissions *
+bz_app_permissions_new_from_metadata (GKeyFile *keyfile,
+                                      GError  **error);
 
-void bz_app_permissions_seal (BzAppPermissions *self);
+void
+bz_app_permissions_seal (BzAppPermissions *self);
 
-gboolean bz_app_permissions_is_sealed (BzAppPermissions *self);
+gboolean
+bz_app_permissions_is_sealed (BzAppPermissions *self);
 
-gboolean bz_app_permissions_is_empty (BzAppPermissions *self);
+gboolean
+bz_app_permissions_is_empty (BzAppPermissions *self);
 
-void bz_app_permissions_set_flags (BzAppPermissions     *self,
-                                   BzAppPermissionsFlags flags);
+void
+bz_app_permissions_set_flags (BzAppPermissions     *self,
+                              BzAppPermissionsFlags flags);
 
-BzAppPermissionsFlags bz_app_permissions_get_flags (BzAppPermissions *self);
+BzAppPermissionsFlags
+bz_app_permissions_get_flags (BzAppPermissions *self);
 
-void bz_app_permissions_add_flag (BzAppPermissions     *self,
-                                  BzAppPermissionsFlags flags);
+void
+bz_app_permissions_add_flag (BzAppPermissions     *self,
+                             BzAppPermissionsFlags flags);
 
-void bz_app_permissions_remove_flag (BzAppPermissions     *self,
-                                     BzAppPermissionsFlags flags);
+void
+bz_app_permissions_remove_flag (BzAppPermissions     *self,
+                                BzAppPermissionsFlags flags);
 
-void bz_app_permissions_add_filesystem_read (BzAppPermissions    *self,
-                                             BzFilesystemPathType type,
-                                             const char          *subpath);
+void
+bz_app_permissions_add_filesystem_read (BzAppPermissions    *self,
+                                        BzFilesystemPathType type,
+                                        const char          *subpath);
 
-const GPtrArray *bz_app_permissions_get_filesystem_read (BzAppPermissions *self);
+const GPtrArray *
+bz_app_permissions_get_filesystem_read (BzAppPermissions *self);
 
-void bz_app_permissions_add_filesystem_full (BzAppPermissions    *self,
-                                             BzFilesystemPathType type,
-                                             const char          *subpath);
+void
+bz_app_permissions_add_filesystem_full (BzAppPermissions    *self,
+                                        BzFilesystemPathType type,
+                                        const char          *subpath);
 
-const GPtrArray *bz_app_permissions_get_filesystem_full (BzAppPermissions *self);
+const GPtrArray *
+bz_app_permissions_get_filesystem_full (BzAppPermissions *self);
 
-void bz_app_permissions_add_bus_policy (BzAppPermissions     *self,
-                                        GBusType              bus_type,
-                                        const char           *bus_name,
-                                        BzBusPolicyPermission permission);
+void
+bz_app_permissions_add_bus_policy (BzAppPermissions     *self,
+                                   GBusType              bus_type,
+                                   const char           *bus_name,
+                                   BzBusPolicyPermission permission);
 
-const BzBusPolicy *const *bz_app_permissions_get_bus_policies (BzAppPermissions *self,
-                                                               size_t           *out_n_bus_policies);
+const BzBusPolicy *const *
+bz_app_permissions_get_bus_policies (BzAppPermissions *self,
+                                     size_t           *out_n_bus_policies);
 
-void bz_app_permissions_serialize (BzAppPermissions *self,
-                                   GVariantBuilder  *builder);
+void
+bz_app_permissions_serialize (BzAppPermissions *self,
+                              GVariantBuilder  *builder);
 
-gboolean bz_app_permissions_deserialize (BzAppPermissions *self,
-                                         GVariant         *import,
-                                         GError          **error);
+gboolean
+bz_app_permissions_deserialize (BzAppPermissions *self,
+                                GVariant         *import,
+                                GError          **error);
 
 G_END_DECLS

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -341,8 +341,22 @@ template $BzFullView: Adw.Bin {
                             label: bind $get_safety_rating_label(template.ui-entry as <$BzResult>.object as <$BzEntry>) as <string>;
                             lozenge-style: bind $get_safety_rating_style(template.ui-entry as <$BzResult>.object as <$BzEntry>) as <string>;
 
-                            lozenge-child: Image {
-                              icon-name: bind $get_safety_rating_icon(template.ui-entry as <$BzResult>.object as <$BzEntry>) as <string>;
+                            lozenge-child: Box {
+                              spacing: 4;
+
+                              Image {
+                                icon-name: bind $get_safety_rating_icon(template.ui-entry as <$BzResult>.object as <$BzEntry>,0) as <string>;
+                                visible: bind $invert_boolean($is_empty_string($get_safety_rating_icon(template.ui-entry as <$BzResult>.object as <$BzEntry>,0) as <string>) as <bool>) as <bool>;
+                              }
+                              Image {
+                                icon-name: bind $get_safety_rating_icon(template.ui-entry as <$BzResult>.object as <$BzEntry>,1) as <string>;
+                                visible: bind $invert_boolean($is_empty_string($get_safety_rating_icon(template.ui-entry as <$BzResult>.object as <$BzEntry>,1) as <string>) as <bool>) as <bool>;
+                              }
+                              Image {
+                                icon-name: bind $get_safety_rating_icon(template.ui-entry as <$BzResult>.object as <$BzEntry>,2) as <string>;
+                                visible: bind $invert_boolean($is_empty_string($get_safety_rating_icon(template.ui-entry as <$BzResult>.object as <$BzEntry>,2) as <string>) as <bool>) as <bool>;
+                              }
+
                             };
                           }
                         }

--- a/src/bz-safety-calculator.h
+++ b/src/bz-safety-calculator.h
@@ -27,7 +27,14 @@
 
 G_BEGIN_DECLS
 
-GListModel  *bz_safety_calculator_analyze_entry (BzEntry *entry);
-BzImportance bz_safety_calculator_calculate_rating (BzEntry *entry);
+GListModel  *
+bz_safety_calculator_analyze_entry (BzEntry *entry);
+
+BzImportance
+bz_safety_calculator_calculate_rating (BzEntry *entry);
+
+char *
+bz_safety_calculator_get_top_icon (BzEntry *entry,
+                                   int      index);
 
 G_END_DECLS

--- a/src/bz-transaction-dialog.c
+++ b/src/bz-transaction-dialog.c
@@ -1,0 +1,447 @@
+/* bz-transaction-dialog.c
+ *
+ * Copyright 2026 Alexander Vanhee
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+
+#include "bz-error.h"
+#include "bz-safety-calculator.h"
+#include "bz-transaction-dialog.h"
+#include "bz-util.h"
+
+BzTransactionDialogResult *
+bz_transaction_dialog_result_new (void)
+{
+  return g_new0 (BzTransactionDialogResult, 1);
+}
+
+void
+bz_transaction_dialog_result_free (BzTransactionDialogResult *result)
+{
+  if (result == NULL)
+    return;
+
+  g_clear_object (&result->selected_entry);
+  g_free (result);
+}
+
+static gboolean
+should_skip_entry (BzEntry *entry,
+                   gboolean remove)
+{
+  gboolean is_installed;
+
+  if (bz_entry_is_holding (entry))
+    return TRUE;
+
+  is_installed = bz_entry_is_installed (entry);
+
+  return (!remove && is_installed) || (remove && !is_installed);
+}
+
+static GtkWidget *
+create_entry_radio_button (BzEntry    *entry,
+                           GtkWidget **out_radio)
+{
+  GtkWidget       *row;
+  GtkWidget       *radio;
+  g_autofree char *label;
+
+  label = g_strdup (bz_entry_get_unique_id (entry));
+
+  row = adw_action_row_new ();
+  adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row), label);
+
+  radio = gtk_check_button_new ();
+  gtk_widget_set_valign (radio, GTK_ALIGN_CENTER);
+  adw_action_row_add_prefix (ADW_ACTION_ROW (row), radio);
+  adw_action_row_set_activatable_widget (ADW_ACTION_ROW (row), radio);
+
+  if (out_radio != NULL)
+    *out_radio = radio;
+
+  return row;
+}
+
+static GPtrArray *
+create_entry_radio_buttons (AdwAlertDialog *alert,
+                            GListStore     *store,
+                            gboolean        remove)
+{
+  g_autoptr (GPtrArray) radios = NULL;
+  GtkWidget *container         = NULL;
+
+  container = gtk_box_new (GTK_ORIENTATION_VERTICAL, 12);
+
+  radios = g_ptr_array_new ();
+  if (store != NULL)
+    {
+      guint n_valid_entries = 0;
+
+      for (guint i = 0; i < g_list_model_get_n_items (G_LIST_MODEL (store));)
+        {
+          g_autoptr (BzEntry) entry = NULL;
+
+          entry = g_list_model_get_item (G_LIST_MODEL (store), i);
+          if (should_skip_entry (entry, remove))
+            {
+              g_list_store_remove (store, i);
+              continue;
+            }
+          n_valid_entries++;
+          i++;
+        }
+      if (n_valid_entries > 1)
+        {
+          GtkWidget      *listbox           = NULL;
+          GtkCheckButton *first_valid_radio = NULL;
+
+          listbox = gtk_list_box_new ();
+          gtk_list_box_set_selection_mode (GTK_LIST_BOX (listbox), GTK_SELECTION_NONE);
+          gtk_widget_add_css_class (listbox, "boxed-list");
+
+          for (guint i = 0; i < n_valid_entries; i++)
+            {
+              g_autoptr (BzEntry) entry = NULL;
+              GtkWidget *row            = NULL;
+              GtkWidget *radio          = NULL;
+
+              entry = g_list_model_get_item (G_LIST_MODEL (store), i);
+              row   = create_entry_radio_button (entry, &radio);
+              g_ptr_array_add (radios, radio);
+
+              if (first_valid_radio != NULL)
+                gtk_check_button_set_group (GTK_CHECK_BUTTON (radio), first_valid_radio);
+              else
+                {
+                  gtk_check_button_set_active (GTK_CHECK_BUTTON (radio), TRUE);
+                  first_valid_radio = (GtkCheckButton *) radio;
+                }
+
+              gtk_list_box_append (GTK_LIST_BOX (listbox), row);
+            }
+
+          gtk_box_append (GTK_BOX (container), listbox);
+        }
+    }
+
+  if (remove)
+    {
+      GtkWidget *listbox         = NULL;
+      GtkWidget *keep_data_row   = NULL;
+      GtkWidget *delete_data_row = NULL;
+      GtkWidget *keep_radio      = NULL;
+      GtkWidget *delete_radio    = NULL;
+
+      listbox = gtk_list_box_new ();
+      gtk_list_box_set_selection_mode (GTK_LIST_BOX (listbox), GTK_SELECTION_NONE);
+      gtk_widget_add_css_class (listbox, "boxed-list");
+
+      keep_data_row = adw_action_row_new ();
+      adw_preferences_row_set_title (ADW_PREFERENCES_ROW (keep_data_row), _ ("Keep Data"));
+      adw_action_row_set_subtitle (ADW_ACTION_ROW (keep_data_row), _ ("Allow restoring settings and content"));
+      keep_radio = gtk_check_button_new ();
+      gtk_widget_set_valign (keep_radio, GTK_ALIGN_CENTER);
+      gtk_check_button_set_active (GTK_CHECK_BUTTON (keep_radio), TRUE);
+      adw_action_row_add_prefix (ADW_ACTION_ROW (keep_data_row), keep_radio);
+      adw_action_row_set_activatable_widget (ADW_ACTION_ROW (keep_data_row), keep_radio);
+      gtk_list_box_append (GTK_LIST_BOX (listbox), keep_data_row);
+
+      delete_data_row = adw_action_row_new ();
+      adw_preferences_row_set_title (ADW_PREFERENCES_ROW (delete_data_row), _ ("Delete Data"));
+      adw_action_row_set_subtitle (ADW_ACTION_ROW (delete_data_row), _ ("Permanently remove app data to save space"));
+      delete_radio = gtk_check_button_new ();
+      gtk_widget_set_valign (delete_radio, GTK_ALIGN_CENTER);
+      gtk_check_button_set_group (GTK_CHECK_BUTTON (delete_radio), GTK_CHECK_BUTTON (keep_radio));
+      adw_action_row_add_prefix (ADW_ACTION_ROW (delete_data_row), delete_radio);
+      adw_action_row_set_activatable_widget (ADW_ACTION_ROW (delete_data_row), delete_radio);
+      gtk_list_box_append (GTK_LIST_BOX (listbox), delete_data_row);
+
+      g_ptr_array_add (radios, keep_radio);
+      g_ptr_array_add (radios, delete_radio);
+      gtk_box_append (GTK_BOX (container), listbox);
+    }
+
+  adw_alert_dialog_set_extra_child (alert, container);
+  return g_steal_pointer (&radios);
+}
+
+static void
+configure_install_dialog (AdwAlertDialog *alert,
+                          const char     *title,
+                          const char     *id)
+{
+  g_autofree char *heading = NULL;
+
+  heading = g_strdup_printf (_ ("Install %s?"), title);
+
+  adw_alert_dialog_set_heading (alert, heading);
+  adw_alert_dialog_set_body (alert, _ ("May install additional shared components"));
+
+  adw_alert_dialog_add_responses (alert,
+                                  "cancel", _ ("Cancel"),
+                                  "install", _ ("Install"),
+                                  NULL);
+
+  adw_alert_dialog_set_response_appearance (alert, "install", ADW_RESPONSE_SUGGESTED);
+  adw_alert_dialog_set_default_response (alert, "install");
+  adw_alert_dialog_set_close_response (alert, "cancel");
+}
+
+static void
+configure_remove_dialog (AdwAlertDialog *alert,
+                         const char     *title,
+                         const char     *id)
+{
+  g_autofree char *heading = NULL;
+
+  heading = g_strdup_printf (_ ("Remove %s?"), title);
+
+  adw_alert_dialog_set_heading (alert, heading);
+  adw_alert_dialog_set_body (
+      alert, g_strdup_printf (_ ("It will not be possible to use %s after it is uninstalled."), title));
+
+  adw_alert_dialog_add_responses (alert,
+                                  "cancel", _ ("Cancel"),
+                                  "remove", _ ("Remove"),
+                                  NULL);
+
+  adw_alert_dialog_set_response_appearance (alert, "remove", ADW_RESPONSE_DESTRUCTIVE);
+  adw_alert_dialog_set_default_response (alert, "remove");
+  adw_alert_dialog_set_close_response (alert, "cancel");
+}
+
+static void
+configure_high_risk_warning_dialog (AdwAlertDialog *alert,
+                                    const char     *title)
+{
+  g_autofree char *heading = NULL;
+  g_autofree char *body    = NULL;
+
+  heading = g_strdup_printf (_ ("“%s” is High Risk"), title);
+  body    = g_strdup (_ ("This app has full access to your system, including all "
+                            "<b>your files, browser history, saved passwords</b>, and "
+                            "more. It also has access to the internet, meaning it "
+                            "could send your data to outside parties.\n\n"
+                            "Because the app is proprietary, it can not be audited "
+                            "for what it does with these permissions."));
+
+  adw_alert_dialog_set_heading (alert, heading);
+  adw_alert_dialog_set_body (alert, body);
+  adw_alert_dialog_set_body_use_markup (alert, TRUE);
+  adw_alert_dialog_set_prefer_wide_layout (alert, TRUE);
+
+  adw_alert_dialog_add_responses (alert,
+                                  "cancel", _ ("Cancel"),
+                                  "install", _ ("Install Anyway"),
+                                  NULL);
+
+  adw_alert_dialog_set_response_appearance (alert, "install", ADW_RESPONSE_DESTRUCTIVE);
+  adw_alert_dialog_set_default_response (alert, "cancel");
+  adw_alert_dialog_set_close_response (alert, "cancel");
+}
+
+static gboolean
+is_entry_high_risk (BzEntry *entry)
+{
+  BzImportance rating;
+
+  g_return_val_if_fail (BZ_IS_ENTRY (entry), FALSE);
+
+  rating = bz_safety_calculator_calculate_rating (entry);
+  return rating == BZ_IMPORTANCE_IMPORTANT;
+}
+
+typedef struct
+{
+  GtkWidget    *parent;
+  BzEntry      *entry;
+  BzEntryGroup *group;
+  gboolean      remove;
+  gboolean      auto_confirm;
+} ShowDialogData;
+
+static void
+show_dialog_data_free (ShowDialogData *data)
+{
+  g_clear_object (&data->entry);
+  g_clear_object (&data->group);
+  g_free (data);
+}
+
+static DexFuture *
+show_dialog_fiber (ShowDialogData *data)
+{
+  g_autoptr (GError) local_error               = NULL;
+  g_autoptr (GListStore) store                 = NULL;
+  const char *title                            = NULL;
+  const char *id                               = NULL;
+  g_autoptr (AdwDialog) alert                  = NULL;
+  g_autoptr (AdwDialog) risk_alert             = NULL;
+  g_autoptr (GPtrArray) radios                 = NULL;
+  g_autofree char *dialog_response             = NULL;
+  g_autofree char *risk_response               = NULL;
+  g_autoptr (BzTransactionDialogResult) result = NULL;
+  g_autoptr (BzEntry) check_entry              = NULL;
+  gboolean is_high_risk                        = FALSE;
+
+  result = bz_transaction_dialog_result_new ();
+
+  if (data->group != NULL)
+    {
+      store = dex_await_object (bz_entry_group_dup_all_into_store (data->group), &local_error);
+      if (store == NULL)
+        {
+          bz_show_error_for_widget (data->parent, local_error->message);
+          return dex_future_new_for_error (g_steal_pointer (&local_error));
+        }
+      title = bz_entry_group_get_title (data->group);
+      id    = bz_entry_group_get_id (data->group);
+
+      if (g_list_model_get_n_items (G_LIST_MODEL (store)) > 0)
+        check_entry = g_list_model_get_item (G_LIST_MODEL (store), 0);
+    }
+  else
+    {
+      title       = bz_entry_get_title (data->entry);
+      id          = bz_entry_get_id (data->entry);
+      check_entry = g_object_ref (data->entry);
+    }
+
+  if (!data->remove && check_entry != NULL)
+    {
+      is_high_risk = is_entry_high_risk (check_entry);
+    }
+
+  if (is_high_risk)
+    {
+      risk_alert = g_object_ref_sink (adw_alert_dialog_new (NULL, NULL));
+      configure_high_risk_warning_dialog (ADW_ALERT_DIALOG (risk_alert), title);
+
+      adw_dialog_present (risk_alert, data->parent);
+      risk_response = dex_await_string (
+          bz_make_alert_dialog_future (ADW_ALERT_DIALOG (risk_alert)),
+          &local_error);
+
+      if (risk_response == NULL)
+        return dex_future_new_for_error (g_steal_pointer (&local_error));
+
+      if (g_strcmp0 (risk_response, "install") != 0)
+        {
+          result->confirmed = FALSE;
+          return dex_future_new_for_pointer (g_steal_pointer (&result));
+        }
+    }
+
+  alert = g_object_ref_sink (adw_alert_dialog_new (NULL, NULL));
+  if (data->remove)
+    configure_remove_dialog (ADW_ALERT_DIALOG (alert), title, id);
+  else
+    configure_install_dialog (ADW_ALERT_DIALOG (alert), title, id);
+
+  radios = create_entry_radio_buttons (ADW_ALERT_DIALOG (alert), store, data->remove);
+
+  if (!data->remove && data->auto_confirm && radios->len <= 1 && !is_high_risk)
+    {
+      dialog_response = g_strdup ("install");
+      g_ptr_array_set_size (radios, 0);
+      g_clear_object (&alert);
+    }
+  else if (data->remove && data->auto_confirm && radios->len <= 1)
+    {
+      dialog_response = g_strdup ("remove");
+      g_ptr_array_set_size (radios, 0);
+      g_clear_object (&alert);
+    }
+  else
+    {
+      adw_dialog_present (alert, data->parent);
+      dialog_response = dex_await_string (
+          bz_make_alert_dialog_future (ADW_ALERT_DIALOG (alert)),
+          &local_error);
+      if (dialog_response == NULL)
+        return dex_future_new_for_error (g_steal_pointer (&local_error));
+
+      if (data->remove && radios->len >= 2)
+        {
+          GtkCheckButton *delete_radio = g_ptr_array_index (radios, radios->len - 1);
+          result->delete_user_data     = gtk_check_button_get_active (delete_radio);
+        }
+    }
+
+  result->confirmed = (g_strcmp0 (dialog_response, "install") == 0) ||
+                      (g_strcmp0 (dialog_response, "remove") == 0);
+
+  if (!result->confirmed)
+    return dex_future_new_for_pointer (g_steal_pointer (&result));
+
+  if (data->group != NULL)
+    {
+      guint n_entries = g_list_model_get_n_items (G_LIST_MODEL (store));
+
+      for (guint i = 0; i < MIN (n_entries, radios->len); i++)
+        {
+          GtkCheckButton *check = g_ptr_array_index (radios, i);
+
+          if (gtk_check_button_get_active (check))
+            {
+              result->selected_entry = g_list_model_get_item (G_LIST_MODEL (store), i);
+              break;
+            }
+        }
+
+      if (result->selected_entry == NULL && n_entries > 0)
+        result->selected_entry = g_list_model_get_item (G_LIST_MODEL (store), 0);
+    }
+  else
+    {
+      result->selected_entry = g_object_ref (data->entry);
+    }
+
+  return dex_future_new_for_pointer (g_steal_pointer (&result));
+}
+
+DexFuture *
+bz_transaction_dialog_show (GtkWidget    *parent,
+                            BzEntry      *entry,
+                            BzEntryGroup *group,
+                            gboolean      remove,
+                            gboolean      auto_confirm)
+{
+  ShowDialogData *data;
+
+  g_return_val_if_fail (GTK_IS_WIDGET (parent), NULL);
+  g_return_val_if_fail (entry != NULL || group != NULL, NULL);
+
+  data               = g_new0 (ShowDialogData, 1);
+  data->parent       = parent;
+  data->entry        = entry ? g_object_ref (entry) : NULL;
+  data->group        = group ? g_object_ref (group) : NULL;
+  data->remove       = remove;
+  data->auto_confirm = auto_confirm;
+
+  return dex_scheduler_spawn (
+      dex_scheduler_get_default (),
+      0,
+      (DexFiberFunc) show_dialog_fiber,
+      data,
+      (GDestroyNotify) show_dialog_data_free);
+}

--- a/src/bz-transaction-dialog.h
+++ b/src/bz-transaction-dialog.h
@@ -1,0 +1,49 @@
+/* bz-transaction-dialog.h
+ *
+ * Copyright 2026 Alexander Vanhee
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "bz-entry-group.h"
+#include "bz-entry.h"
+#include <adwaita.h>
+
+G_BEGIN_DECLS
+
+typedef struct _BzTransactionDialogResult BzTransactionDialogResult;
+
+struct _BzTransactionDialogResult
+{
+  BzEntry *selected_entry;
+  gboolean delete_user_data;
+  gboolean confirmed;
+};
+
+BzTransactionDialogResult *bz_transaction_dialog_result_new (void);
+void                       bz_transaction_dialog_result_free (BzTransactionDialogResult *result);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (BzTransactionDialogResult, bz_transaction_dialog_result_free)
+
+DexFuture *bz_transaction_dialog_show (GtkWidget    *parent,
+                                       BzEntry      *entry,
+                                       BzEntryGroup *group,
+                                       gboolean      remove,
+                                       gboolean      auto_confirm);
+
+G_END_DECLS

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -38,6 +38,7 @@
 #include "bz-progress-bar.h"
 #include "bz-search-widget.h"
 #include "bz-transaction-manager.h"
+#include "bz-transaction-dialog.h"
 #include "bz-update-dialog.h"
 #include "bz-user-data-page.h"
 #include "bz-util.h"
@@ -106,25 +107,6 @@ static void
 update_dialog_response (BzUpdateDialog *dialog,
                         const char     *response,
                         BzWindow       *self);
-
-static void
-configure_install_dialog (AdwAlertDialog *alert,
-                          const char     *title,
-                          const char     *id);
-
-static void
-configure_remove_dialog (AdwAlertDialog *alert,
-                         const char     *title,
-                         const char     *id);
-
-static GPtrArray *
-create_entry_radio_buttons (AdwAlertDialog *alert,
-                            GListStore     *store,
-                            gboolean        remove);
-
-static GtkWidget *
-create_entry_radio_button (BzEntry    *entry,
-                           GtkWidget **out_radio);
 
 static DexFuture *
 transact (BzWindow  *self,
@@ -716,114 +698,47 @@ checking_for_updates_changed (BzWindow    *self,
 static DexFuture *
 transact_fiber (TransactData *data)
 {
-  g_autoptr (BzWindow) self             = NULL;
-  BzEntry      *entry                   = data->entry;
-  BzEntryGroup *group                   = data->group;
-  gboolean      remove                  = data->remove;
-  gboolean      auto_confirm            = data->auto_confirm;
-  GtkWidget    *source                  = data->source;
-  g_autoptr (GError) local_error        = NULL;
-  g_autoptr (GListStore) store          = NULL;
-  const char      *title                = NULL;
-  const char      *id                   = NULL;
-  g_autofree char *id_dup               = NULL;
-  g_autoptr (AdwDialog) alert           = NULL;
-  gboolean delete_user_data             = FALSE;
-  g_autoptr (GPtrArray) radios          = NULL;
-  g_autofree char *dialog_response      = NULL;
-  gboolean         should_install       = FALSE;
-  gboolean         should_remove        = FALSE;
+  g_autoptr (BzWindow) self = NULL;
+  g_autoptr (GError) local_error = NULL;
+  g_autoptr (BzTransactionDialogResult) dialog_result = NULL;
   g_autoptr (DexFuture) transact_future = NULL;
+  g_autofree char *id_dup = NULL;
 
   bz_weak_get_or_return_reject (self, data->self);
 
-  if (group != NULL)
-    {
-      store = dex_await_object (bz_entry_group_dup_all_into_store (group), &local_error);
-      if (store == NULL)
-        {
-          bz_show_error_for_widget (GTK_WIDGET (self), local_error->message);
-          return dex_future_new_for_error (g_steal_pointer (&local_error));
-        }
-      title = bz_entry_group_get_title (group);
-      id    = bz_entry_group_get_id (group);
-    }
+  // Get ID early before any async operations
+  if (data->group != NULL)
+    id_dup = g_strdup (bz_entry_group_get_id (data->group));
   else
-    {
-      title = bz_entry_get_title (entry);
-      id    = bz_entry_get_id (entry);
-    }
-  /* id may become invalid after awaiting */
-  id_dup = g_strdup (id);
+    id_dup = g_strdup (bz_entry_get_id (data->entry));
 
-  alert = g_object_ref_sink (adw_alert_dialog_new (NULL, NULL));
-  if (remove)
-    configure_remove_dialog (ADW_ALERT_DIALOG (alert), title, id);
-  else
-    configure_install_dialog (ADW_ALERT_DIALOG (alert), title, id);
-  id    = NULL;
-  title = NULL;
+  // Show the dialog
+  dialog_result = dex_await_pointer (
+      bz_transaction_dialog_show (
+          GTK_WIDGET (self),
+          data->entry,
+          data->group,
+          data->remove,
+          data->auto_confirm),
+      &local_error);
 
-  radios = create_entry_radio_buttons (ADW_ALERT_DIALOG (alert), store, remove);
-  if (!remove && auto_confirm && radios->len <= 1)
-    {
-      dialog_response = g_strdup (remove ? "remove" : "install");
-      g_ptr_array_set_size (radios, 0);
-      g_clear_object (&alert);
-    }
-  else
-    {
-      adw_dialog_present (alert, GTK_WIDGET (self));
-      dialog_response = dex_await_string (
-          bz_make_alert_dialog_future (ADW_ALERT_DIALOG (alert)),
-          &local_error);
-      if (dialog_response == NULL)
-        return dex_future_new_for_error (g_steal_pointer (&local_error));
-      if (remove && radios->len >= 2)
-        {
-          GtkCheckButton *delete_radio = g_ptr_array_index (radios, radios->len - 1);
-          delete_user_data             = gtk_check_button_get_active (delete_radio);
-        }
-    }
+  if (dialog_result == NULL)
+    return dex_future_new_for_error (g_steal_pointer (&local_error));
 
-  should_install = g_strcmp0 (dialog_response, "install") == 0;
-  should_remove  = g_strcmp0 (dialog_response, "remove") == 0;
-  if (!should_install && !should_remove)
+  if (!dialog_result->confirmed)
     return dex_future_new_false ();
 
-  if (group != NULL)
-    {
-      guint n_entries                    = 0;
-      g_autoptr (BzEntry) selected_entry = NULL;
-
-      n_entries = g_list_model_get_n_items (G_LIST_MODEL (store));
-      for (guint i = 0; i < MIN (n_entries, radios->len); i++)
-        {
-          GtkCheckButton *check = NULL;
-
-          check = g_ptr_array_index (radios, i);
-          if (gtk_check_button_get_active (check))
-            {
-              selected_entry = g_list_model_get_item (G_LIST_MODEL (store), i);
-              break;
-            }
-        }
-      if (selected_entry == NULL)
-        selected_entry = g_list_model_get_item (G_LIST_MODEL (store), 0);
-
-      transact_future = transact (self, selected_entry, should_remove, source);
-    }
-  else
-    transact_future = transact (self, entry, should_remove, source);
-  g_clear_pointer (&radios, g_ptr_array_unref);
+  // Perform the transaction
+  transact_future = transact (self, dialog_result->selected_entry, data->remove, data->source);
 
   if (!dex_await (g_steal_pointer (&transact_future), &local_error))
     return dex_future_new_for_error (g_steal_pointer (&local_error));
 
-  if (delete_user_data)
+  // Handle user data deletion
+  if (dialog_result->delete_user_data)
     {
-      if (group != NULL)
-        bz_entry_group_reap_user_data (group);
+      if (data->group != NULL)
+        bz_entry_group_reap_user_data (data->group);
       else
         dex_future_disown (bz_reap_user_data_dex (id_dup));
     }
@@ -1100,192 +1015,6 @@ try_transact (BzWindow     *self,
       bz_get_dex_stack_size (),
       (DexFiberFunc) transact_fiber,
       transact_data_ref (data), transact_data_unref));
-}
-
-static gboolean
-should_skip_entry (BzEntry *entry,
-                   gboolean remove)
-{
-  gboolean is_installed;
-
-  if (bz_entry_is_holding (entry))
-    return TRUE;
-
-  is_installed = bz_entry_is_installed (entry);
-
-  return (!remove && is_installed) || (remove && !is_installed);
-}
-
-static GtkWidget *
-create_entry_radio_button (BzEntry    *entry,
-                           GtkWidget **out_radio)
-{
-  GtkWidget       *row;
-  GtkWidget       *radio;
-  g_autofree char *label;
-
-  label = g_strdup (bz_entry_get_unique_id (entry));
-
-  row = adw_action_row_new ();
-  adw_preferences_row_set_title (ADW_PREFERENCES_ROW (row), label);
-
-  radio = gtk_check_button_new ();
-  gtk_widget_set_valign (radio, GTK_ALIGN_CENTER);
-  adw_action_row_add_prefix (ADW_ACTION_ROW (row), radio);
-  adw_action_row_set_activatable_widget (ADW_ACTION_ROW (row), radio);
-
-  if (out_radio != NULL)
-    *out_radio = radio;
-
-  return row;
-}
-
-static GPtrArray *
-create_entry_radio_buttons (AdwAlertDialog *alert,
-                            GListStore     *store,
-                            gboolean        remove)
-{
-  g_autoptr (GPtrArray) radios = NULL;
-  GtkWidget *container         = NULL;
-
-  container = gtk_box_new (GTK_ORIENTATION_VERTICAL, 12);
-
-  radios = g_ptr_array_new ();
-  if (store != NULL)
-    {
-      guint n_valid_entries = 0;
-
-      for (guint i = 0; i < g_list_model_get_n_items (G_LIST_MODEL (store));)
-        {
-          g_autoptr (BzEntry) entry = NULL;
-
-          entry = g_list_model_get_item (G_LIST_MODEL (store), i);
-          if (should_skip_entry (entry, remove))
-            {
-              g_list_store_remove (store, i);
-              continue;
-            }
-          n_valid_entries++;
-          i++;
-        }
-      if (n_valid_entries > 1)
-        {
-          GtkWidget      *listbox           = NULL;
-          GtkCheckButton *first_valid_radio = NULL;
-
-          listbox = gtk_list_box_new ();
-          gtk_list_box_set_selection_mode (GTK_LIST_BOX (listbox), GTK_SELECTION_NONE);
-          gtk_widget_add_css_class (listbox, "boxed-list");
-
-          for (guint i = 0; i < n_valid_entries; i++)
-            {
-              g_autoptr (BzEntry) entry = NULL;
-              GtkWidget *row            = NULL;
-              GtkWidget *radio          = NULL;
-
-              entry = g_list_model_get_item (G_LIST_MODEL (store), i);
-              row   = create_entry_radio_button (entry, &radio);
-              g_ptr_array_add (radios, radio);
-
-              if (first_valid_radio != NULL)
-                gtk_check_button_set_group (GTK_CHECK_BUTTON (radio), first_valid_radio);
-              else
-                {
-                  gtk_check_button_set_active (GTK_CHECK_BUTTON (radio), TRUE);
-                  first_valid_radio = (GtkCheckButton *) radio;
-                }
-
-              gtk_list_box_append (GTK_LIST_BOX (listbox), row);
-            }
-
-          gtk_box_append (GTK_BOX (container), listbox);
-        }
-    }
-
-  if (remove)
-    {
-      GtkWidget *listbox         = NULL;
-      GtkWidget *keep_data_row   = NULL;
-      GtkWidget *delete_data_row = NULL;
-      GtkWidget *keep_radio      = NULL;
-      GtkWidget *delete_radio    = NULL;
-
-      listbox = gtk_list_box_new ();
-      gtk_list_box_set_selection_mode (GTK_LIST_BOX (listbox), GTK_SELECTION_NONE);
-      gtk_widget_add_css_class (listbox, "boxed-list");
-
-      keep_data_row = adw_action_row_new ();
-      adw_preferences_row_set_title (ADW_PREFERENCES_ROW (keep_data_row), _ ("Keep Data"));
-      adw_action_row_set_subtitle (ADW_ACTION_ROW (keep_data_row), _ ("Allow restoring settings and content"));
-      keep_radio = gtk_check_button_new ();
-      gtk_widget_set_valign (keep_radio, GTK_ALIGN_CENTER);
-      gtk_check_button_set_active (GTK_CHECK_BUTTON (keep_radio), TRUE);
-      adw_action_row_add_prefix (ADW_ACTION_ROW (keep_data_row), keep_radio);
-      adw_action_row_set_activatable_widget (ADW_ACTION_ROW (keep_data_row), keep_radio);
-      gtk_list_box_append (GTK_LIST_BOX (listbox), keep_data_row);
-
-      delete_data_row = adw_action_row_new ();
-      adw_preferences_row_set_title (ADW_PREFERENCES_ROW (delete_data_row), _ ("Delete Data"));
-      adw_action_row_set_subtitle (ADW_ACTION_ROW (delete_data_row), _ ("Permanently remove app data to save space"));
-      delete_radio = gtk_check_button_new ();
-      gtk_widget_set_valign (delete_radio, GTK_ALIGN_CENTER);
-      gtk_check_button_set_group (GTK_CHECK_BUTTON (delete_radio), GTK_CHECK_BUTTON (keep_radio));
-      adw_action_row_add_prefix (ADW_ACTION_ROW (delete_data_row), delete_radio);
-      adw_action_row_set_activatable_widget (ADW_ACTION_ROW (delete_data_row), delete_radio);
-      gtk_list_box_append (GTK_LIST_BOX (listbox), delete_data_row);
-
-      g_ptr_array_add (radios, keep_radio);
-      g_ptr_array_add (radios, delete_radio);
-      gtk_box_append (GTK_BOX (container), listbox);
-    }
-
-  adw_alert_dialog_set_extra_child (alert, container);
-  return g_steal_pointer (&radios);
-}
-
-static void
-configure_install_dialog (AdwAlertDialog *alert,
-                          const char     *title,
-                          const char     *id)
-{
-  g_autofree char *heading = NULL;
-
-  heading = g_strdup_printf (_ ("Install %s?"), title);
-
-  adw_alert_dialog_set_heading (alert, heading);
-  adw_alert_dialog_set_body (alert, _ ("May install additional shared components"));
-
-  adw_alert_dialog_add_responses (alert,
-                                  "cancel", _ ("Cancel"),
-                                  "install", _ ("Install"),
-                                  NULL);
-
-  adw_alert_dialog_set_response_appearance (alert, "install", ADW_RESPONSE_SUGGESTED);
-  adw_alert_dialog_set_default_response (alert, "install");
-  adw_alert_dialog_set_close_response (alert, "cancel");
-}
-
-static void
-configure_remove_dialog (AdwAlertDialog *alert,
-                         const char     *title,
-                         const char     *id)
-{
-  g_autofree char *heading = NULL;
-
-  heading = g_strdup_printf (_ ("Remove %s?"), title);
-
-  adw_alert_dialog_set_heading (alert, heading);
-  adw_alert_dialog_set_body (
-      alert, g_strdup_printf (_ ("It will not be possible to use %s after it is uninstalled."), title));
-
-  adw_alert_dialog_add_responses (alert,
-                                  "cancel", _ ("Cancel"),
-                                  "remove", _ ("Remove"),
-                                  NULL);
-
-  adw_alert_dialog_set_response_appearance (alert, "remove", ADW_RESPONSE_DESTRUCTIVE);
-  adw_alert_dialog_set_default_response (alert, "remove");
-  adw_alert_dialog_set_close_response (alert, "cancel");
 }
 
 static void

--- a/src/meson.build
+++ b/src/meson.build
@@ -137,6 +137,7 @@ bz_sources = files(
   'bz-transaction-manager.c',
   'bz-transaction-view.c',
   'bz-transaction.c',
+  'bz-transaction-dialog.c',
   'bz-update-dialog.c',
   'bz-user-data-page.c',
   'bz-user-data-tile.c',


### PR DESCRIPTION
This PR tries to implement some changes from the "Context Tile Refresh" design document, mainly the icon set shown in the safety context tile based on requested permissions, and the “High Risk” dialog.

I moved the transaction dialog code to a new file to avoid cluttering the window file further, and also added some new icons for XDG folder permissions.

<img width="3240" height="1360" alt="image" src="https://github.com/user-attachments/assets/4f52a051-5367-473c-9d7d-f400015ec5d4" />

<img width="1213" height="1015" alt="Screenshot From 2026-01-03 18-37-50" src="https://github.com/user-attachments/assets/1ae08ccb-bcdc-400c-adb0-1a7dbc64f2a9" />

<img width="143" height="122" alt="image" src="https://github.com/user-attachments/assets/a4eec6e3-0fb7-4163-85f5-fdfe147620ef" />

<img width="143" height="122" alt="image" src="https://github.com/user-attachments/assets/05ca6336-8888-4b41-bb61-7976ae1d5bf9" />

<img width="143" height="122" alt="image" src="https://github.com/user-attachments/assets/908f0e9f-0266-468a-864e-4163e1eadd4a" />

<img width="143" height="122" alt="image" src="https://github.com/user-attachments/assets/566b808c-53de-4da7-bfeb-b4262b7eb9d8" />


