### PR TITLE
Fix open button not having a label

### DIFF
--- a/src/bz-transaction-tile.blp
+++ b/src/bz-transaction-tile.blp
@@ -266,7 +266,7 @@ template $BzTransactionTile: $BzListTile {
                         ) as <bool>;
 
             valign: center;
-            tooltip-text: _("Open App");
+            label: _("Open");
             clicked => $run_cb(template);
 
             styles [


### PR DESCRIPTION
acidentally removed "label" instead of "tooltip-text" and did not notice