### PR TITLE
Allow managment of user installs inside the Flatpak

### DIFF
--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.json
@@ -16,6 +16,7 @@
     "--socket=wayland",
     "--device=dri",
     "--filesystem=/var/lib/flatpak",
+    "--filesystem=~/.local/share/flatpak",
     "--filesystem=~/.var/app",
     "--talk-name=org.freedesktop.Flatpak",
     "--system-talk-name=org.freedesktop.Flatpak.SystemHelper",

--- a/src/bz-entry-group.c
+++ b/src/bz-entry-group.c
@@ -1145,13 +1145,21 @@ bz_entry_group_add (BzEntryGroup *self,
         }
       else
         {
-          self->installable++;
-          if (!bz_entry_is_holding (entry))
+          gboolean is_installed_ref = FALSE;
+
+          if (BZ_IS_FLATPAK_ENTRY (entry))
+            is_installed_ref = bz_flatpak_entry_is_installed_ref (BZ_FLATPAK_ENTRY (entry));
+
+          if (!is_installed_ref)
             {
-              self->installable_available++;
-              g_object_notify_by_pspec (G_OBJECT (self), props[PROP_INSTALLABLE_AND_AVAILABLE]);
+              self->installable++;
+              if (!bz_entry_is_holding (entry))
+                {
+                  self->installable_available++;
+                  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_INSTALLABLE_AND_AVAILABLE]);
+                }
+              g_object_notify_by_pspec (G_OBJECT (self), props[PROP_INSTALLABLE]);
             }
-          g_object_notify_by_pspec (G_OBJECT (self), props[PROP_INSTALLABLE]);
         }
     }
   if (is_searchable && !self->searchable)

--- a/src/bz-transaction-dialog.c
+++ b/src/bz-transaction-dialog.c
@@ -42,6 +42,10 @@ should_skip_entry (BzEntry *entry,
   if (bz_entry_is_holding (entry))
     return TRUE;
 
+  if (!remove && BZ_IS_FLATPAK_ENTRY (entry) &&
+      bz_flatpak_entry_is_installed_ref (BZ_FLATPAK_ENTRY (entry)))
+    return TRUE;
+
   is_installed = bz_entry_is_installed (entry);
 
   return (!remove && is_installed) || (remove && !is_installed);
@@ -327,6 +331,18 @@ show_dialog_fiber (ShowDialogData *data)
           bz_show_error_for_widget (data->parent, local_error->message);
           return dex_future_new_for_error (g_steal_pointer (&local_error));
         }
+
+      for (guint i = g_list_model_get_n_items (G_LIST_MODEL (store)); i > 0; i--)
+        {
+          g_autoptr (BzEntry) entry = NULL;
+
+          entry = g_list_model_get_item (G_LIST_MODEL (store), i - 1);
+          if (BZ_IS_FLATPAK_ENTRY (entry) &&
+              bz_flatpak_entry_is_installed_ref (BZ_FLATPAK_ENTRY (entry)) &&
+              (!data->remove || !bz_entry_is_installed (entry)))
+            g_list_store_remove (store, i - 1);
+        }
+
       title = bz_entry_group_get_title (data->group);
       id    = bz_entry_group_get_id (data->group);
 


### PR DESCRIPTION
We might not be able to support installs from user remotes in the Flatpak due to the extra-data issue, but I don’t see a reason why we can’t allow listing and removal already installed user refs, especially since we already have the infrastructure to load as installed refs that cant be reinstalled due to already supporting non-enumerable refs.

It would help a lot of people who are migrating from another app store where user installs are possible.