### PR TITLE
Add thumbnails for search

### DIFF
--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -73,50 +73,51 @@ typedef struct
   gint     hold;
   gboolean installed;
 
-  guint            kinds;
-  GListModel      *addons;
-  char            *id;
-  char            *unique_id;
-  char            *unique_id_checksum;
-  char            *title;
-  char            *eol;
-  char            *description;
-  char            *long_description;
-  char            *remote_repo_name;
-  char            *url;
-  guint64          size;
-  guint64          installed_size;
-  GdkPaintable    *icon_paintable;
-  GIcon           *mini_icon;
-  GdkPaintable    *remote_repo_icon;
-  char            *search_tokens;
-  char            *metadata_license;
-  char            *project_license;
-  gboolean         is_floss;
-  char            *project_group;
-  char            *developer;
-  char            *developer_id;
-  GListModel      *developer_apps;
-  GListModel      *screenshot_paintables;
-  GListModel      *screenshot_captions;
-  GListModel      *share_urls;
-  char            *donation_url;
-  char            *forge_url;
-  GListModel      *reviews;
-  double           average_rating;
-  char            *ratings_summary;
-  GListModel      *version_history;
-  char            *light_accent_color;
-  char            *dark_accent_color;
-  gboolean         is_mobile_friendly;
-  guint            required_controls;
-  guint            recommended_controls;
-  guint            supported_controls;
-  gint             min_display_length;
-  gint             max_display_length;
-  AsContentRating *content_rating;
-  GListModel      *keywords;
-  GListModel      *categories;
+  guint             kinds;
+  GListModel       *addons;
+  char             *id;
+  char             *unique_id;
+  char             *unique_id_checksum;
+  char             *title;
+  char             *eol;
+  char             *description;
+  char             *long_description;
+  char             *remote_repo_name;
+  char             *url;
+  guint64           size;
+  guint64           installed_size;
+  GdkPaintable     *icon_paintable;
+  GIcon            *mini_icon;
+  GdkPaintable     *remote_repo_icon;
+  char             *search_tokens;
+  char             *metadata_license;
+  char             *project_license;
+  gboolean          is_floss;
+  char             *project_group;
+  char             *developer;
+  char             *developer_id;
+  GListModel       *developer_apps;
+  GListModel       *screenshot_paintables;
+  GListModel       *screenshot_captions;
+  GdkPaintable     *thumbnail_paintable;
+  GListModel       *share_urls;
+  char             *donation_url;
+  char             *forge_url;
+  GListModel       *reviews;
+  double            average_rating;
+  char             *ratings_summary;
+  GListModel       *version_history;
+  char             *light_accent_color;
+  char             *dark_accent_color;
+  gboolean          is_mobile_friendly;
+  guint             required_controls;
+  guint             recommended_controls;
+  guint             supported_controls;
+  gint              min_display_length;
+  gint              max_display_length;
+  AsContentRating  *content_rating;
+  GListModel       *keywords;
+  GListModel       *categories;
   BzAppPermissions *permissions;
 
   gboolean              is_flathub;
@@ -166,6 +167,7 @@ enum
   PROP_DEVELOPER_APPS,
   PROP_SCREENSHOT_PAINTABLES,
   PROP_SCREENSHOT_CAPTIONS,
+  PROP_THUMBNAIL_PAINTABLE,
   PROP_SHARE_URLS,
   PROP_DONATION_URL,
   PROP_FORGE_URL,
