### PR TITLE
(UX) Improve how app different app sizes are displayed

### DIFF
--- a/src/bz-app-size-dialog.blp
+++ b/src/bz-app-size-dialog.blp
@@ -76,6 +76,29 @@ template $BzAppSizeDialog: Adw.Dialog {
             title: _("Installed Size");
             subtitle: _("Size on Disk");
           }
+
+          Adw.ActionRow {
+            visible: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.user-data-size ) as <bool>) as <bool>;
+
+            [prefix]
+            Label {
+              label: bind $format_size(template.group as <$BzEntryGroup>.user-data-size) as <string>;
+              use-markup: true;
+              valign: center;
+              width-request: 90;
+              margin-top: 8;
+              margin-bottom: 8;
+
+              styles [
+                "circular-lozenge",
+                "title-4",
+                "grey",
+              ]
+            }
+
+            title: _("User Data Size");
+            subtitle: _("Caches, settings, and other app data");
+          }
         }
       };
     };

--- a/src/bz-app-size-dialog.c
+++ b/src/bz-app-size-dialog.c
@@ -120,6 +120,13 @@ format_size (gpointer object, guint64 value)
   return g_strdup (size_str);
 }
 
+static gboolean
+is_zero (gpointer object,
+         int      value)
+{
+  return value == 0;
+}
+
 static void
 bz_app_size_dialog_class_init (BzAppSizeDialogClass *klass)
 {
@@ -144,6 +151,7 @@ bz_app_size_dialog_class_init (BzAppSizeDialogClass *klass)
   gtk_widget_class_set_template_from_resource (widget_class, "/io/github/kolunmi/Bazaar/bz-app-size-dialog.ui");
   gtk_widget_class_bind_template_callback (widget_class, format_size);
   gtk_widget_class_bind_template_callback (widget_class, is_null);
+  gtk_widget_class_bind_template_callback (widget_class, is_zero);
   gtk_widget_class_bind_template_callback (widget_class, invert_boolean);
 }
 

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -297,7 +297,7 @@ template $BzFullView: Adw.Bin {
                           homogeneous: true;
 
                           $BzContextTile download_size_tile {
-                            label: _("Size");
+                            label: bind $get_size_label($is_zero(template.entry-group as <$BzEntryGroup>.removable) as <bool>) as <string>;
                             has-tooltip: true;
                             tooltip-text: bind $format_size_tooltip(template.ui-entry as <$BzResult>.object as <$BzEntry>.size) as <string>;
                             lozenge-style: "grey";
@@ -305,7 +305,7 @@ template $BzFullView: Adw.Bin {
 
                             lozenge-child: Label {
                               justify: center;
-                              label: bind $format_size(template.ui-entry as <$BzResult>.object as <$BzEntry>.size) as <string>;
+                              label: bind $format_size($get_size_type(template.ui-entry as <$BzResult>.object as <$BzEntry>, $is_zero(template.entry-group as <$BzEntryGroup>.removable) as <bool>) as <int>) as <string>;
                               lines: 3;
                               ellipsize: end;
                               halign: center;

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -356,6 +356,24 @@ format_size (gpointer object, guint64 value)
   return g_strdup (size_str);
 }
 
+static  char *
+get_size_label (gpointer object,
+                gboolean is_installable)
+{
+   return g_strdup (is_installable ? _("Download") : _("Installed"));
+}
+
+static guint64
+get_size_type (gpointer object,
+               BzEntry *entry,
+               gboolean is_installable)
+{
+  if (entry == NULL)
+    return 0;
+
+  return is_installable ? bz_entry_get_size (entry) : bz_entry_get_installed_size (entry);
+}
+
 static char *
 format_size_tooltip (gpointer object, guint64 value)
 {
@@ -1261,6 +1279,7 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, format_recent_downloads);
   gtk_widget_class_bind_template_callback (widget_class, format_recent_downloads_tooltip);
   gtk_widget_class_bind_template_callback (widget_class, format_size);
+  gtk_widget_class_bind_template_callback (widget_class, get_size_label);
   gtk_widget_class_bind_template_callback (widget_class, format_size_tooltip);
   gtk_widget_class_bind_template_callback (widget_class, age_rating_cb);
   gtk_widget_class_bind_template_callback (widget_class, format_age_rating);
@@ -1288,6 +1307,7 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, dl_stats_cb);
   gtk_widget_class_bind_template_callback (widget_class, screenshot_clicked_cb);
   gtk_widget_class_bind_template_callback (widget_class, size_cb);
+  gtk_widget_class_bind_template_callback (widget_class, get_size_type);
   gtk_widget_class_bind_template_callback (widget_class, formfactor_cb);
   gtk_widget_class_bind_template_callback (widget_class, safety_cb);
   gtk_widget_class_bind_template_callback (widget_class, run_cb);


### PR DESCRIPTION
Added user data size to the size dialog for apps that have user data, and updated the full view so that either the download size or installed size is shown, with the logic that the installed size is generally more relevant for installed apps.

<img width="762" height="604" alt="Screenshot From 2026-01-06 22-18-09" src="https://github.com/user-attachments/assets/d602372c-2116-4cd3-9b48-e805eaaef636" />
<img width="159" height="139" alt="Screenshot From 2026-01-06 22-18-31" src="https://github.com/user-attachments/assets/acd8e3f7-57fc-41a5-9138-8e0fda2a8fdb" />
