### PR TITLE
Disable focus on click for decorated screenshots

### DIFF
--- a/src/bz-decorated-screenshot.blp
+++ b/src/bz-decorated-screenshot.blp
@@ -2,6 +2,7 @@ using Gtk 4.0;
 
 template $BzDecoratedScreenshot: Button {
   halign: center;
+  focus-on-click: false;
   styles [
     "flat", "decorated-screenshot"
   ]


### PR DESCRIPTION
When dragging over another screenshot, the focus would shift and cause the carousel to change pages to that screenshot while the drag was still in progress, resulting in a strange jitter.