### PR TITLE
Add "installed" lozenge to version history

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -706,6 +706,7 @@ template $BzFullView: Adw.Bin {
 
                         $BzReleasesList releases_list {
                           version-history: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.version-history;
+                          installed-versions: bind template.entry-group as <$BzEntryGroup>.installed-versions;
                         }
 
                         $BzShareList {

--- a/src/bz-releases-list.h
+++ b/src/bz-releases-list.h
@@ -28,9 +28,14 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (BzReleasesList, bz_releases_list, BZ, RELEASES_LIST, AdwBin)
 
-GtkWidget  *bz_releases_list_new (void);
-void        bz_releases_list_set_version_history (BzReleasesList *self,
-                                                  GListModel     *version_history);
-GListModel *bz_releases_list_get_version_history (BzReleasesList *self);
+GtkWidget *
+bz_releases_list_new (void);
+
+void
+bz_releases_list_set_version_history (BzReleasesList *self,
+                                      GListModel     *version_history);
+
+GListModel *
+bz_releases_list_get_version_history (BzReleasesList *self);
 
 G_END_DECLS

--- a/src/bz-share-list.blp
+++ b/src/bz-share-list.blp
@@ -1,4 +1,0 @@
-using Gtk 4.0;
-using Adw 1;
-
-template $BzShareList: Adw.PreferencesGroup {

--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -274,6 +274,12 @@ global-progress image {
 	  transition: background-color 150ms ease;
 }
 
+.lozenge.small {
+	padding: 1px 9px;
+	font-size: 12px;
+	font-weight: bold;
+}
+
 .lozenge-ring-button {
 	padding: 0;
 	border-radius: 999999px;


### PR DESCRIPTION
This is also a thing in GS.

<img width="1205" height="899" alt="image" src="https://github.com/user-attachments/assets/a8711972-d17b-4dae-a6ee-2aa44673f3eb" />