@@ -372,6 +374,9 @@ bz_entry_get_property (GObject    *object,
     case PROP_SCREENSHOT_CAPTIONS:
       g_value_set_object (value, priv->screenshot_captions);
       break;
+    case PROP_THUMBNAIL_PAINTABLE:
+      g_value_set_object (value, priv->thumbnail_paintable);
+      break;
     case PROP_SHARE_URLS:
       g_value_set_object (value, priv->share_urls);
       break;
@@ -576,6 +581,10 @@ bz_entry_set_property (GObject      *object,
     case PROP_SCREENSHOT_CAPTIONS:
       g_clear_object (&priv->screenshot_captions);
       priv->screenshot_captions = g_value_dup_object (value);
+      break;
+    case PROP_THUMBNAIL_PAINTABLE:
+      g_clear_object (&priv->thumbnail_paintable);
+      priv->thumbnail_paintable = g_value_dup_object (value);
       break;
     case PROP_SHARE_URLS:
       g_clear_object (&priv->share_urls);
@@ -801,7 +810,7 @@ bz_entry_class_init (BzEntryClass *klass)
           0, G_MAXUINT64, 0,
           G_PARAM_READWRITE);
 
-    props[PROP_INSTALLED_SIZE] =
+  props[PROP_INSTALLED_SIZE] =
       g_param_spec_uint64 (
           "installed-size",
           NULL, NULL,
@@ -890,6 +899,13 @@ bz_entry_class_init (BzEntryClass *klass)
           "screenshot-captions",
           NULL, NULL,
           G_TYPE_LIST_MODEL,
+          G_PARAM_READWRITE);
+
+  props[PROP_THUMBNAIL_PAINTABLE] =
+      g_param_spec_object (
+          "thumbnail-paintable",
+          NULL, NULL,
+          GDK_TYPE_PAINTABLE,
           G_PARAM_READWRITE);
 
   props[PROP_SHARE_URLS] =
@@ -1206,6 +1222,8 @@ bz_entry_real_serialize (BzSerializable  *serializable,
           g_variant_builder_add (builder, "{sv}", "screenshot-captions", g_variant_builder_end (sub_builder));
         }
     }
