### PR TITLE
Update meson setup command for bge

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you would like to try this project on your local machine, clone it
 on the cli and type these commands inside the project root:
 
 ```sh
-meson setup build --prefix=/usr/local
+meson setup build --prefix=/usr --libdir=/usr/lib64
 ninja -C build
 sudo ninja -C build install
 bazaar


### PR DESCRIPTION
Fixes the following error when building from source outside the Flatpak: 

```shell
bazaar: error while loading shared libraries: libbge-0.1.so: cannot open shared object file: No such file or directory
``` 

Closes #1249 