### PR TITLE
desktop: List compatible form factors

### DIFF
--- a/data/io.github.kolunmi.Bazaar.desktop.in
+++ b/data/io.github.kolunmi.Bazaar.desktop.in
@@ -10,6 +10,7 @@ Keywords=GTK;System;PackageManager;Discover;Flatpak;Software;Store;
 StartupNotify=true
 MimeType=x-scheme-handler/appstream;x-scheme-handler/flatpak;x-scheme-handler/flatpak+https;
 Actions=new-window;
+X-Purism-FormFactor=Workstation;Mobile;
 
 [Desktop Action new-window]
 Name=New Window


### PR DESCRIPTION
List the form factors the app was designed for in the desktop file. This is so desktop environments like Phosh and Plasma Mobile can show or hide the app in the correct contexts.