### PR TITLE
Add "New Window" desktop action

### DIFF
--- a/data/io.github.kolunmi.Bazaar.desktop.in
+++ b/data/io.github.kolunmi.Bazaar.desktop.in
@@ -9,3 +9,8 @@ Categories=Utility;
 Keywords=GTK;System;PackageManager;Discover;Flatpak;Software;Store;
 StartupNotify=true
 MimeType=x-scheme-handler/appstream;x-scheme-handler/flatpak;x-scheme-handler/flatpak+https;
+Actions=new-window;
+
+[Desktop Action new-window]
+Name=New Window
+Exec=bazaar %U


### PR DESCRIPTION
Since we do support multiple windows, it makes sense to enable this option for users who want to compare multiple apps or something.

<img width="271" height="417" alt="image" src="https://github.com/user-attachments/assets/92076167-c6d5-40bf-bbe0-798b366ae424" />
