### PR TITLE
Add error pill to transaction tile

### DIFF
--- a/src/bz-transaction-tile.blp
+++ b/src/bz-transaction-tile.blp
@@ -204,6 +204,30 @@ template $BzTransactionTile: $BzListTile {
               }
 
               Box {
+                visible: bind $is_transaction_tracker_errored(template.tracker as <$BzTransactionEntryTracker>.finished-ops) as <bool>;
+                halign: start;
+                spacing: 4;
+                margin-top: 8;
+
+                styles [
+                  "error",
+                  "colored",
+                  "small-pill",
+                  "download-size-pill",
+                ]
+
+                Label {
+                  styles [
+                    "caption-heading",
+                  ]
+
+                  valign: center;
+                  xalign: 0.0;
+                  label: _("Error");
+                }
+              }
+
+              Box {
                 halign: start;
                 spacing: 4;
                 margin-top: 8;
@@ -355,6 +379,8 @@ template $BzTransactionTile: $BzListTile {
                       single-line-mode: true;
                       label: bind template.item as <$BzTransactionTask>.op as <$BzBackendTransactionOpPayload>.name;
                       visible: bind $invert_boolean($is_null(template.item as <$BzTransactionTask>.error) as <bool>) as <bool>;
+                      has-tooltip: true;
+                      tooltip-text: bind template.item as <$BzTransactionTask>.error as <string>;
                     }
                   }
                 };

--- a/src/bz-transaction-tile.c
+++ b/src/bz-transaction-tile.c
@@ -155,6 +155,28 @@ is_transaction_tracker_removal (gpointer                   object,
 }
 
 static gboolean
+is_transaction_tracker_errored (gpointer    object,
+                                GListModel *finished_ops)
+{
+  guint n_items = 0;
+
+  if (finished_ops == NULL)
+    return FALSE;
+
+  n_items = g_list_model_get_n_items (finished_ops);
+  for (guint i = 0; i < n_items; i++)
+    {
+      g_autoptr (BzTransactionTask) task = NULL;
+
+      task = g_list_model_get_item (finished_ops, i);
+      if (bz_transaction_task_get_error (task) != NULL)
+        return TRUE;
+    }
+
+  return FALSE;
+}
+
+static gboolean
 list_has_items (gpointer    object,
                 GListModel *model)
 {
@@ -350,6 +372,7 @@ bz_transaction_tile_class_init (BzTransactionTileClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, is_transaction_tracker_install);
   gtk_widget_class_bind_template_callback (widget_class, is_transaction_tracker_update);
   gtk_widget_class_bind_template_callback (widget_class, is_transaction_tracker_removal);
+  gtk_widget_class_bind_template_callback (widget_class, is_transaction_tracker_errored);
   gtk_widget_class_bind_template_callback (widget_class, list_has_items);
   gtk_widget_class_bind_template_callback (widget_class, is_queued);
   gtk_widget_class_bind_template_callback (widget_class, is_ongoing);


### PR DESCRIPTION
Previously you had to open the dropdown to see that a transaction had errored out.

<img width="895" height="706" alt="Screenshot From 2026-02-10 20-53-21" src="https://github.com/user-attachments/assets/ef0c08a3-eb2f-47a4-b40f-dc531ca609f4" />
