### PR TITLE
Add Runtime info to full view

### DIFF
--- a/src/bz-app-size-dialog.blp
+++ b/src/bz-app-size-dialog.blp
@@ -99,6 +99,28 @@ template $BzAppSizeDialog: Adw.Dialog {
             title: _("User Data Size");
             subtitle: _("Caches, settings, and other app data");
           }
+
+          Adw.ActionRow {
+            visible: bind $invert_boolean($is_null(template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.runtime as <$BzResult>.object) as <bool>) as <bool>;
+
+            [prefix]
+            Label {
+              label: bind $format_size(template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.runtime as <$BzResult>.object as <$BzEntry>.installed-size as <int>) as <string>;
+              use-markup: true;
+              valign: center;
+              width-request: 90;
+              margin-top: 8;
+              margin-bottom: 8;
+
+              styles [
+                "circular-lozenge",
+                "title-4",
+                "grey",
+              ]
+            }
+            title: _("Runtime Size");
+            subtitle: bind template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.runtime as <$BzResult>.object as <$BzEntry>.title;
+          }
         }
       };
     };

--- a/src/bz-flatpak-entry.c
+++ b/src/bz-flatpak-entry.c
@@ -27,26 +27,31 @@
 #include <xmlb.h>
 
 #include "bz-app-permissions.h"
+#include "bz-application-map-factory.h"
+#include "bz-application.h"
 #include "bz-appstream-parser.h"
 #include "bz-flatpak-private.h"
 #include "bz-io.h"
+#include "bz-result.h"
 #include "bz-serializable.h"
+#include "bz-state-info.h"
 
 struct _BzFlatpakEntry
 {
   BzEntry parent_instance;
 
-  gboolean user;
-  gboolean is_bundle;
-  gboolean is_installed_ref;
-  char    *flatpak_name;
-  char    *flatpak_id;
-  char    *flatpak_version;
-  char    *application_name;
-  char    *application_runtime;
-  char    *application_command;
-  char    *runtime_name;
-  char    *addon_extension_of_ref;
+  gboolean  user;
+  gboolean  is_bundle;
+  gboolean  is_installed_ref;
+  char     *flatpak_name;
+  char     *flatpak_id;
+  char     *flatpak_version;
+  char     *application_name;
+  char     *application_runtime;
+  char     *application_command;
+  char     *runtime_name;
+  char     *addon_extension_of_ref;
+  BzResult *runtime_result;
 
   FlatpakRef *ref;
 };
@@ -73,6 +78,7 @@ enum
   PROP_APPLICATION_RUNTIME,
   PROP_APPLICATION_COMMAND,
   PROP_RUNTIME_NAME,
+  PROP_RUNTIME_RESULT,
   PROP_ADDON_OF_REF,
 
   LAST_PROP
