### PR TITLE
fix: use proper finish-arg for user flatpaks path

### DIFF
--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.json
@@ -16,7 +16,7 @@
     "--socket=wayland",
     "--device=dri",
     "--filesystem=/var/lib/flatpak",
-    "--filesystem=~/.local/share/flatpak",
+    "--filesystem=xdg-data/flatpak",
     "--filesystem=~/.var/app",
     "--talk-name=org.freedesktop.Flatpak",
     "--system-talk-name=org.freedesktop.Flatpak.SystemHelper",


### PR DESCRIPTION
This is what we are supposed to be using, this would pass a review on flatpak-builder-lint.