### PR TITLE
Fix horizontal overflow issues in full view header section

### DIFF
--- a/src/bz-developer-badge.blp
+++ b/src/bz-developer-badge.blp
@@ -10,6 +10,8 @@ template $BzDeveloperBadge: Box {
     label: bind $get_developer_name(template.entry) as <string>;
     xalign: 0.0;
     wrap: true;
+    lines: 3;
+    ellipsize: end;
     wrap-mode: word_char;
     natural-wrap-mode: word;
 

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -96,7 +96,7 @@ template $BzFullView: Adw.Bin {
             height-request: 100;
 
             Adw.Breakpoint breakpoint {
-              condition ("max-width: 500px")
+              condition ("max-width: 525px")
 
               setters {
                 top_box.margin-start: 10;
@@ -191,6 +191,8 @@ template $BzFullView: Adw.Bin {
 
                               xalign: 0.0;
                               wrap: true;
+                              lines: 2;
+                              ellipsize: end;
                               wrap-mode: word_char;
                               natural-wrap-mode: word;
                               label: bind template.ui-entry as <$BzResult>.object as <$BzEntry>.title;
@@ -228,7 +230,10 @@ template $BzFullView: Adw.Bin {
                             }
 
                             Box {
-                              spacing: 8;
+                              layout-manager: Adw.WrapLayout {
+                                child-spacing: 4;
+                                line-spacing: 0;
+                              };
 
                               Button {
                                 visible: bind $invert_boolean($is_null(template.ui-entry as <$BzResult>.object as <$BzEntry>.donation-url) as <bool>) as <bool>;

--- a/src/bz-install-controls.blp
+++ b/src/bz-install-controls.blp
@@ -17,6 +17,7 @@ template $BzInstallControls: Box {
       transition-type: crossfade;
       visible-child-name: bind $get_visible_page(template.entry-group as <$BzEntryGroup>.installable, template.entry-group as <$BzEntryGroup>.removable, template.state as <$BzStateInfo>.available-updates) as <string>;
       hexpand: bind $invert_boolean(template.wide) as <bool>;
+      hhomogeneous: false;
 
       StackPage install {
         name: "install";


### PR DESCRIPTION
Having the support button and/or "install more" button visible caused a ugly horizontal overflow. This should hopefully help with that.