### PR TITLE
Remove the account menu button revealer

### DIFF
--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -326,20 +326,17 @@ template $BzWindow: Adw.ApplicationWindow {
 
                     Adw.HeaderBar top_header_bar {
                       [start]
-                      Revealer {
-                        reveal-child: bind template.state as <$BzStateInfo>.auth-state as <$BzAuthState>.authenticated;
-                        transition-type: slide_left;
-                        child: MenuButton {
-                          menu-model: account_menu;
-                          styles [
-                            "circular",
-                            "flat",
-                          ]
+                      MenuButton {
+                        visible: bind template.state as <$BzStateInfo>.auth-state as <$BzAuthState>.authenticated;
+                        menu-model: account_menu;
+                        styles [
+                          "circular",
+                          "flat",
+                        ]
 
-                          child: Adw.Avatar {
-                            size: 24;
-                            custom-image: bind template.state as <$BzStateInfo>.auth-state as <$BzAuthState>.paintable;
-                          };
+                        child: Adw.Avatar {
+                          size: 24;
+                          custom-image: bind template.state as <$BzStateInfo>.auth-state as <$BzAuthState>.paintable;
                         };
                       }
 


### PR DESCRIPTION
The revealer caused the update button to have some ugly spacing at the start. And the animation also looked kinda weird in hindsight.

<img width="138" height="118" alt="image" src="https://github.com/user-attachments/assets/c8f1f474-83a5-4301-92f8-d1653f06f283" />
