### PR TITLE
docs: explain how to get useful crash reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_form.yml
@@ -10,7 +10,7 @@ body:
     id: describe-bug
     attributes:
       label: Describe the bug
-      description: A clear and concise description of what the bug is. If you are reporting a crash with the flatpak version please follow https://docs.flatpak.org/en/latest/debugging.html
+      description: A clear and concise description of what the bug is. If you are reporting a crash please take a look at https://github.com/kolunmi/bazaar/blob/debug-symbols/docs/debugging.md#debugging-crashes
       placeholder: Tell us what happened!
       value: "When I entered 2 + 2, I got the answer 6."
     validations:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -28,3 +28,48 @@ property, not a configuration option; It will not be saved for the next Bazaar
 process.
 
 The rest of the contents of this window should be self-explanatory.
+
+# Debugging Crashes
+
+## Flatpak
+
+### Installing debug symbols
+
+This is mostly based on [flatpak docs](https://docs.flatpak.org/en/latest/debugging.html).
+
+Installing debug extensions so the stacktrace is actually useful for developers:
+```sh
+flatpak install --include-debug --include-sdk io.github.kolunmi.Bazaar
+```
+
+You can remove all the gnome sdk and debug extensions again when you are finished with debugging.
+This is quite a big download, please have patience.
+
+### Actually start debugging
+
+Bazaar starts a background service once started, make sure it is not running first:
+```sh
+flatpak kill io.github.kolunmi.Bazaar
+```
+
+```sh
+flatpak run --devel --command=bash io.github.kolunmi.Bazaar
+```
+
+This will get you a shell inside the flatpak sandbox:
+run this: `gdb /app/bin/bazaar`
+```sh
+[📦 io.github.kolunmi.Bazaar ~]$ gdb /app/bin/bazaar
+```
+
+actually run bazaar:
+```sh
+$ (gdb) run
+```
+
+(reproduce the bug here so it crashes)
+
+after it crashed, the actual useful information:
+```sh
+$ (gdb) thread apply all backtrace
+```


### PR DESCRIPTION
The flatpak install command is a bit unfortunate as this also pulls in
aarch64 and i386 Debug extensions, even if we don't need them at all,
but this is the most maintainable way to document this.

Or else we would have to update the documentation every time we update
the gnome runtime. As we only actually need
`io.github.kolunmi.Bazaar.Debug` and `org.gnome.Sdk.Debug`.