@@ -109,6 +115,9 @@ bz_flatpak_entry_get_property (GObject    *object,
     case PROP_FLATPAK_ID:
       g_value_set_string (value, self->flatpak_id);
       break;
+    case PROP_FLATPAK_NAME:
+      g_value_set_string (value, self->flatpak_name);
+      break;
     case PROP_FLATPAK_VERSION:
       g_value_set_string (value, self->flatpak_version);
       break;
@@ -126,6 +135,9 @@ bz_flatpak_entry_get_property (GObject    *object,
       break;
     case PROP_RUNTIME_NAME:
       g_value_set_string (value, self->runtime_name);
+      break;
+    case PROP_RUNTIME_RESULT:
+      g_value_take_object (value, bz_flatpak_entry_get_runtime (self));
       break;
     case PROP_ADDON_OF_REF:
       g_value_set_string (value, self->addon_extension_of_ref);
@@ -225,6 +237,13 @@ bz_flatpak_entry_class_init (BzFlatpakEntryClass *klass)
           NULL, NULL, NULL,
           G_PARAM_READABLE);
 
+  props[PROP_RUNTIME_RESULT] =
+      g_param_spec_object (
+          "runtime",
+          NULL, NULL,
+          BZ_TYPE_RESULT,
+          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
   props[PROP_ADDON_OF_REF] =
       g_param_spec_string (
           "addon-extension-of-ref",
@@ -316,6 +335,37 @@ serializable_iface_init (BzSerializableInterface *iface)
 {
   iface->serialize   = bz_flatpak_entry_real_serialize;
   iface->deserialize = bz_flatpak_entry_real_deserialize;
+}
+
+BzResult *
+bz_flatpak_entry_get_runtime (BzFlatpakEntry *self)
+{
+  BzStateInfo             *state             = NULL;
+  BzApplicationMapFactory *factory           = NULL;
+  g_autofree char         *runtime_unique_id = NULL;
+
+  g_return_val_if_fail (BZ_IS_FLATPAK_ENTRY (self), NULL);
+
+  state = bz_state_info_get_default ();
+
+  if (self->runtime_result != NULL)
+    return g_object_ref (self->runtime_result);
+
+  if (self->application_runtime == NULL)
+    return NULL;
+
+  factory = bz_state_info_get_entry_factory (state);
+  if (factory == NULL)
+    return NULL;
+
+  runtime_unique_id = g_strdup_printf ("FLATPAK-SYSTEM::flathub::runtime/%s",
+                                       self->application_runtime);
+
+  self->runtime_result = bz_application_map_factory_convert_one (
+      factory,
+      gtk_string_object_new (runtime_unique_id));
+
+  return self->runtime_result != NULL ? g_object_ref (self->runtime_result) : NULL;
 }
 
 BzFlatpakEntry *
@@ -571,6 +621,15 @@ bz_flatpak_entry_new_for_ref (FlatpakRef    *ref,
         title = self->flatpak_id;
     }
 
+  if ((kinds & BZ_ENTRY_KIND_RUNTIME) && !(kinds & BZ_ENTRY_KIND_ADDON) && self->flatpak_version != NULL)
+    {
+      if (!g_str_has_suffix (title, self->flatpak_version)) // GNOME runtimes have the flatpak version at the end whilst others don't.
+        {
+          g_autofree char *original_title = g_strdup (title);
+          title = g_strdup_printf ("%s %s", original_title, self->flatpak_version);
+        }
+    }
+
   if (FLATPAK_IS_REMOTE_REF (ref))
     eol = flatpak_remote_ref_get_eol (FLATPAK_REMOTE_REF (ref));
   else if (FLATPAK_IS_INSTALLED_REF (ref))
@@ -781,4 +840,5 @@ clear_entry (BzFlatpakEntry *self)
   g_clear_pointer (&self->application_command, g_free);
   g_clear_pointer (&self->runtime_name, g_free);
   g_clear_pointer (&self->addon_extension_of_ref, g_free);
+  g_clear_object (&self->runtime_result);
 }

--- a/src/bz-flatpak-entry.h
+++ b/src/bz-flatpak-entry.h
@@ -22,6 +22,7 @@
 
 #include "bz-entry.h"
 #include "bz-flatpak-instance.h"
+#include "bz-result.h"
 
 G_BEGIN_DECLS
 
@@ -52,6 +53,9 @@ bz_flatpak_entry_get_application_runtime (BzFlatpakEntry *self);
 
 const char *
 bz_flatpak_entry_get_runtime_name (BzFlatpakEntry *self);
+
+BzResult *
+bz_flatpak_entry_get_runtime (BzFlatpakEntry *self);
 
 gboolean
 bz_flatpak_entry_is_bundle (BzFlatpakEntry *self);

--- a/src/bz-safety-dialog.blp
+++ b/src/bz-safety-dialog.blp
@@ -71,9 +71,12 @@ template $BzSafetyDialog: Adw.Dialog {
 
             Adw.ActionRow {
               title: _("SDK");
-              visible: bind $invert_boolean($is_null(template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.application-runtime) as <bool>) as <bool>;
-              subtitle: bind template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.application-runtime;
+              subtitle: bind template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.runtime as <$BzResult>.object as <$BzEntry>.title;
               subtitle-selectable: true;
+              has-tooltip: true;
+              tooltip-text: bind template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.application-runtime;
+              visible: bind $invert_boolean($is_null(template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.runtime as <$BzResult>.object) as <bool>) as <bool>;
+
               styles [
                 "property",
               ]


### PR DESCRIPTION
Async loads the runtime of the UI entry and uses its metadata in the app size dialog and safety dialog

Closes #1058 
<img width="1120" height="987" alt="Screenshot From 2026-02-15 18-19-38" src="https://github.com/user-attachments/assets/dd2107dd-85e3-4ce4-b788-fe42a6acf11c" />
