### PR TITLE
Add Neutrois Pride Flag

### DIFF
--- a/data/io.github.kolunmi.Bazaar.gschema.xml
+++ b/data/io.github.kolunmi.Bazaar.gschema.xml
@@ -49,6 +49,7 @@
         <choice value="biromantic-flag"/>
         <choice value="disability-flag"/>
         <choice value="femboy-flag"/>
+	    <choice value="neutrois-flag"/>
       </choices>
       <default>'accent-color'</default>
       <summary>Global Progress Bar Theme</summary>

--- a/src/bz-preferences-dialog.c
+++ b/src/bz-preferences-dialog.c
@@ -50,6 +50,7 @@ static const BarTheme bar_themes[] = {
   {               "biromantic-flag",               "biromantic-flag-theme",                   N_ ("Biromantic Pride Colors") },
   {               "disability-flag",               "disability-flag-theme",                   N_ ("Disability Pride Colors") },
   {                   "femboy-flag",                   "femboy-flag-theme",                       N_ ("Femboy Pride Colors") },
+  {                 "neutrois-flag",                 "neutrois-flag-theme",                     N_ ("Neutrois Pride Colors") },
 };
 
 struct _BzPreferencesDialog

--- a/src/progress-bar-designs/pride/pride-flags.yaml
+++ b/src/progress-bar-designs/pride/pride-flags.yaml
@@ -273,3 +273,13 @@ flag-specs:
       - rgba: "#FFFFFF"
       - rgba: "#E4ADCD"
       - rgba: "#D460A7"
+
+
+  - id: "neutrois-flag"
+    name: "Neutrois Flag"
+    homogeneous: true
+    direction: to bottom
+    stripes: &neutrois-flag-stripes
+     - rgba: "rgb(255,255,255)"
+     - rgba: "rgb(31,159,0)"
+     - rgba: "rgb(0,0,0)"


### PR DESCRIPTION
Adds the [Neutrois Pride Flag](https://en.wikipedia.org/wiki/File:Neutrois_Flag.svg).
<img width="847" height="343" alt="immagine" src="https://github.com/user-attachments/assets/9acefe0a-9bbd-4a54-be87-567b3ffd373e" />
<img width="438" height="63" alt="immagine" src="https://github.com/user-attachments/assets/a2eccf01-f41f-4060-81d6-6c624d0354f3" />
