### PR TITLE
Hide title on app page until header is no longer visible

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -7,6 +7,19 @@ template $BzFullView: Adw.Bin {
 
     [top]
     Adw.HeaderBar header_bar {
+      overflow: hidden;
+
+      [title]
+      Revealer {
+        reveal-child: bind $is_scrolled_down(main_scroll.vadjustment as <Adjustment>.value) as <bool>;
+        transition-type: slide_up;
+        transition-duration: 500;
+        overflow: visible;
+        child: Label {
+          label: bind template.entry-group as <$BzEntryGroup>.title;
+          styles ["title"]
+        };
+      }
 
       [end]
       MenuButton {

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -200,6 +200,13 @@ format_with_small_suffix (char *number, const char *suffix)
                           number, suffix);
 }
 
+static gboolean
+is_scrolled_down (gpointer object,
+                  double   value)
+{
+  return value > 100.0;
+}
+
 static char *
 format_favorites_count (gpointer object,
                         int      favorites_count)
@@ -1177,6 +1184,7 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_child (widget_class, BzFullView, wide_install_button);
   gtk_widget_class_bind_template_child (widget_class, BzFullView, narrow_install_button);
   gtk_widget_class_bind_template_child (widget_class, BzFullView, narrow_open_button);
+  gtk_widget_class_bind_template_callback (widget_class, is_scrolled_down);
   gtk_widget_class_bind_template_callback (widget_class, format_favorites_count);
   gtk_widget_class_bind_template_callback (widget_class, format_recent_downloads);
   gtk_widget_class_bind_template_callback (widget_class, format_recent_downloads_tooltip);

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -347,7 +347,7 @@ template $BzWindow: Adw.ApplicationWindow {
 
               Adw.NavigationPage {
                 tag: "view";
-                title: bind full_view.ui-entry as <$BzResult>.object as <$BzEntry>.title;
+                title: "view";
 
                 child: $BzFullView full_view {
                   state: bind template.state;


### PR DESCRIPTION
It was a bit awkward seeing the app name twice so close to each other

https://github.com/user-attachments/assets/c51f9d5d-d9de-45c4-aaac-71b00f7ca345

