### PR TITLE
Fix "other apps" label appearing when there are no apps

### DIFF
--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -642,7 +642,7 @@ template $BzFullView: Adw.Bin {
 
                         Box {
                           orientation: vertical;
-                          visible: bind $has_other_apps(template.entry-group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.developer-apps, template.entry-group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>) as <bool>;
+                          visible: bind $invert_boolean($is_zero(other_apps_model.n-items) as <int>) as <bool>;
 
                           Label {
                             styles [
@@ -668,7 +668,7 @@ template $BzFullView: Adw.Bin {
                             bind-widget => $bind_app_tile_cb(template);
                             unbind-widget => $unbind_app_tile_cb(template);
 
-                            model: SliceListModel {
+                            model: SliceListModel other_apps_model {
                               offset: 0;
                               size: 6;
                               model: bind $get_developer_apps_entries(template.entry-group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.developer-apps, template.entry-group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>) as <Gio.ListModel>;

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -642,13 +642,6 @@ filter_own_app_id (BzEntry *entry, GtkStringList *app_ids)
     return NULL;
 }
 
-static gboolean
-has_other_apps (gpointer object, GtkStringList *app_ids, BzEntry *entry)
-{
-  g_autoptr (GtkStringList) filtered = filter_own_app_id (BZ_ENTRY (entry), app_ids);
-  return filtered != NULL;
-}
-
 static GListModel *
 get_developer_apps_entries (gpointer object, GtkStringList *app_ids, BzEntry *entry)
 {
@@ -1136,7 +1129,6 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, format_more_other_apps_label);
   gtk_widget_class_bind_template_callback (widget_class, get_developer_apps_entries);
   gtk_widget_class_bind_template_callback (widget_class, more_apps_button_clicked_cb);
-  gtk_widget_class_bind_template_callback (widget_class, has_other_apps);
   gtk_widget_class_bind_template_callback (widget_class, open_url_cb);
   gtk_widget_class_bind_template_callback (widget_class, license_cb);
   gtk_widget_class_bind_template_callback (widget_class, dl_stats_cb);


### PR DESCRIPTION
Fixes the issue where the "other apps" label still gets shown even when all the "other" apps get hidden due to a filter.