### PR TITLE
chore: update flathub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Bazaar's market stall icon.
 
 Pre-built binaries are distributed via Flathub and GitHub actions:
 
-<a href='https://flathub.org/apps/details/io.github.kolunmi.Bazaar'><img width='240' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
+<a href='https://flathub.org/apps/details/io.github.kolunmi.Bazaar'><img width='240' alt='Download on Flathub' src='https://flathub.org/api/badge?locale=en'/></a>
 
 [![Build Flatpak and Upload Artifact](https://github.com/kolunmi/bazaar/actions/workflows/build-flatpak.yml/badge.svg)](https://github.com/kolunmi/bazaar/actions/workflows/build-flatpak.yml)
 


### PR DESCRIPTION
Uses newer and nicer one from https://flathub.org/en/badges page