### PR TITLE
Support ** in appstream renderer

### DIFF
--- a/src/bz-appstream-description-render.c
+++ b/src/bz-appstream-description-render.c
@@ -20,6 +20,8 @@
 
 #define G_LOG_DOMAIN "BAZAAR::APPSTREAM-DESCRIPTION-RENDER"
 
+#include "config.h"
+
 #include <xmlb.h>
 
 #include "bz-appstream-description-render.h"
@@ -59,7 +61,15 @@ enum
 static GParamSpec *props[LAST_PROP] = { 0 };
 
 static void
+setup_text_tags (GtkTextBuffer *buffer);
+
+static void
 regenerate (BzAppstreamDescriptionRender *self);
+
+static void
+insert (GtkTextBuffer *buffer,
+        GtkTextIter   *iter,
+        const char    *text);
 
 static void
 compile (BzAppstreamDescriptionRender *self,
@@ -269,7 +279,10 @@ insert (GtkTextBuffer *buffer,
         GtkTextIter   *iter,
         const char    *text)
 {
-  g_auto (GStrv) parts = g_strsplit (text, "**", -1);
+  g_auto (GStrv) parts = NULL;
+
+  parts = g_strsplit (text, "**", -1);
+
   for (int j = 0; parts[j] != NULL; j++)
     {
       if (j % 2 == 0)
@@ -278,8 +291,10 @@ insert (GtkTextBuffer *buffer,
         }
       else
         {
-          GtkTextMark *m = gtk_text_buffer_create_mark (buffer, NULL, iter, TRUE);
-          GtkTextIter  si;
+          GtkTextMark *m  = NULL;
+          GtkTextIter  si = { 0 };
+
+          m = gtk_text_buffer_create_mark (buffer, NULL, iter, TRUE);
           gtk_text_buffer_insert (buffer, iter, parts[j], -1);
           gtk_text_buffer_get_iter_at_mark (buffer, &si, m);
           gtk_text_buffer_apply_tag_by_name (buffer, "emphasis", &si, iter);


### PR DESCRIPTION
It’s pretty weird that Flathub randomly supports Markdown for bold text in AppStream descriptions, but so be it.

<img width="1208" height="884" alt="image" src="https://github.com/user-attachments/assets/f5925f76-9c20-424b-9add-441164e5746b" />


closes #971