### PR TITLE
chore: clarify direction of vertical stripes

### DIFF
--- a/src/bz-preferences-dialog.blp
+++ b/src/bz-preferences-dialog.blp
@@ -87,7 +87,7 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
       }
       Adw.SwitchRow rotate_switch {
         title: _("Vertical Stripes");
-        subtitle: _("Display flag colors from top to bottom");
+        subtitle: _("Display flag colors from left to right");
         notify::active => $on_rotate_switch_changed();
       }
     }


### PR DESCRIPTION
Since "from top to bottom" doesn't really makes sense to me when colors are flipped to another direction.

Before:

<img width="566" height="232" alt="Screenshot From 2026-01-23 16-28-47" src="https://github.com/user-attachments/assets/32a8e820-c41d-4829-857d-a523c3562b66" />

After:

<img width="570" height="238" alt="Screenshot From 2026-01-25 12-30-32" src="https://github.com/user-attachments/assets/c1ba5329-a505-4c19-b414-4ed72553b5ae" />
