### PR TITLE
Reremove subtitle for non spotlight categories

### DIFF
--- a/src/bz-apps-page.c
+++ b/src/bz-apps-page.c
@@ -501,7 +501,7 @@ bz_apps_page_new_from_category (BzFlathubCategory *category)
   else
     apps_page = create_standard_page (title, model, carousel_model);
 
-  if (total_entries > 0)
+  if (total_entries > 0 && !bz_flathub_category_get_is_spotlight (category))
     {
       subtitle = g_strdup_printf (_ ("%d Applications"), total_entries);
       bz_apps_page_set_subtitle (BZ_APPS_PAGE (apps_page), subtitle);


### PR DESCRIPTION
Categories like “Trending” incorrectly showed this “1000 applications” subtitle. I believe this bug appeared after the app pages rework.

<img width="183" height="100" alt="image" src="https://github.com/user-attachments/assets/09dd8993-3c7f-4795-9bf8-3fe1e6e0aafb" />
