### PR TITLE
Improve list parsing for malformed appstream

### DIFF
--- a/src/bz-appstream-description-render.c
+++ b/src/bz-appstream-description-render.c
@@ -317,6 +317,7 @@ compile (BzAppstreamDescriptionRender *self,
   XbNode      *child      = NULL;
   int          kind       = NO_ELEMENT;
   GtkTextMark *start_mark = NULL;
+  int          child_count= 0;
 
   element    = xb_node_get_element (node);
   text       = xb_node_get_text (node);
@@ -354,7 +355,7 @@ compile (BzAppstreamDescriptionRender *self,
               gtk_text_buffer_apply_tag_by_name (buffer, "list-number", &prefix_start_iter, iter);
               gtk_text_buffer_delete_mark (buffer, prefix_start_mark);
             }
-          else if (parent_kind == UNORDERED_LIST)
+          else
             gtk_text_buffer_insert (buffer, iter, "• ", -1);
         }
       else if (g_strcmp0 (element, "code") == 0)
@@ -398,6 +399,7 @@ compile (BzAppstreamDescriptionRender *self,
 
       g_object_unref (child);
       child = next;
+      child_count++;
     }
 
   if (start_mark != NULL)
@@ -426,7 +428,7 @@ compile (BzAppstreamDescriptionRender *self,
 
   if (kind == PARAGRAPH && !is_last_sibling)
     gtk_text_buffer_insert (buffer, iter, "\n", 1);
-  else if ((kind == ORDERED_LIST || kind == UNORDERED_LIST) && !is_last_sibling)
+  else if ((kind == ORDERED_LIST || kind == UNORDERED_LIST) && !is_last_sibling && child_count > 0)
     gtk_text_buffer_insert (buffer, iter, "\n", 1);
 }
 


### PR DESCRIPTION
Fixes the issue where [this description](https://github.com/jardon/outlet/blob/0b4309336896d4ebe56bc515c218620c634c9f72/dist/io.github.jardon.Outlet.metainfo.xml#L45-L71) would cause a bunch of newlines to be shown. The new behavior removes these newlines but still does not render the text, like the Flathub site.

Also fixes a more theoretical issue where, if an `li` tag appears while not inside a `ul` or `ol`, it wouldn’t have a prefix. The new behavior is to just fall back to `ul`.