### PR TITLE
(UI) Improve stat dialogs

### DIFF
--- a/src/bazaar.gresource.xml
+++ b/src/bazaar.gresource.xml
@@ -115,6 +115,7 @@
     <file preprocess="xml-stripblanks">icons/scalable/actions/sliders-horizontal-symbolic.svg</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/smartphone2-symbolic.svg</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/software-update-available-symbolic.svg</file>
+    <file preprocess="xml-stripblanks">icons/scalable/actions/square-filled-symbolic.svg</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/thumbs-up-outline-symbolic.svg</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/timer-sand-symbolic.svg</file>
     <file preprocess="xml-stripblanks">icons/scalable/actions/translations-symbolic.svg</file>

--- a/src/bz-stats-dialog.blp
+++ b/src/bz-stats-dialog.blp
@@ -4,8 +4,8 @@ using Adw 1;
 template $BzStatsDialog: Adw.Dialog {
   width-request: 360;
   height-request: 450;
-  content-width: 2000;
-  content-height: 1500;
+  content-width: 1250;
+  content-height: 750;
   child: Adw.ToolbarView {
     bottom-bar-style: raised_border;
 

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -231,6 +231,14 @@
   }
 }
 
+.floating-tooltip {
+	background-color: var(--dialog-bg-color);
+}
+
+.floating-tooltip .monospace {
+	font-size: 1em;
+}
+
 .flathub {
 	--accent-color: alpha(@window_fg_color,0.75);
 	--accent-bg-color: @window_fg_color;

--- a/src/icons/scalable/actions/square-filled-symbolic.svg
+++ b/src/icons/scalable/actions/square-filled-symbolic.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 0 16 16" width="16px"><path d="m 13 2 h -10 c -0.550781 0 -1 0.449219 -1 1 v 10 c 0 0.550781 0.449219 1 1 1 h 10 c 0.550781 0 1 -0.449219 1 -1 v -10 c 0 -0.550781 -0.449219 -1 -1 -1 z m 0 0" fill="#222222"/></svg>


### PR DESCRIPTION
Changes the tooltips in the two stats dialogs to use widgets, allowing for better layout and styling. Also updates the graph to no longer draw a raster, as it is now redundant with the tooltip and also kinda looked bad.

<img width="1920" height="1048" alt="Screenshot From 2026-01-21 14-02-38" src="https://github.com/user-attachments/assets/28961194-2972-4248-9a43-9f0aead62f9a" />
<img width="1920" height="1048" alt="Screenshot From 2026-01-21 14-02-47" src="https://github.com/user-attachments/assets/c332e9ef-4397-4e14-8e3d-68b81cffdfe9" />
