### PR TITLE
gettext: Add comments to Installed string

### DIFF
--- a/src/bz-app-tile.blp
+++ b/src/bz-app-tile.blp
@@ -82,6 +82,7 @@ template $BzAppTile: Button {
           }
 
           Label {
+            // Translators: As in 'The app is installed'.
             label: _("Installed");
           }
         }

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -360,7 +360,8 @@ static  char *
 get_size_label (gpointer object,
                 gboolean is_installable)
 {
-   return g_strdup (is_installable ? _("Download") : _("Installed"));
+  // Translators: .
+  return g_strdup (is_installable ? _("Download") : _("Installed"));
 }
 
 static guint64

--- a/src/bz-installed-page.blp
+++ b/src/bz-installed-page.blp
@@ -82,6 +82,7 @@ template $BzInstalledPage: Adw.Bin {
 
         Adw.ViewStackPage {
           name: "content";
+          // Translators: .
           title: _("Installed");
 
           child: ScrolledWindow {

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -293,6 +293,7 @@ template $BzWindow: Adw.ApplicationWindow {
 
                         Adw.ViewStackPage {
                           name: "installed";
+                          // Translators: .
                           title: _("Installed");
                           icon-name: "library-symbolic";
 


### PR DESCRIPTION
The string "Installed" is sometimes plural, sometimes singular. We need to add translator comments to make sure the string is correctly translated.

Here I marked one instance I found that I know is used for singular. Could I have a little help to know if the others are singular or plural? I don't know where to find them in the app.