### PR TITLE
add malcontent support (parental controls)

### DIFF
--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.json
@@ -80,6 +80,29 @@
           ]
         },
         {
+          "name": "malcontent",
+          "buildsystem": "meson",
+          "config-opts": [
+	    "-Dui=disabled",
+	    "-Dinstalled_tests=false"
+          ],
+          "sources": [
+            {
+              "type": "git",
+              "url": "https://gitlab.freedesktop.org/pwithnall/malcontent.git",
+              "tag": "0.12.0"
+            },
+            {
+	      "type": "shell",
+	      "commands": [
+		"sed -i \"/subdir('tests')/d\" libmalcontent/meson.build",
+		"sed -i \"/subdir('tests')/d\" meson.build",
+		"sed -i \"/subdir('pam')/d\" meson.build"
+	      ]
+	    }
+          ]
+        },
+        {
           "name": "flatpak",
           "buildsystem": "meson",
           "config-opts": [

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -48,6 +48,7 @@
 #include "bz-internal-config.h"
 #include "bz-io.h"
 #include "bz-login-page.h"
+#include "bz-malcontent-service.h"
 #include "bz-newline-parser.h"
 #include "bz-parser.h"
 #include "bz-preferences-dialog.h"
@@ -78,6 +79,7 @@ struct _BzApplication
   BzGnomeShellSearchProvider *gs_search;
   BzInternalConfig           *internal_config;
   BzMainConfig               *config;
+  BzMalcontentService        *malcontent;
   BzNewlineParser            *txt_blocklist_parser;
   BzSearchEngine             *search_engine;
   BzStateInfo                *state;
@@ -349,6 +351,7 @@ bz_application_dispose (GObject *object)
   g_clear_object (&self->groups);
   g_clear_object (&self->gs_search);
   g_clear_object (&self->installed_apps);
+  g_clear_object (&self->malcontent);
   g_clear_object (&self->internal_config);
   g_clear_object (&self->network);
   g_clear_object (&self->search_biases);
@@ -1648,6 +1651,8 @@ init_fiber_finally (DexFuture *future,
       self->periodic_timeout_source = g_timeout_add_seconds (
           /* Check every day */
           60 * 60 * 24, (GSourceFunc) periodic_timeout_cb, self);
+
+      bz_malcontent_service_start (self->malcontent);
     }
   else
     {
@@ -2670,6 +2675,24 @@ init_service_struct (BzApplication *self,
     bz_state_info_set_system_icon_theme (self->state, system_theme);
   }
 
+  {
+    g_autoptr (GError)          bus_error = NULL;
+    g_autoptr (GDBusConnection) sys_bus   = NULL;
+
+    sys_bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &bus_error);
+    if (sys_bus != NULL)
+      self->malcontent = bz_malcontent_service_new (sys_bus, self->state);
+    else
+      g_warning ("Failed to connect to system bus for malcontent: %s", bus_error->message);
+
+    if (self->malcontent != NULL)
+      g_signal_connect_swapped (
+          self->state,
+          "notify::parental-blocked-ids",
+          G_CALLBACK (show_hide_app_setting_changed),
+          self);
+  }
+
   g_signal_connect_swapped (
       self->state,
       "notify::disable-blocklists",
@@ -3095,6 +3118,18 @@ validate_group_for_ui (BzApplication *self,
   if (bz_state_info_get_show_only_verified (self->state) &&
       !bz_entry_group_get_is_verified (group))
     return FALSE;
+
+  if (self->malcontent != NULL)
+    {
+      int parental_age = 0;
+      int app_age      = 0;
+
+      parental_age = bz_state_info_get_parental_age_rating (self->state);
+      app_age      = bz_entry_group_get_content_age_rating (group);
+
+      if (app_age > parental_age && parental_age != 0)
+        return FALSE;
+    }
 
   if (bz_state_info_get_disable_blocklists (self->state))
     return TRUE;

--- a/src/bz-entry-group.c
+++ b/src/bz-entry-group.c
@@ -54,6 +54,7 @@ struct _BzEntryGroup
   int            n_addons;
   char          *donation_url;
   GListModel    *categories;
+  int            content_age_rating;
 
   int max_usefulness;
 
@@ -747,6 +748,13 @@ bz_entry_group_get_categories (BzEntryGroup *self)
   return self->categories;
 }
 
+int
+bz_entry_group_get_content_age_rating (BzEntryGroup *self)
+{
+  g_return_val_if_fail (BZ_IS_ENTRY_GROUP (self), 0);
+  return self->content_age_rating;
+}
+
 guint64
 bz_entry_group_get_user_data_size (BzEntryGroup *self)
 {
@@ -861,29 +869,30 @@ bz_entry_group_add (BzEntryGroup *self,
                     BzEntry      *runtime,
                     gboolean      ignore_eol)
 {
-  g_autoptr (GMutexLocker) locker  = NULL;
-  const char   *unique_id          = NULL;
-  const char   *installed_version  = NULL;
-  gint          usefulness         = 0;
-  const char   *eol                = NULL;
-  const char   *title              = NULL;
-  const char   *developer          = NULL;
-  const char   *description        = NULL;
-  GdkPaintable *icon_paintable     = NULL;
-  GIcon        *mini_icon          = NULL;
-  const char   *search_tokens      = NULL;
-  gboolean      is_floss           = FALSE;
-  const char   *light_accent_color = NULL;
-  const char   *dark_accent_color  = NULL;
-  gboolean      is_flathub         = FALSE;
-  gboolean      is_verified        = FALSE;
-  guint64       installed_size     = 0;
-  GListModel   *addons             = NULL;
-  int           n_addons           = 0;
-  const char   *donation_url       = NULL;
-  GListModel   *entry_categories   = NULL;
-  guint         existing           = 0;
-  gboolean      is_searchable      = FALSE;
+  g_autoptr (GMutexLocker) locker     = NULL;
+  const char      *unique_id          = NULL;
+  const char      *installed_version  = NULL;
+  gint             usefulness         = 0;
+  const char      *eol                = NULL;
+  const char      *title              = NULL;
+  const char      *developer          = NULL;
+  const char      *description        = NULL;
+  GdkPaintable    *icon_paintable     = NULL;
+  GIcon           *mini_icon          = NULL;
+  const char      *search_tokens      = NULL;
+  gboolean         is_floss           = FALSE;
+  const char      *light_accent_color = NULL;
+  const char      *dark_accent_color  = NULL;
+  gboolean         is_flathub         = FALSE;
+  gboolean         is_verified        = FALSE;
+  guint64          installed_size     = 0;
+  GListModel      *addons             = NULL;
+  int              n_addons           = 0;
+  const char      *donation_url       = NULL;
+  GListModel      *entry_categories   = NULL;
+  guint            existing           = 0;
+  gboolean         is_searchable      = FALSE;
+  AsContentRating *content_rating     = NULL;
 
   g_return_if_fail (BZ_IS_ENTRY_GROUP (self));
   g_return_if_fail (BZ_IS_ENTRY (entry));
@@ -929,6 +938,7 @@ bz_entry_group_add (BzEntryGroup *self,
   installed_size     = bz_entry_get_installed_size (entry);
   donation_url       = bz_entry_get_donation_url (entry);
   entry_categories   = bz_entry_get_categories (entry);
+  content_rating     = bz_entry_get_content_rating (entry);
 
   addons        = bz_entry_get_addons (entry);
   is_searchable = bz_entry_is_searchable (entry);
@@ -1034,6 +1044,8 @@ bz_entry_group_add (BzEntryGroup *self,
           self->categories = g_object_ref (entry_categories);
           g_object_notify_by_pspec (G_OBJECT (self), props[PROP_CATEGORIES]);
         }
+      if (content_rating != NULL)
+        self->content_age_rating = as_content_rating_get_minimum_age (content_rating);
 
       self->max_usefulness = usefulness;
     }

--- a/src/bz-entry-group.h
+++ b/src/bz-entry-group.h
@@ -97,6 +97,9 @@ bz_entry_group_get_donation_url (BzEntryGroup *self);
 GListModel *
 bz_entry_group_get_categories (BzEntryGroup *self);
 
+int
+bz_entry_group_get_content_age_rating (BzEntryGroup *self);
+
 BzResult *
 bz_entry_group_dup_ui_entry (BzEntryGroup *self);
 

--- a/src/bz-inspector.blp
+++ b/src/bz-inspector.blp
@@ -136,6 +136,44 @@ template $BzInspector: Adw.Window {
         }
       }
 
+      Box {
+        orientation: vertical;
+        spacing: 3;
+
+        Box {
+          orientation: horizontal;
+          spacing: 10;
+
+          Label {
+            styles [
+              "heading"
+            ]
+            label: "Max Age Rating:";
+            xalign: 0.0;
+          }
+          Label {
+            label: bind $format_uint(template.state as <$BzStateInfo>.parental-age-rating) as <string>;
+            xalign: 0.0;
+          }
+        }
+        Label {
+          styles [
+            "heading"
+          ]
+          label: "Restricted App IDs";
+          xalign: 0.0;
+        }
+        ScrolledWindow {
+          propagate-natural-height: true;
+          child: ListView {
+            model: NoSelection {
+              model: bind template.state as <$BzStateInfo>.parental-blocked-ids;
+            };
+            factory: plain_string_list_factory;
+          };
+        }
+      }
+
       Label {
         styles [
           "heading"
@@ -256,6 +294,38 @@ BuilderListItemFactory string_list_factory {
       Button {
         label: "Open";
         clicked => $open_file_externally_cb(template);
+      }
+    };
+  }
+}
+
+BuilderListItemFactory plain_string_list_factory {
+  template ListItem {
+    selectable: false;
+    activatable: false;
+    child: Box {
+      orientation: horizontal;
+      spacing: 10;
+
+      Label {
+        styles [
+          "dimmed",
+          "bz-monospace",
+        ]
+        width-request: 30;
+        label: bind $format_uint(template.position) as <string>;
+        xalign: 1.0;
+      }
+      Label {
+        styles [
+          "bz-monospace",
+        ]
+        hexpand: true;
+        margin-top: 2;
+        margin-bottom: 2;
+        xalign: 0.0;
+        selectable: true;
+        label: bind template.item as <$GtkStringObject>.string as <string>;
       }
     };
   }

--- a/src/bz-install-controls.blp
+++ b/src/bz-install-controls.blp
@@ -48,7 +48,7 @@ template $BzInstallControls: Box {
             styles [
               "pill",
             ]
-
+            visible: bind $invert_boolean($is_blocked(template.state as <$BzStateInfo>.parental-blocked-ids, template.entry-group as <$BzEntryGroup>) as <bool>) as <bool>;
             has-tooltip: true;
             hexpand: bind $invert_boolean(template.wide) as <bool>;
             label: _("Open");

--- a/src/bz-install-controls.c
+++ b/src/bz-install-controls.c
@@ -159,6 +159,30 @@ get_visible_page (gpointer    object,
     return g_strdup ("empty");
 }
 
+static gboolean
+is_blocked (gpointer      object,
+            GListModel   *parental_blocked,
+            BzEntryGroup *group)
+{
+  const char *id = NULL;
+
+  if (parental_blocked == NULL || group == NULL)
+    return FALSE;
+
+  id = bz_entry_group_get_id (group);
+  if (id == NULL)
+    return FALSE;
+
+  for (guint i = 0; i < g_list_model_get_n_items (parental_blocked); i++)
+    {
+      g_autoptr (GtkStringObject) obj = g_list_model_get_item (parental_blocked, i);
+      if (strstr (gtk_string_object_get_string (obj), id) != NULL)
+        return TRUE;
+    }
+
+  return FALSE;
+}
+
 static void
 bz_install_controls_dispose (GObject *object)
 {
@@ -290,6 +314,7 @@ bz_install_controls_class_init (BzInstallControlsClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, run_cb);
   gtk_widget_class_bind_template_callback (widget_class, update_cb);
   gtk_widget_class_bind_template_callback (widget_class, get_visible_page);
+  gtk_widget_class_bind_template_callback (widget_class, is_blocked);
 }
 
 static void

--- a/src/bz-malcontent-service.c
+++ b/src/bz-malcontent-service.c
@@ -1,0 +1,227 @@
+/* bz-malcontent-service.c
+ *
+ * Copyright 2026 Alexander Vanhee
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "config.h"
+
+#include <appstream.h>
+#include <libmalcontent/malcontent.h>
+#include <unistd.h>
+
+#include "bz-malcontent-service.h"
+
+struct _BzMalcontentService
+{
+  GObject          parent_instance;
+  MctManager      *manager;
+  BzStateInfo     *state;
+  GDBusConnection *bus;
+  MctAppFilter    *filter;
+  gulong           changed_id;
+};
+
+G_DEFINE_FINAL_TYPE (BzMalcontentService, bz_malcontent_service, G_TYPE_OBJECT)
+
+static void fetch_blocked_ids (BzMalcontentService *self);
+static void apply_filter (BzMalcontentService *self,
+                          MctAppFilter        *filter);
+static void on_filter_loaded (GObject      *source,
+                              GAsyncResult *result,
+                              gpointer      user_data);
+static void on_filter_changed (MctManager *manager,
+                               guint64     user_id,
+                               gpointer    user_data);
+
+static void
+bz_malcontent_service_dispose (GObject *object)
+{
+  BzMalcontentService *self = NULL;
+
+  self = BZ_MALCONTENT_SERVICE (object);
+
+  g_signal_handler_disconnect (self->manager, self->changed_id);
+  g_clear_object (&self->manager);
+  g_clear_object (&self->state);
+  g_clear_object (&self->bus);
+  g_clear_pointer (&self->filter, mct_app_filter_unref);
+
+  G_OBJECT_CLASS (bz_malcontent_service_parent_class)->dispose (object);
+}
+
+static void
+bz_malcontent_service_class_init (BzMalcontentServiceClass *klass)
+{
+  G_OBJECT_CLASS (klass)->dispose = bz_malcontent_service_dispose;
+}
+
+static void
+bz_malcontent_service_init (BzMalcontentService *self)
+{
+}
+
+BzMalcontentService *
+bz_malcontent_service_new (GDBusConnection *bus,
+                           BzStateInfo     *state)
+{
+  BzMalcontentService *self = NULL;
+
+  self             = g_object_new (BZ_TYPE_MALCONTENT_SERVICE, NULL);
+  self->state      = g_object_ref (state);
+  self->bus        = g_object_ref (bus);
+  self->manager    = mct_manager_new (bus);
+  self->changed_id = g_signal_connect (self->manager,
+                                       "app-filter-changed",
+                                       G_CALLBACK (on_filter_changed),
+                                       self);
+
+  return self;
+}
+
+void
+bz_malcontent_service_start (BzMalcontentService *self)
+{
+  mct_manager_get_app_filter_async (self->manager,
+                                    getuid (),
+                                    MCT_MANAGER_GET_VALUE_FLAGS_INTERACTIVE,
+                                    NULL,
+                                    on_filter_loaded,
+                                    self);
+}
+
+static void
+fetch_blocked_ids (BzMalcontentService *self)
+{
+  g_autoptr (GError) local_error    = NULL;
+  g_autoptr (GVariant) result       = NULL;
+  g_autoptr (GVariant) prop         = NULL;
+  g_autoptr (GVariant) filter_tuple = NULL;
+  g_autoptr (GtkStringList) blocked = NULL;
+  g_autofree char *object_path      = NULL;
+  gboolean         is_allowlist     = FALSE;
+  GVariantIter    *iter             = NULL;
+  const char      *ref              = NULL;
+
+  object_path = g_strdup_printf ("/org/freedesktop/Accounts/User%d", (int) getuid ());
+
+  result = g_dbus_connection_call_sync (
+      self->bus,
+      "org.freedesktop.Accounts",
+      object_path,
+      "org.freedesktop.DBus.Properties",
+      "Get",
+      g_variant_new ("(ss)",
+                     "com.endlessm.ParentalControls.AppFilter",
+                     "AppFilter"),
+      G_VARIANT_TYPE ("(v)"),
+      G_DBUS_CALL_FLAGS_NONE,
+      -1,
+      NULL,
+      &local_error);
+
+  if (result == NULL)
+    {
+      g_warning ("failed to fetch malcontent AppFilter from D-Bus: %s", local_error->message);
+      return;
+    }
+
+  prop         = g_variant_get_child_value (result, 0);
+  filter_tuple = g_variant_get_variant (prop);
+
+  g_variant_get (filter_tuple, "(bas)", &is_allowlist, &iter);
+
+  blocked = gtk_string_list_new (NULL);
+  while (g_variant_iter_next (iter, "s", &ref))
+    gtk_string_list_append (blocked, ref);
+
+  g_variant_iter_free (iter);
+
+  bz_state_info_set_parental_blocked_ids (self->state, G_LIST_MODEL (blocked));
+}
+
+static void
+apply_filter (BzMalcontentService *self,
+              MctAppFilter        *filter)
+{
+  const char *const *oars_sections = NULL;
+  int                max_age       = 0;
+
+  g_clear_pointer (&self->filter, mct_app_filter_unref);
+  self->filter = mct_app_filter_ref (filter);
+
+  oars_sections = mct_app_filter_get_oars_sections (self->filter);
+
+  for (gsize i = 0; oars_sections[i] != NULL; i++)
+    {
+      MctAppFilterOarsValue filter_value;
+      int                   section_age;
+
+      filter_value = mct_app_filter_get_oars_value (self->filter, oars_sections[i]);
+
+      if (filter_value == MCT_APP_FILTER_OARS_VALUE_UNKNOWN)
+        continue;
+
+      section_age = as_content_rating_attribute_to_csm_age (oars_sections[i],
+                                                            (AsContentRatingValue) filter_value);
+
+      if (section_age > max_age)
+        max_age = section_age;
+    }
+
+  bz_state_info_set_parental_age_rating (self->state, max_age);
+
+  fetch_blocked_ids (self);
+}
+
+static void
+on_filter_loaded (GObject      *source,
+                  GAsyncResult *result,
+                  gpointer      user_data)
+{
+  BzMalcontentService *self       = NULL;
+  g_autoptr (MctAppFilter) filter = NULL;
+  g_autoptr (GError) local_error  = NULL;
+
+  self   = user_data;
+  filter = mct_manager_get_app_filter_finish (self->manager, result, &local_error);
+
+  if (filter != NULL)
+    apply_filter (self, filter);
+  else
+    g_warning ("Failed to load malcontent app filter: %s", local_error->message);
+}
+
+static void
+on_filter_changed (MctManager *manager,
+                   guint64     user_id,
+                   gpointer    user_data)
+{
+  BzMalcontentService *self = NULL;
+
+  self = user_data;
+
+  if (user_id != (guint64) getuid ())
+    return;
+
+  mct_manager_get_app_filter_async (self->manager,
+                                    getuid (),
+                                    MCT_MANAGER_GET_VALUE_FLAGS_NONE,
+                                    NULL,
+                                    on_filter_loaded,
+                                    self);
+}

--- a/src/bz-malcontent-service.h
+++ b/src/bz-malcontent-service.h
@@ -1,0 +1,38 @@
+/* bz-malcontent-service.h
+ *
+ * Copyright 2026 Alexander Vanhee
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include "bz-state-info.h"
+#include <appstream.h>
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define BZ_TYPE_MALCONTENT_SERVICE bz_malcontent_service_get_type ()
+G_DECLARE_FINAL_TYPE (BzMalcontentService, bz_malcontent_service, BZ, MALCONTENT_SERVICE, GObject)
+
+BzMalcontentService *
+bz_malcontent_service_new (GDBusConnection *bus,
+                           BzStateInfo     *state);
+void
+bz_malcontent_service_start (BzMalcontentService *self);
+
+G_END_DECLS

--- a/src/bz-state-info.txt
+++ b/src/bz-state-info.txt
@@ -58,3 +58,5 @@ property=transaction_manager BzTransactionManager BZ_TYPE_TRANSACTION_MANAGER ob
 property=txt_blocklists GListModel G_TYPE_LIST_MODEL object
 property=txt_blocklists_provider BzContentProvider BZ_TYPE_CONTENT_PROVIDER object
 property=user_icon_theme GtkIconTheme GTK_TYPE_ICON_THEME object
+property=parental_blocked_ids GListModel G_TYPE_LIST_MODEL object
+property=parental_age_rating int G_TYPE_INT int

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ md4c_dep             = dependency('md4c', version: '>= 0.5.1')
 webkit_dep           = dependency('webkitgtk-6.0', version: '>= 2.50.2')
 libsecret_dep        = dependency('libsecret-1', version: '>= 0.20')
 libproxy_dep         = dependency('libproxy-1.0', version: '>= 0.5')
+malcontent_dep 	     = dependency('malcontent-0', version: '>= 0.12.0')
 
 
 dl_worker_sources = [
@@ -120,6 +121,7 @@ bz_sources = files(
   'bz-list-tile.c',
   'bz-login-page.c',
   'bz-lozenge.c',
+  'bz-malcontent-service.c',
   'bz-markdown-render.c',
   'bz-newline-parser.c',
   'bz-parser.c',
@@ -184,6 +186,7 @@ bz_deps = [
   webkit_dep,
   libsecret_dep,
   libproxy_dep,
+  malcontent_dep,
 ]
 
 gen_gobject = find_program('./gen_gobject.sh')


### PR DESCRIPTION
Add the malcontent service, which maintains a list of blocked refs and a maximum age rating value. This is used to restrict the launch of certain applications and to filter which apps are displayed in the UI respectively.

There is also a "Restrict Application Installation" toggle. However, this is already handled by libflatpak, which prompts the user to enter an administrator password when installing or removing applications if the toggle is on.

You will need an extra user account to test these changes out.

<img width="590" height="671" alt="image" src="https://github.com/user-attachments/assets/e723be67-f3e0-445a-8ce2-169056f18a14" />

