### PR TITLE
Fix age rating notification

### DIFF
--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -2688,7 +2688,7 @@ init_service_struct (BzApplication *self,
     if (self->malcontent != NULL)
       g_signal_connect_swapped (
           self->state,
-          "notify::parental-blocked-ids",
+          "notify::parental-age-rating",
           G_CALLBACK (show_hide_app_setting_changed),
           self);
   }

--- a/src/bz-search-widget.c
+++ b/src/bz-search-widget.c
@@ -516,6 +516,12 @@ bz_search_widget_set_state (BzSearchWidget *self,
           G_CALLBACK (invalidating_state_prop_changed),
           self);
 
+      g_signal_connect_swapped (
+          state,
+          "notify::parental-age-rating",
+          G_CALLBACK (invalidating_state_prop_changed),
+          self);
+
       g_object_get (
           state,
           "blocklists-provider", &self->blocklists_provider,


### PR DESCRIPTION
It was using the wrong variable binding (which happened to change at the same time), and I also forgot to add it to search.