### PR TITLE
Ask user to setup system Flathub when in Flatpak

### DIFF
--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -963,15 +963,27 @@ init_fiber (GWeakRef *wr)
           AdwDialog *alert = NULL;
 
           alert = adw_alert_dialog_new (NULL, NULL);
-          adw_alert_dialog_set_prefer_wide_layout (ADW_ALERT_DIALOG (alert), TRUE);
+
+#ifdef SANDBOXED_LIBFLATPAK
           adw_alert_dialog_format_heading (
               ADW_ALERT_DIALOG (alert),
-              _ ("Set Up Flathub"));
+              _ ("Set Up System Flathub?"));
+          adw_alert_dialog_format_body (
+              ADW_ALERT_DIALOG (alert),
+              _ ("The system Flathub remote is not set up. Bazaar requires "
+                 "Flathub to be configured on the system Flatpak installation "
+                 "to browse and install applications.\n\n"
+                 "You can still use Bazaar to browse and remove already installed apps."));
+#else
+          adw_alert_dialog_format_heading (
+              ADW_ALERT_DIALOG (alert),
+              _ ("Set Up Flathub?"));
           adw_alert_dialog_format_body (
               ADW_ALERT_DIALOG (alert),
               _ ("Flathub is not set up on this system. "
                  "You will not be able to browse and install applications in Bazaar if its unavailable.\n\n"
                  "You can still use Bazaar to browse and remove already installed apps."));
+#endif
           adw_alert_dialog_add_responses (
               ADW_ALERT_DIALOG (alert),
               "later", _ ("Later"),

--- a/src/bz-flatpak-instance.c
+++ b/src/bz-flatpak-instance.c
@@ -768,6 +768,8 @@ check_has_flathub_fiber (CheckHasFlathubData *data)
       n_system_remotes = system_remotes->len;
     }
 
+// Downloading from user remotes in the Flatpak is unsupported.
+#ifndef SANDBOXED_LIBFLATPAK
   if (self->user != NULL)
     {
       user_remotes = flatpak_installation_list_remotes (
@@ -780,6 +782,7 @@ check_has_flathub_fiber (CheckHasFlathubData *data)
             local_error->message);
       n_user_remotes = user_remotes->len;
     }
+#endif
 
   for (guint i = 0; i < n_system_remotes + n_user_remotes; i++)
     {


### PR DESCRIPTION
Newer versions of Flatpak support user remotes, but only for listing already installed apps, causing an edge case when users might only have the user Flathub. This results in the dialog not being shown, even though they cannot install apps from Flathub.