### PR TITLE
Make minimum window height smaller

### DIFF
--- a/src/bz-all-apps-page.blp
+++ b/src/bz-all-apps-page.blp
@@ -65,7 +65,7 @@ template $BzAllAppsPage: Adw.NavigationPage {
 
     content: Adw.BreakpointBin {
       width-request: 360;
-      height-request: 450;
+      height-request: 100;
 
       child: ScrolledWindow {
         hexpand: true;

--- a/src/bz-apps-page.blp
+++ b/src/bz-apps-page.blp
@@ -65,7 +65,7 @@ template $BzAppsPage: Adw.NavigationPage {
 
     content: Adw.BreakpointBin {
       width-request: 360;
-      height-request: 450;
+      height-request: 100;
 
       child: Gtk.ScrolledWindow {
         hscrollbar-policy: never;

--- a/src/bz-favorites-page.blp
+++ b/src/bz-favorites-page.blp
@@ -45,7 +45,7 @@ template $BzFavoritesPage: Adw.NavigationPage {
 
     content: Adw.BreakpointBin {
       width-request: 360;
-      height-request: 450;
+      height-request: 100;
 
       child: Adw.ViewStack stack {
         enable-transitions: true;

--- a/src/bz-flathub-page.blp
+++ b/src/bz-flathub-page.blp
@@ -4,11 +4,11 @@ using Adw 1;
 template $BzFlathubPage: Adw.Bin {
   child: Adw.BreakpointBin {
     width-request: 360;
-    height-request: 450;
+    height-request: 100;
 
     child: Adw.BreakpointBin {
       width-request: 360;
-      height-request: 450;
+      height-request: 100;
 
       child: Adw.ViewStack stack {
         enable-transitions: true;

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -73,7 +73,7 @@ template $BzFullView: Adw.Bin {
 
         child: Adw.BreakpointBin {
           width-request: 360;
-          height-request: 450;
+          height-request: 100;
 
           Adw.Breakpoint {
             condition ("max-width: 700px")
@@ -93,7 +93,7 @@ template $BzFullView: Adw.Bin {
 
           child: Adw.BreakpointBin breakpoint_bin {
             width-request: 360;
-            height-request: 450;
+            height-request: 100;
 
             Adw.Breakpoint breakpoint {
               condition ("max-width: 500px")

--- a/src/bz-preferences-dialog.blp
+++ b/src/bz-preferences-dialog.blp
@@ -5,7 +5,7 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
   content-height: 500;
   search-enabled: true;
   width-request: 350;
-  height-request: 500;
+  height-request: 100;
 
   Adw.Breakpoint {
     condition ("max-width: 625sp")

--- a/src/bz-screenshot-page.blp
+++ b/src/bz-screenshot-page.blp
@@ -6,7 +6,7 @@ template $BzScreenshotPage: Adw.NavigationPage {
 
   child: Adw.BreakpointBin {
     width-request: 360;
-    height-request: 450;
+    height-request: 100;
 
     Adw.Breakpoint {
       condition ("max-width: 700px")

--- a/src/bz-search-widget.blp
+++ b/src/bz-search-widget.blp
@@ -4,7 +4,7 @@ using Adw 1;
 template $BzSearchWidget: Adw.Bin {
   child: Adw.BreakpointBin {
     width-request: 360;
-    height-request: 294;
+    height-request: 100;
 
     Adw.Breakpoint {
       condition ("max-width: 1000sp")

--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -7,7 +7,7 @@ template $BzWindow: Adw.ApplicationWindow {
   default-width: 1220;
   default-height: 900;
   width-request: 360;
-  height-request: 550;
+  height-request: 294;
 
   ShortcutController {
     Shortcut {


### PR DESCRIPTION
Changes the minimum height to 294 like asked in the GNOME HIG.

The previous max height actually caused issues when opening the on screen keyboard on mobile.

<img width="410" height="350" alt="image" src="https://github.com/user-attachments/assets/c89c6fee-3388-41a0-9375-2faf327e1152" />
