### PR TITLE
(Bug) fix issue where installed page is empty on opening second window

### DIFF
--- a/src/bz-installed-page.c
+++ b/src/bz-installed-page.c
@@ -362,7 +362,7 @@ bz_installed_page_set_model (BzInstalledPage *self,
       self->model = g_object_ref (model);
       g_signal_connect_swapped (model, "items-changed", G_CALLBACK (items_changed), self);
     }
-  set_page (self);
+  g_idle_add_once ((GSourceOnceFunc) set_page, self);
 
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_MODEL]);
 }


### PR DESCRIPTION
set_page seemed to check the filtered item count before the filter was done, showing an empty page until the user changed the search text evaluating the logic again.

This wasn't an issue for the first window as the installed entry groups were added incrementally, triggering set_page multiple times as the model kept changing

<img width="1046" height="750" alt="image" src="https://github.com/user-attachments/assets/fe5a70aa-b98f-4061-b654-0a67fb82b84b" />
