### PR TITLE
Disable the update banner on first start

### DIFF
--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -949,7 +949,7 @@ init_fiber (GWeakRef *wr)
         }
     }
   else
-    bz_state_info_set_donation_prompt_dismissed (self->state, FALSE);
+    bz_state_info_set_donation_prompt_dismissed (self->state, TRUE);
 
   g_clear_object (&self->flatpak);
   self->flatpak = dex_await_object (bz_flatpak_instance_new (), &local_error);


### PR DESCRIPTION
It does not make sense for this banner to be shown to users who probably have not even used the app yet.