### PR TITLE
Proxy screenshots via Flathub

### DIFF
--- a/src/bz-appstream-parser.c
+++ b/src/bz-appstream-parser.c
@@ -49,6 +49,42 @@ calculate_is_mobile_friendly (guint required_controls,
   return (supported_controls & BZ_CONTROL_TOUCH) != 0;
 }
 
+static char *
+proxy_screenshot_url (const char *url, gboolean high_quality)
+{
+  g_autofree char *src         = NULL;
+  g_autofree char *encoded_url = NULL;
+  const char      *suffix      = NULL;
+
+  if (g_str_has_prefix (url, "https://dl.flathub.org/repo/screenshots/"))
+    {
+      suffix = url + strlen ("https://dl.flathub.org/repo/screenshots/");
+      src    = g_strdup_printf ("https://dl.flathub.org/media/%s", suffix);
+    }
+  else if (g_str_has_prefix (url, "https://dl.flathub.org/"))
+    {
+      src = g_strdup (url);
+    }
+  else
+    {
+      return g_strdup (url);
+    }
+
+  encoded_url = g_base64_encode ((const guchar *) src, strlen (src));
+  g_strdelimit (encoded_url, "=", '\0');
+
+  for (char *p = encoded_url; *p; p++)
+    {
+      if (*p == '+') *p = '-';
+      if (*p == '/') *p = '_';
+    }
+
+  return g_strdup_printf (
+      "https://imgproxy.flathub.org/insecure/%s/%s",
+      high_quality ? "q:90/f:avif" : "dpr:1/f:avif/rs:fill-down",
+      encoded_url);
+}
+
 static GdkPaintable *
 find_screenshot (GPtrArray  *images,
                  const char *caption,
@@ -106,9 +142,11 @@ find_screenshot (GPtrArray  *images,
     {
       g_autoptr (GFile) screenshot_file = NULL;
       g_autoptr (GFile) cache_file      = NULL;
+      g_autofree char  *proxied_url     = NULL;
       BzAsyncTexture *texture           = NULL;
 
-      screenshot_file = g_file_new_for_uri (best_url);
+      proxied_url     = proxy_screenshot_url (best_url, match_highest);
+      screenshot_file = g_file_new_for_uri (proxied_url);
       cache_file      = g_file_new_build_filename (
           module_dir, unique_id_checksum, cache_filename, NULL);
 
@@ -228,13 +266,13 @@ bz_appstream_parser_populate_entry (BzEntry     *entry,
           if (i == 0 && thumbnail_paintable == NULL)
             {
               thumbnail_paintable = find_screenshot (images, caption, FALSE, 400, 300, TRUE,
-                                                     module_dir, unique_id_checksum, "thumbnail.png", NULL);
+                                                     module_dir, unique_id_checksum, "thumbnail", NULL);
               if (thumbnail_paintable == NULL)
                 thumbnail_paintable = find_screenshot (images, caption, FALSE, 400, 300, FALSE,
-                                                       module_dir, unique_id_checksum, "thumbnail.png", NULL);
+                                                       module_dir, unique_id_checksum, "thumbnail", NULL);
             }
 
-          cache_name = g_strdup_printf ("screenshot_%u.png", i);
+          cache_name = g_strdup_printf ("screenshot_%u", i);
           paintable  = find_screenshot (images, caption, TRUE, 0, 0, TRUE,
                                         module_dir, unique_id_checksum, cache_name, &caption_str);
           if (paintable == NULL)


### PR DESCRIPTION
This should hopefully reduce the cache size and the amount of data the user needs to download.

The non search thumbnail screenshots are less compressed so they still look reasonably good in the image viewer.