### PR TITLE
Fix "is mobile friendly" calculations

### DIFF
--- a/src/bz-appstream-parser.c
+++ b/src/bz-appstream-parser.c
@@ -42,11 +42,12 @@ parse_control_value (const char *value)
 
 static gboolean
 calculate_is_mobile_friendly (guint required_controls,
-                              guint supported_controls,
-                              gint  min_display_length,
-                              gint  max_display_length)
+                              guint recommended_controls,
+                              guint supported_controls)
 {
-  return (supported_controls & BZ_CONTROL_TOUCH) != 0;
+  return (required_controls & BZ_CONTROL_TOUCH) != 0 ||
+         (recommended_controls & BZ_CONTROL_TOUCH) != 0 ||
+         (supported_controls & BZ_CONTROL_TOUCH) != 0;
 }
 
 static char *
@@ -588,9 +589,8 @@ bz_appstream_parser_populate_entry (BzEntry     *entry,
     }
 
   is_mobile_friendly = calculate_is_mobile_friendly (required_controls,
-                                                     supported_controls,
-                                                     min_display_length,
-                                                     max_display_length);
+                                                     recommended_controls,
+                                                     supported_controls);
 
   if (as_search_tokens != NULL)
     {


### PR DESCRIPTION
It did not see apps that recommend touch as mobile friendly apps such as this one:
https://github.com/lainsce/colorway/blob/main/data/io.github.lainsce.Colorway.metainfo.xml.in

It was a bug in the algorithm, apps that "recommended" touch input were not considered mobile friendly.

Also, both we and GNOME Software only check for touch input, while Flathub additionally checks the minimum and maximum supported display widths. As a result, apps like Bazaar may appear as mobile friendly on the app page but not show up in the mobile category.