+  if (priv->thumbnail_paintable != NULL)
+    maybe_save_paintable (priv, "thumbnail-paintable", priv->thumbnail_paintable, builder);
   if (priv->share_urls != NULL)
     {
       guint n_items = 0;
@@ -1248,11 +1266,11 @@ bz_entry_real_serialize (BzSerializable  *serializable,
           sub_builder = g_variant_builder_new (G_VARIANT_TYPE ("a(mstmsms)"));
           for (guint i = 0; i < n_items; i++)
             {
-              g_autoptr (BzRelease) release              = NULL;
-              guint64     timestamp                      = 0;
-              const char *url                            = NULL;
-              const char *version                        = NULL;
-              const char *description                    = NULL;
+              g_autoptr (BzRelease) release = NULL;
+              guint64     timestamp         = 0;
+              const char *url               = NULL;
+              const char *version           = NULL;
+              const char *description       = NULL;
 
               release     = g_list_model_get_item (priv->version_history, i);
               timestamp   = bz_release_get_timestamp (release);
@@ -1563,6 +1581,8 @@ bz_entry_real_deserialize (BzSerializable *serializable,
 
           priv->screenshot_captions = G_LIST_MODEL (g_steal_pointer (&store));
         }
+      else if (g_strcmp0 (key, "thumbnail-paintable") == 0)
+        priv->thumbnail_paintable = make_async_texture (value);
       else if (g_strcmp0 (key, "share-urls") == 0)
         {
           g_autoptr (GListStore) store      = NULL;
@@ -1603,11 +1623,11 @@ bz_entry_real_deserialize (BzSerializable *serializable,
           version_iter = g_variant_iter_new (value);
           for (;;)
             {
-              guint64          timestamp          = 0;
-              g_autofree char *url                = NULL;
-              g_autofree char *description        = NULL;
-              g_autofree char *version            = NULL;
-              g_autoptr (BzRelease) release       = NULL;
+              guint64          timestamp    = 0;
+              g_autofree char *url          = NULL;
+              g_autofree char *description  = NULL;
+              g_autofree char *version      = NULL;
+              g_autoptr (BzRelease) release = NULL;
 
               if (!g_variant_iter_next (version_iter, "(mstmsms)", &description, &timestamp, &url, &version))
                 break;
@@ -2866,6 +2886,7 @@ clear_entry (BzEntry *self)
   g_clear_object (&priv->developer_apps);
   g_clear_object (&priv->screenshot_paintables);
   g_clear_object (&priv->screenshot_captions);
+  g_clear_object (&priv->thumbnail_paintable);
   g_clear_object (&priv->share_urls);
   g_clear_pointer (&priv->donation_url, g_free);
   g_clear_pointer (&priv->forge_url, g_free);

--- a/src/bz-flatpak-entry.c
+++ b/src/bz-flatpak-entry.c
@@ -350,6 +350,80 @@ calculate_is_mobile_friendly (guint required_controls,
   return (supported_controls & BZ_CONTROL_TOUCH) != 0;
 }
 
+static GdkPaintable *
+find_screenshot (GPtrArray  *images,
+                 const char *caption,
+                 gboolean    match_highest,
+                 guint       target_width,
+                 guint       target_height,
+                 gboolean    require_flathub,
+                 const char *module_dir,
+                 const char *unique_id_checksum,
+                 const char *cache_filename,
+                 char      **out_caption)
+{
+  const char *best_url      = NULL;
+  gint        best_diff     = G_MAXINT;
+  guint       best_res      = 0;
+  guint       target_pixels = target_width * target_height;
+
+  if (images == NULL)
+    return NULL;
+
+  for (guint j = 0; j < images->len; j++)
+    {
+      AsImage    *image_obj = g_ptr_array_index (images, j);
+      const char *url       = as_image_get_url (image_obj);
+      guint       width     = as_image_get_width (image_obj);
+      guint       height    = as_image_get_height (image_obj);
+      guint       pixels    = width * height;
+
+      if (url == NULL)
+        continue;
+
+      if (require_flathub && !g_str_has_prefix (url, "https://dl.flathub.org/"))
+        continue;
+
+      if (match_highest)
+        {
+          if (pixels > best_res)
+            {
+              best_url = url;
+              best_res = pixels;
+            }
+        }
+      else
+        {
+          gint diff = ABS ((gint) pixels - (gint) target_pixels);
+          if (diff < best_diff)
+            {
+              best_url  = url;
+              best_diff = diff;
+            }
+        }
+    }
+
+  if (best_url != NULL)
+    {
+      g_autoptr (GFile) screenshot_file = NULL;
+      g_autoptr (GFile) cache_file      = NULL;
+      BzAsyncTexture *texture           = NULL;
+
+      screenshot_file = g_file_new_for_uri (best_url);
+      cache_file      = g_file_new_build_filename (
+          module_dir, unique_id_checksum, cache_filename, NULL);
+
+      texture = bz_async_texture_new_lazy (screenshot_file, cache_file);
+
+      if (out_caption != NULL)
+        *out_caption = g_strdup (caption ? caption : "");
+
+      return GDK_PAINTABLE (texture);
+    }
+
+  return NULL;
+}
+
 BzFlatpakEntry *
 bz_flatpak_entry_new_for_ref (FlatpakRef    *ref,
                               FlatpakRemote *remote,
@@ -387,6 +461,7 @@ bz_flatpak_entry_new_for_ref (FlatpakRef    *ref,
   g_autoptr (GIcon) mini_icon                          = NULL;
   g_autoptr (GListStore) screenshot_paintables         = NULL;
   g_autoptr (GListStore) screenshot_captions           = NULL;
+  g_autoptr (GdkPaintable) thumbnail_paintable         = NULL;
   g_autoptr (GListStore) share_urls                    = NULL;
   g_autofree char *donation_url                        = NULL;
   g_autofree char *forge_url                           = NULL;
@@ -537,42 +612,40 @@ bz_flatpak_entry_new_for_ref (FlatpakRef    *ref,
 
           for (guint i = 0; i < screenshots->len; i++)
             {
-              AsScreenshot *screenshot = NULL;
-              GPtrArray    *images     = NULL;
-              const gchar  *caption    = NULL;
+              AsScreenshot    *screenshot        = NULL;
+              GPtrArray       *images            = NULL;
+              const gchar     *caption           = NULL;
+              g_autofree char *caption_str       = NULL;
+              g_autoptr (GdkPaintable) paintable = NULL;
+              g_autofree char *cache_name        = NULL;
 
               screenshot = g_ptr_array_index (screenshots, i);
               images     = as_screenshot_get_images_all (screenshot);
               caption    = as_screenshot_get_caption (screenshot);
 
-              for (guint j = 0; j < images->len; j++)
+              if (i == 0 && thumbnail_paintable == NULL)
                 {
-                  AsImage         *image_obj              = NULL;
-                  const char      *url                    = NULL;
-                  g_autoptr (GFile) screenshot_file       = NULL;
-                  g_autofree char *cache_basename         = NULL;
-                  g_autoptr (GFile) cache_file            = NULL;
-                  g_autoptr (BzAsyncTexture) texture      = NULL;
+                  thumbnail_paintable = find_screenshot (images, caption, FALSE, 400, 300, TRUE,
+                                                         module_dir, unique_id_checksum, "thumbnail.png", NULL);
+                  if (thumbnail_paintable == NULL)
+                    thumbnail_paintable = find_screenshot (images, caption, FALSE, 400, 300, FALSE,
+                                                           module_dir, unique_id_checksum, "thumbnail.png", NULL);
+                }
+
+              cache_name = g_strdup_printf ("screenshot_%u.png", i);
+              paintable  = find_screenshot (images, caption, TRUE, 0, 0, TRUE,
+                                            module_dir, unique_id_checksum, cache_name, &caption_str);
+              if (paintable == NULL)
+                paintable = find_screenshot (images, caption, TRUE, 0, 0, FALSE,
+                                             module_dir, unique_id_checksum, cache_name, &caption_str);
+
+              if (paintable != NULL)
+                {
                   g_autoptr (GtkStringObject) caption_obj = NULL;
 
-                  image_obj = g_ptr_array_index (images, j);
-                  url       = as_image_get_url (image_obj);
-
-                  if (url != NULL)
-                    {
-                      screenshot_file = g_file_new_for_uri (url);
-                      cache_basename  = g_strdup_printf ("screenshot_%u.png", i);
-                      cache_file      = g_file_new_build_filename (
-                          module_dir, unique_id_checksum, cache_basename, NULL);
-
-                      texture = bz_async_texture_new_lazy (screenshot_file, cache_file);
-                      g_list_store_append (screenshot_paintables, texture);
-
-                      caption_obj = gtk_string_object_new (caption ? caption : "");
-                      g_list_store_append (screenshot_captions, caption_obj);
-
-                      break;
-                    }
+                  g_list_store_append (screenshot_paintables, paintable);
+                  caption_obj = gtk_string_object_new (caption_str);
+                  g_list_store_append (screenshot_captions, caption_obj);
                 }
             }
         }
@@ -1026,6 +1099,7 @@ bz_flatpak_entry_new_for_ref (FlatpakRef    *ref,
       "mini-icon", mini_icon,
       "screenshot-paintables", screenshot_paintables,
       "screenshot-captions", screenshot_captions,
+      "thumbnail-paintable", thumbnail_paintable,
       "share-urls", share_urls,
       "donation-url", donation_url,
       "forge-url", forge_url,

--- a/src/bz-rich-app-tile.blp
+++ b/src/bz-rich-app-tile.blp
@@ -37,18 +37,17 @@ template $BzRichAppTile: $BzListTile {
           valign: center;
           hexpand: true;
 
-          visible: bind $is_null(template.first-screenshot) as <bool>;
-
+          visible: bind $is_null(template.ui-entry as <$BzEntry>.thumbnail-paintable) as <bool>;
         }
 
         $BzRoundedPicture {
           halign: center;
           hexpand: true;
           valign: center;
-          paintable: bind template.first-screenshot;
+          paintable: bind template.ui-entry as <$BzEntry>.thumbnail-paintable;
           radius: 6;
 
-          visible: bind $invert_boolean($is_null(template.first-screenshot) as <bool>) as <bool>;
+          visible: bind $invert_boolean($is_null(template.ui-entry as <$BzEntry>.thumbnail-paintable) as <bool>) as <bool>;
         }
       };
     }

--- a/src/bz-rich-app-tile.c
+++ b/src/bz-rich-app-tile.c
@@ -28,8 +28,7 @@ struct _BzRichAppTile
 {
   BzListTile    parent_instance;
   BzEntryGroup *group;
-  GdkPaintable *first_screenshot;
-  gboolean      has_screenshot;
+  BzEntry      *ui_entry;
   DexFuture    *ui_entry_resolve;
 
   GtkWidget *picture_box;
@@ -41,8 +40,7 @@ enum
 {
   PROP_0,
   PROP_GROUP,
-  PROP_FIRST_SCREENSHOT,
-  PROP_HAS_SCREENSHOT,
+  PROP_UI_ENTRY,
   LAST_PROP
 };
 
@@ -56,18 +54,7 @@ enum
 
 static guint signals[LAST_SIGNAL];
 
-static void update_screenshot (BzRichAppTile *self);
-
-static inline void
-notify_properties (BzRichAppTile *self, gboolean has_screenshot)
-{
-  if (self->has_screenshot != has_screenshot)
-    {
-      self->has_screenshot = has_screenshot;
-      g_object_notify_by_pspec (G_OBJECT (self), props[PROP_HAS_SCREENSHOT]);
-    }
-  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_FIRST_SCREENSHOT]);
-}
+static void update_ui_entry (BzRichAppTile *self);
 
 static DexFuture *
 ui_entry_resolved_finally (DexFuture *future,
@@ -75,44 +62,34 @@ ui_entry_resolved_finally (DexFuture *future,
 {
   g_autoptr (BzRichAppTile) self = NULL;
   const GValue *value            = NULL;
-  gboolean      has_screenshot   = FALSE;
 
   bz_weak_get_or_return_reject (self, wr);
-
   value = dex_future_get_value (future, NULL);
   if (value != NULL)
     {
-      BzEntry *ui_entry                  = NULL;
-      g_autoptr (GListModel) screenshots = NULL;
-
-      ui_entry = g_value_get_object (value);
-
-      g_object_get (ui_entry, "screenshot-paintables", &screenshots, NULL);
-      if (screenshots != NULL &&
-          g_list_model_get_n_items (screenshots) > 0)
-        {
-          self->first_screenshot = g_list_model_get_item (screenshots, 0);
-          has_screenshot         = TRUE;
-        }
+      BzEntry *ui_entry = g_value_get_object (value);
+      g_set_object (&self->ui_entry, ui_entry);
     }
+  else
+    {
+      g_clear_object (&self->ui_entry);
+    }
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_UI_ENTRY]);
 
-  notify_properties (self, has_screenshot);
   return NULL;
 }
 
 static void
-update_screenshot (BzRichAppTile *self)
+update_ui_entry (BzRichAppTile *self)
 {
   g_autoptr (BzResult) ui_entry_result = NULL;
-  g_autoptr (GListModel) screenshots   = NULL;
 
   dex_clear (&self->ui_entry_resolve);
-  g_clear_object (&self->first_screenshot);
 
-  if (self->group == NULL)
+  if (self->ui_entry != NULL)
     {
-      notify_properties (self, FALSE);
-      return;
+      g_clear_object (&self->ui_entry);
+      g_object_notify_by_pspec (G_OBJECT (self), props[PROP_UI_ENTRY]);
     }
 
   ui_entry_result        = bz_entry_group_dup_ui_entry (self->group);
@@ -129,7 +106,7 @@ bz_rich_app_tile_dispose (GObject *object)
   BzRichAppTile *self = BZ_RICH_APP_TILE (object);
 
   g_clear_object (&self->group);
-  g_clear_object (&self->first_screenshot);
+  g_clear_object (&self->ui_entry);
   dex_clear (&self->ui_entry_resolve);
 
   G_OBJECT_CLASS (bz_rich_app_tile_parent_class)->dispose (object);
@@ -147,11 +124,8 @@ bz_rich_app_tile_get_property (GObject    *object,
     case PROP_GROUP:
       g_value_set_object (value, bz_rich_app_tile_get_group (self));
       break;
-    case PROP_FIRST_SCREENSHOT:
-      g_value_set_object (value, self->first_screenshot);
-      break;
-    case PROP_HAS_SCREENSHOT:
-      g_value_set_boolean (value, self->has_screenshot);
+    case PROP_UI_ENTRY:
+      g_value_set_object (value, self->ui_entry);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -170,8 +144,7 @@ bz_rich_app_tile_set_property (GObject      *object,
     case PROP_GROUP:
       bz_rich_app_tile_set_group (self, g_value_get_object (value));
       break;
-    case PROP_FIRST_SCREENSHOT:
-    case PROP_HAS_SCREENSHOT:
+    case PROP_UI_ENTRY:
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -222,18 +195,11 @@ bz_rich_app_tile_class_init (BzRichAppTileClass *klass)
           BZ_TYPE_ENTRY_GROUP,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
-  props[PROP_FIRST_SCREENSHOT] =
+  props[PROP_UI_ENTRY] =
       g_param_spec_object (
-          "first-screenshot",
+          "ui-entry",
           NULL, NULL,
-          GDK_TYPE_PAINTABLE,
-          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
-
-  props[PROP_HAS_SCREENSHOT] =
-      g_param_spec_boolean (
-          "has-screenshot",
-          NULL, NULL,
-          FALSE,
+          BZ_TYPE_ENTRY,
           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class, LAST_PROP, props);
@@ -292,7 +258,7 @@ bz_rich_app_tile_set_group (BzRichAppTile *self,
   if (group != NULL)
     self->group = g_object_ref (group);
 
-  update_screenshot (self);
+  update_ui_entry (self);
 
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_GROUP]);
 }


### PR DESCRIPTION
Fetching lower resolution screenshots for search thumbnails reduces network usage and cache size and improves image loading speed.

I also made it so that screenshot variants from Flathub are preferred, as sometimes the first variant was a link pointing to some random site that doesn't even serve the screenshot anymore.