### PR TITLE
Restore contrast to featured carousel text

### DIFF
--- a/src/gtk/style.css
+++ b/src/gtk/style.css
@@ -262,6 +262,14 @@
 	--accent-bg-color: @window_fg_color;
 }
 
+.flathub-lotion {
+  color: #fafafa;
+}
+
+.flathub-gunmetal {
+  color: #251f32;
+}
+
 @media (prefers-color-scheme: dark) {
   .flathub {
     --accent-color: alpha(#fafafa,0.75);


### PR DESCRIPTION
These 2 styles were accidentally removed some time ago.