### PR TITLE
gettext: Fix empty translatable string error

### DIFF
--- a/src/bz-installed-page.blp
+++ b/src/bz-installed-page.blp
@@ -65,7 +65,7 @@ template $BzInstalledPage: Adw.Bin {
           child: Adw.StatusPage {
             icon-name: "library-symbolic";
             title: _("No Apps Found");
-            description: _("");
+            description: "";
           };
         }
 


### PR DESCRIPTION
It causes a gettext error.

