### PR TITLE
Hide EOL by default

### DIFF
--- a/data/io.github.kolunmi.Bazaar.gschema.xml
+++ b/data/io.github.kolunmi.Bazaar.gschema.xml
@@ -2,7 +2,7 @@
 <schemalist gettext-domain="bazaar">
   <schema id="io.github.kolunmi.Bazaar" path="/io/github/kolunmi/Bazaar/">
     <key name="hide-eol" type="b">
-      <default>false</default>
+      <default>true</default>
       <summary>Hide EOL Entries</summary>
       <description>Hide EOL entries and entries depending on them</description>
     </key>


### PR DESCRIPTION
EOL apps most likely have security issues and sometimes don't even have any metadata. So it's probably best to hide them by default.