### PR TITLE
Add contextual window titles

### DIFF
--- a/src/bz-window.blp
+++ b/src/bz-window.blp
@@ -3,7 +3,7 @@ using Gio 2.0;
 using Adw 1;
 
 template $BzWindow: Adw.ApplicationWindow {
-  title: _("Bazaar");
+  title: bind $format_title(navigation_view.visible-page as <Adw.NavigationPage>.title);
   default-width: 1220;
   default-height: 900;
   width-request: 360;
@@ -295,7 +295,7 @@ template $BzWindow: Adw.ApplicationWindow {
 
             Adw.NavigationPage {
               tag: "view";
-              title: "view";
+              title: bind full_view.entry-group as <$BzEntryGroup>.title as <string>;
 
               child: $BzFullView full_view {
                 state: bind template.state;

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -363,6 +363,16 @@ format_progress (gpointer object,
   return g_strdup_printf ("%.0f%%", 100.0 * value);
 }
 
+static char *
+format_title (gpointer    object,
+              const char *title)
+{
+  if (title == NULL || *title == '\0' || g_strcmp0 (title, _("Bazaar")) == 0)
+    return g_strdup (_("Bazaar"));
+  /* Translators: %s is the title of the current page */
+  return g_strdup_printf (_("Bazaar — %s"), title);
+}
+
 static BzEntryGroup *
 resolve_group_from_parameter (BzWindow *self,
                               GVariant *parameter,
@@ -613,6 +623,7 @@ bz_window_class_init (BzWindowClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, browse_flathub_cb);
   gtk_widget_class_bind_template_callback (widget_class, open_search_cb);
   gtk_widget_class_bind_template_callback (widget_class, format_progress);
+  gtk_widget_class_bind_template_callback (widget_class, format_title);
 
   gtk_widget_class_install_action (widget_class, "escape", NULL, action_escape);
   gtk_widget_class_install_action (widget_class, "window.user-data", NULL, action_user_data);


### PR DESCRIPTION
This makes navigation between multiple Bazaar windows easier.

<img width="512" height="976" alt="Screenshot From 2026-03-07 16-28-03" src="https://github.com/user-attachments/assets/8733e5e9-6d59-4a9d-a485-0323fa8942a4" />
