### PR TITLE
(UX) Improve context dialogs

### DIFF
--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -673,7 +673,7 @@ get_safety_rating_label (gpointer object,
   switch (importance)
     {
     case BZ_IMPORTANCE_UNIMPORTANT:
-      return g_strdup (_ ("Low Risk"));
+      return g_strdup (_ ("Safe"));
     case BZ_IMPORTANCE_NEUTRAL:
       return g_strdup (_ ("Low Risk"));
     case BZ_IMPORTANCE_INFORMATION:

--- a/src/bz-safety-dialog.c
+++ b/src/bz-safety-dialog.c
@@ -179,7 +179,6 @@ update_permissions_list (BzSafetyDialog *self)
   GtkWidget       *child;
   g_autoptr (GListModel) model = NULL;
   guint n_items                = 0;
-  guint i                      = 0;
 
   while ((child = gtk_widget_get_first_child (GTK_WIDGET (self->permissions_list))) != NULL)
     gtk_list_box_remove (self->permissions_list, child);
@@ -204,14 +203,20 @@ update_permissions_list (BzSafetyDialog *self)
   importance = bz_safety_calculator_calculate_rating (entry);
 
   n_items = g_list_model_get_n_items (model);
-  for (i = 0; i < n_items; i++)
+  for (gint level = BZ_IMPORTANCE_IMPORTANT; level >= BZ_IMPORTANCE_UNIMPORTANT; level--)
     {
-      g_autoptr (BzSafetyRow) row_data;
-      AdwActionRow *row;
-
-      row_data = g_list_model_get_item (model, i);
-      row      = create_permission_row (row_data);
-      gtk_list_box_append (self->permissions_list, GTK_WIDGET (row));
+      for (gint j = 0; j < n_items; j++)
+        {
+          g_autoptr (BzSafetyRow) row_data;
+          AdwActionRow *row;
+          BzImportance row_importance;
+          row_data       = g_list_model_get_item (model, j);
+          row_importance = bz_safety_row_get_importance (row_data);
+          if (row_importance != level)
+            continue;
+          row = create_permission_row (row_data);
+          gtk_list_box_append (self->permissions_list, GTK_WIDGET (row));
+        }
     }
 
   switch (importance)


### PR DESCRIPTION
This PR makes the following small improvements:
- Changing "Low Risk" to "Safe" for apps with no permissions.
- Adds clearer explanations for the 5 most commonly used services to better inform the users.
- Ordering the rows in the safety and age rating dialogs by importance.

<img width="1397" height="930" alt="Screenshot From 2026-01-19 18-12-58" src="https://github.com/user-attachments/assets/18c78d89-6c6d-4936-b0da-6339e144a014" />
<img width="1397" height="930" alt="Screenshot From 2026-01-19 17-27-54" src="https://github.com/user-attachments/assets/c6199475-c448-4e89-86f9-b4a9e51a80fe" />
