### PR TITLE
Fix leftover user data bar being shown prematurely

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -590,8 +590,10 @@ template $BzFullView: Adw.Bin {
 
                         Revealer {
                           transition-type: slide_down;
-                          reveal-child: bind $logical_and($invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.user-data-size) as <bool>) as <bool>, $is_zero(template.entry-group as <$BzEntryGroup>.removable) as <bool>) as <bool>;
-
+                          reveal-child: bind $logical_and(
+                              $logical_and($invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.user-data-size) as <bool>) as <bool>,$is_zero(template.entry-group as <$BzEntryGroup>.removable) as <bool>) as <bool>,
+                              $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.installable-and-available) as <bool>) as <bool>
+                            ) as <bool>;
                           child: Box {
                             height-request: 50;
                             margin-bottom: 10;


### PR DESCRIPTION
Fixes the papercut where the bar would be shown for a short time when choosing to remove all user data, allowing users to remove user data twice.

[Screencast From 2026-01-19 19-31-02.webm](https://github.com/user-attachments/assets/c5c7b5d5-aa9c-4428-ae0d-398d2e34d546)
