### PR TITLE
Follow GNOME HIG's capitalization guidelines

### DIFF
--- a/src/bz-addons-dialog.blp
+++ b/src/bz-addons-dialog.blp
@@ -13,7 +13,7 @@ template $BzAddonsDialog: Adw.Dialog {
           "heading",
         ]
 
-        label: _("Manage Add-ons");
+        label: _("Manage Add-Ons");
       };
     }
 

--- a/src/bz-all-apps-page.blp
+++ b/src/bz-all-apps-page.blp
@@ -32,7 +32,7 @@ template $BzAllAppsPage: Adw.NavigationPage {
             }
 
             item {
-              label: _("_Login with Flathub");
+              label: _("_Login With Flathub");
               action: "app.flathub-login";
               hidden-when: "action-disabled";
             }

--- a/src/bz-apps-page.blp
+++ b/src/bz-apps-page.blp
@@ -32,7 +32,7 @@ template $BzAppsPage: Adw.NavigationPage {
             }
 
             item {
-              label: _("_Login with Flathub");
+              label: _("_Login With Flathub");
               action: "app.flathub-login";
               hidden-when: "action-disabled";
             }

--- a/src/bz-entry-selection-row.blp
+++ b/src/bz-entry-selection-row.blp
@@ -14,7 +14,7 @@ template $BzEntrySelectionRow: Adw.ActionRow {
     visible: bind template.repository as <$BzRepository>.is-user;
     icon-name: "person-symbolic";
     has-tooltip: true;
-    tooltip-text: _("For this user only");
+    tooltip-text: _("For This User Only");
   }
 
   title: bind template.repository as <$BzRepository>.title;

--- a/src/bz-favorites-tile.blp
+++ b/src/bz-favorites-tile.blp
@@ -67,7 +67,7 @@ template $BzFavoritesTile: $BzListTile {
       ]
 
       has-tooltip: true;
-      tooltip-text: _("Support this application");
+      tooltip-text: _("Support This Application");
 
       width-request: 32;
       height-request: 32;
@@ -116,7 +116,7 @@ template $BzFavoritesTile: $BzListTile {
             height-request: 32;
             valign: center;
             has-tooltip: true;
-            tooltip-text: _("Remove from Favorites");
+            tooltip-text: _("Remove From Favorites");
             icon-name: "bookmark-filled-symbolic";
             clicked => $unfavorite_cb() swapped;
           };

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -707,7 +707,7 @@ template $BzFullView: Adw.Bin {
                               ]
                             }
 
-                            title: _("Manage Add-ons");
+                            title: _("Manage Add-Ons");
                             activatable: true;
                             activated => $install_addons_cb(template);
                           }

--- a/src/bz-transaction-tile.blp
+++ b/src/bz-transaction-tile.blp
@@ -123,7 +123,7 @@ template $BzTransactionTile: $BzListTile {
 
                   valign: center;
                   xalign: 0.0;
-                  label: _("App Add-on");
+                  label: _("App Add-On");
                 }
               }
 

--- a/src/bz-user-data-page.blp
+++ b/src/bz-user-data-page.blp
@@ -33,7 +33,7 @@ template $BzUserDataPage: Adw.NavigationPage {
             }
 
             item {
-              label: _("_Login with Flathub");
+              label: _("_Login With Flathub");
               action: "app.flathub-login";
               hidden-when: "action-disabled";
             }
@@ -86,7 +86,7 @@ template $BzUserDataPage: Adw.NavigationPage {
           title: _("Empty");
           child: Adw.StatusPage {
             icon-name: "folder-documents-symbolic";
-            title: _("No User Data found");
+            title: _("No User Data Found");
           };
         }
         Adw.ViewStackPage {


### PR DESCRIPTION
Some labels and tooltips weren't following the GNOME HIG's suggestions on [capitalization](https://developer.gnome.org/hig/guidelines/writing-style.html#header-capitalization). If you disagree with any of these changes, I can adjust them.