### PR TITLE
Bring back transaction error button

### DIFF
--- a/src/bz-transaction-tile.blp
+++ b/src/bz-transaction-tile.blp
@@ -400,6 +400,19 @@ template $BzTransactionTile: $BzListTile {
                       has-tooltip: true;
                       tooltip-text: bind template.item as <$BzTransactionTask>.error as <string>;
                     }
+
+                    Button {
+                      icon-name: "info-outline-symbolic";
+                      clicked => $error_clicked_cb(template);
+                      visible: bind $invert_boolean($is_null(template.item as <$BzTransactionTask>.error) as <bool>) as <bool>;
+                      has-tooltip: true;
+                      tooltip-text: _("Show Error Info");
+
+                      styles [
+                        "error",
+                        "flat",
+                      ]
+                    }
                   }
                 };
               }


### PR DESCRIPTION
It was very idiotic that you had to hover over the text to see the error message, so I re added the error button, it now opens the new error dialog.


<img width="1132" height="891" alt="image" src="https://github.com/user-attachments/assets/b5152f1f-34f7-47af-ad6b-9fe94ecb93db" />
