### PR TITLE
Fix float formatting in pride flag css generation

### DIFF
--- a/src/progress-bar-designs/pride/pride.c
+++ b/src/progress-bar-designs/pride/pride.c
@@ -149,7 +149,7 @@ bz_get_pride_style_provider (void)
                           break;
                         }
 
-                      g_string_append_printf (stripe_css, ", %s %f%%", rgba_spec, cur_offset * 100.0);
+                      g_string_append_printf (stripe_css, ", %s %d%%", rgba_spec, (int) round (cur_offset * 100.0));
                       cur_offset += homogeneous ? 1.0 / (double) n_stripes : size;
                       if (cur_offset > 1.0)
                         {
@@ -157,7 +157,7 @@ bz_get_pride_style_provider (void)
                           skip = TRUE;
                           break;
                         }
-                      g_string_append_printf (stripe_css, ", %s %f%%", rgba_spec, cur_offset * 100.0);
+                      g_string_append_printf (stripe_css, ", %s %d%%", rgba_spec, (int) round (cur_offset * 100.0));
                     }
                   if (skip)
                     continue;


### PR DESCRIPTION
See https://github.com/kolunmi/bazaar/issues/900#issuecomment-3763008053

`%f` uses the current locale to format the number, which may not be safe for code generation. For example, it may use a comma for the decimal separator, which is not valid in css. As far as i can tell, `%d` doesn't have this problem and rounding to whole percent values doesn't create a perceivable difference in this case.

This is perhaps not the cleanest way to solve this, but the other options as far as i can see are either explicitly using a safe locale, which wouldn't be thread safe i think, or some custom float formatter that always produces the correct output. Neither of these seem worth the effort to me. Please do correct me if im wrong tho, im a little out of my depth here.