### PR TITLE
(UX) Add a no results page for installed apps

### DIFF
--- a/src/bz-installed-page.blp
+++ b/src/bz-installed-page.blp
@@ -75,7 +75,7 @@ template $BzInstalledPage: Adw.Bin {
 
           child: Adw.StatusPage {
             icon-name: "library-symbolic";
-            title: _("No Installed Apps Found");
+            title: _("No Results");
             description: bind $no_results_found_subtitle(search_bar.text) as <string>;
           };
         }

--- a/src/bz-installed-page.c
+++ b/src/bz-installed-page.c
@@ -151,7 +151,7 @@ no_results_found_subtitle (gpointer    object,
   if (search_text == NULL || *search_text == '\0')
     return g_strdup ("");
 
-  return g_strdup_printf (_ ("No results found for \"%s\" in the list of installed apps"), search_text);
+  return g_strdup_printf (_ ("No matches found for \"%s\" in the list of installed apps"), search_text);
 }
 
 static DexFuture *


### PR DESCRIPTION
Adds a status page for when the search query doesn't return any apps, like with the search page.

<img width="963" height="867" alt="image" src="https://github.com/user-attachments/assets/ca50cea0-950c-40e7-9a96-de6fabcb7137" />
