### PR TITLE
chore: mention secureblue in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_form.yml
@@ -31,7 +31,7 @@ body:
       label: Version
       description: |
         Please check the current version of Bazaar (Main Window > About Bazaar) so we can more easily indentify issues.
-        Output of `flatpak info io.github.kolunmi.Bazaar`. If you are on Bazzite please run `rpm -qi bazaar`
+        Output of `flatpak info io.github.kolunmi.Bazaar`. If you are on Bazzite or secureblue please run `rpm -qi bazaar`
     validations:
       required: true
 


### PR DESCRIPTION
Since Secureblue now includes Bazaar in all flavors instead of using native app stores since v4.8.1 I think we should accept their reports as well if it's relevant for everyone else and not isolated to just secureblue specifically.