### PR TITLE
Add separate warning for the X11 permission

### DIFF
--- a/src/bz-safety-calculator.c
+++ b/src/bz-safety-calculator.c
@@ -427,6 +427,36 @@ bz_safety_calculator_calculate_rating (BzEntry *entry)
   return max_rating;
 }
 
+BzHighRiskGroup
+bz_safety_calculator_get_high_risk_groups (BzEntry *entry)
+{
+  BzAppPermissions     *permissions = NULL;
+  BzAppPermissionsFlags perm_flags  = BZ_APP_PERMISSIONS_FLAGS_NONE;
+  BzHighRiskGroup       result      = BZ_HIGH_RISK_GROUP_NONE;
+
+  g_return_val_if_fail (BZ_IS_ENTRY (entry), BZ_HIGH_RISK_GROUP_NONE);
+
+  g_object_get (entry, "permissions", &permissions, NULL);
+  if (permissions == NULL)
+    return BZ_HIGH_RISK_GROUP_NONE;
+
+  perm_flags = bz_app_permissions_get_flags (permissions);
+
+  if (perm_flags & BZ_APP_PERMISSIONS_FLAGS_X11)
+    result |= BZ_HIGH_RISK_GROUP_X11;
+
+  if (perm_flags & (BZ_APP_PERMISSIONS_FLAGS_FILESYSTEM_FULL |
+                    BZ_APP_PERMISSIONS_FLAGS_FILESYSTEM_READ |
+                    BZ_APP_PERMISSIONS_FLAGS_HOME_FULL |
+                    BZ_APP_PERMISSIONS_FLAGS_HOME_READ |
+                    BZ_APP_PERMISSIONS_FLAGS_ESCAPE_SANDBOX))
+    result |= BZ_HIGH_RISK_GROUP_DISK;
+
+  g_clear_object (&permissions);
+
+  return result;
+}
+
 static char *
 format_bus_policy_title (const BzBusPolicy *bus_policy)
 {

--- a/src/bz-safety-calculator.h
+++ b/src/bz-safety-calculator.h
@@ -27,6 +27,15 @@
 
 G_BEGIN_DECLS
 
+typedef enum
+{
+  BZ_HIGH_RISK_GROUP_NONE = 0,
+  BZ_HIGH_RISK_GROUP_X11  = 1 << 0,
+  BZ_HIGH_RISK_GROUP_DISK = 1 << 1,
+} BzHighRiskGroup;
+
+#define BZ_TYPE_HIGH_RISK_GROUP (bz_high_risk_group_get_type ())
+
 GListModel  *
 bz_safety_calculator_analyze_entry (BzEntry *entry);
 
@@ -36,5 +45,8 @@ bz_safety_calculator_calculate_rating (BzEntry *entry);
 char *
 bz_safety_calculator_get_top_icon (BzEntry *entry,
                                    int      index);
+
+BzHighRiskGroup
+bz_safety_calculator_get_high_risk_groups (BzEntry *entry);
 
 G_END_DECLS


### PR DESCRIPTION
The full disk access warning didn’t make much sense for apps that only have the X11 permission. If an app has both permissions, the full disk access warning will still be shown as before.

<img width="958" height="869" alt="Screenshot From 2026-01-10 14-16-21" src="https://github.com/user-attachments/assets/e310ceaa-f527-4480-9bc9-e8faaaea7f75" />
