### PR TITLE
Increase paragraph spacing

### DIFF
--- a/src/bz-appstream-description-render.c
+++ b/src/bz-appstream-description-render.c
@@ -163,7 +163,7 @@ setup_text_tags (GtkTextBuffer *buffer)
                               NULL);
 
   gtk_text_buffer_create_tag (buffer, "paragraph",
-                              "pixels-below-lines", 10,
+                              "pixels-below-lines", 12,
                               NULL);
 
   gtk_text_buffer_create_tag (buffer, "list-item-ul",


### PR DESCRIPTION
increased the paragraph spacing by 4 pixels, it’s still less than GNOME Software though.

@bertob Does this look good to you, and should we also increase the spacing between list items as well?

Closes #968 

<img width="1600" height="1017" alt="Screenshot From 2026-02-04 20-59-31" src="https://github.com/user-attachments/assets/44d285d8-9ad5-4840-a9df-33334a5ab6ac" />
