### PR TITLE
Remove "install extra" button

### DIFF
--- a/src/bz-install-controls.blp
+++ b/src/bz-install-controls.blp
@@ -2,174 +2,153 @@ using Gtk 4.0;
 using Adw 1;
 
 template $BzInstallControls: Box {
-  orientation: horizontal;
-  spacing: bind $choose(template.wide, 7, 5) as <int>;
+  homogeneous: bind $invert_boolean(template.wide) as <bool>;
+  spacing: bind $choose(template.wide, 10, 8) as <int>;
+  hexpand: bind $invert_boolean(template.wide) as <bool>;
   valign: center;
 
-  Box {
-    homogeneous: bind $invert_boolean(template.wide) as <bool>;
-    spacing: bind $choose(template.wide, 10, 8) as <int>;
+  Stack {
+    transition-type: crossfade;
+    visible-child-name: bind $get_visible_page(template.entry-group as <$BzEntryGroup>.installable, template.entry-group as <$BzEntryGroup>.removable, template.state as <$BzStateInfo>.available-updates) as <string>;
     hexpand: bind $invert_boolean(template.wide) as <bool>;
+    hhomogeneous: false;
 
-    Stack {
-      transition-type: crossfade;
-      visible-child-name: bind $get_visible_page(template.entry-group as <$BzEntryGroup>.installable, template.entry-group as <$BzEntryGroup>.removable, template.state as <$BzStateInfo>.available-updates) as <string>;
-      hexpand: bind $invert_boolean(template.wide) as <bool>;
-      hhomogeneous: false;
+    StackPage install {
+      name: "install";
 
-      StackPage install {
-        name: "install";
+      child: Button install_button {
+        styles [
+          "suggested-action",
+          "pill",
+        ]
 
-        child: Button install_button {
+        margin-top: 3;
+        margin-bottom: 3;
+        margin-start: 3;
+        margin-end: 3;
+
+        has-tooltip: true;
+        hexpand: bind $invert_boolean(template.wide) as <bool>;
+        halign: bind $choose(template.wide, 2, 0) as <int>;
+        tooltip-text: _("Download & Install Application");
+        sensitive: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.installable-and-available) as <bool>) as <bool>;
+        label: _("_Install");
+        use-underline: true;
+        clicked => $install_cb(template);
+      };
+    }
+
+    StackPage open {
+      name: "open";
+
+      child: Box {
+        spacing: bind $choose(template.wide, 10, 8) as <int>;
+        homogeneous: bind $invert_boolean(template.wide) as <bool>;
+        halign: bind $choose(template.wide, 2, 0) as <int>;
+
+        margin-top: 3;
+        margin-bottom: 3;
+        margin-start: 3;
+        margin-end: 3;
+
+        Button open_button {
           styles [
-            "suggested-action",
             "pill",
           ]
-
-          margin-top: 3;
-          margin-bottom: 3;
-          margin-start: 3;
-          margin-end: 3;
-
+          visible: bind $invert_boolean($is_blocked(template.state as <$BzStateInfo>.parental-blocked-ids, template.entry-group as <$BzEntryGroup>) as <bool>) as <bool>;
           has-tooltip: true;
           hexpand: bind $invert_boolean(template.wide) as <bool>;
-          halign: bind $choose(template.wide, 2, 0) as <int>;
-          tooltip-text: _("Download & Install Application");
-          sensitive: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.installable-and-available) as <bool>) as <bool>;
-          label: _("_Install");
+          label: _("_Open");
           use-underline: true;
-          clicked => $install_cb(template);
-        };
-      }
+          sensitive: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>;
+          clicked => $run_cb(template);
+        }
 
-      StackPage open {
-        name: "open";
+        Button {
+          styles [
+            "destructive-action",
+            "circular",
+          ]
 
-        child: Box {
-          spacing: bind $choose(template.wide, 10, 8) as <int>;
-          homogeneous: bind $invert_boolean(template.wide) as <bool>;
-          halign: bind $choose(template.wide, 2, 0) as <int>;
+          width-request: bind $choose(template.wide, 45, -1) as <int>;
+          hexpand: bind $invert_boolean(template.wide) as <bool>;
+          has-tooltip: bind template.wide as <bool>;
+          tooltip-text: _("Uninstall Application");
+          sensitive: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>;
+          clicked => $remove_cb(template);
 
-          margin-top: 3;
-          margin-bottom: 3;
-          margin-start: 3;
-          margin-end: 3;
+          child: Box {
+            halign: center;
+            hexpand: true;
 
-          Button open_button {
-            styles [
-              "pill",
-            ]
-            visible: bind $invert_boolean($is_blocked(template.state as <$BzStateInfo>.parental-blocked-ids, template.entry-group as <$BzEntryGroup>) as <bool>) as <bool>;
-            has-tooltip: true;
-            hexpand: bind $invert_boolean(template.wide) as <bool>;
-            label: _("_Open");
-            use-underline: true;
-            sensitive: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>;
-            clicked => $run_cb(template);
-          }
+            Label {
+              visible: bind $invert_boolean(template.wide) as <bool>;
+              label: _("_Remove");
+              use-underline: true;
+            }
 
-          Button {
-            styles [
-              "destructive-action",
-              "circular",
-            ]
-
-            width-request: bind $choose(template.wide, 45, -1) as <int>;
-            hexpand: bind $invert_boolean(template.wide) as <bool>;
-            has-tooltip: bind template.wide as <bool>;
-            tooltip-text: _("Uninstall Application");
-            sensitive: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>;
-            clicked => $remove_cb(template);
-
-            child: Box {
-              halign: center;
-              hexpand: true;
-
-              Label {
-                visible: bind $invert_boolean(template.wide) as <bool>;
-                label: _("_Remove");
-                use-underline: true;
-              }
-
-              Image {
-                visible: bind template.wide as <bool>;
-                icon-name: "user-trash-symbolic";
-              }
-            };
-          }
-        };
-      }
-
-      StackPage update {
-        name: "update";
-
-        child: Box {
-          spacing: bind $choose(template.wide, 10, 8) as <int>;
-          homogeneous: bind $invert_boolean(template.wide) as <bool>;
-          halign: bind $choose(template.wide, 2, 0) as <int>;
-
-          Button update_button {
-            styles [
-              "pill",
-              "suggested-action"
-            ]
-
-            hexpand: bind $invert_boolean(template.wide) as <bool>;
-            label: _("Update");
-            clicked => $update_cb(template);
-          }
-
-          Button {
-            styles [
-              "destructive-action",
-              "circular",
-            ]
-
-            width-request: bind $choose(template.wide, 45, -1) as <int>;
-            hexpand: bind $invert_boolean(template.wide) as <bool>;
-            has-tooltip: bind template.wide as <bool>;
-            tooltip-text: _("Uninstall Application");
-            sensitive: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>;
-            clicked => $remove_cb(template);
-
-            child: Box {
-              halign: center;
-              hexpand: true;
-
-              Label {
-                visible: bind $invert_boolean(template.wide) as <bool>;
-                label: _("Remove");
-              }
-
-              Image {
-                visible: bind template.wide as <bool>;
-                icon-name: "user-trash-symbolic";
-              }
-            };
-          }
-        };
-      }
-
-      StackPage empty {
-        name: "empty";
-        child: Adw.Bin {};
-      }
+            Image {
+              visible: bind template.wide as <bool>;
+              icon-name: "user-trash-symbolic";
+            }
+          };
+        }
+      };
     }
-  }
 
-  Button {
-    styles [
-      "circular",
-    ]
+    StackPage update {
+      name: "update";
 
-    width-request: 45;
-    has-tooltip: true;
-    margin-top: 3;
-    margin-bottom: 3;
-    icon-name: "download-plus-symbolic";
-    tooltip-text: _("Install Other Version");
-    visible: bind $logical_and($invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.installable) as <bool>) as <bool>, $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.removable) as <bool>) as <bool>) as <bool>;
-    sensitive: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.installable-and-available) as <bool>) as <bool>;
-    clicked => $install_cb(template);
+      child: Box {
+        spacing: bind $choose(template.wide, 10, 8) as <int>;
+        homogeneous: bind $invert_boolean(template.wide) as <bool>;
+        halign: bind $choose(template.wide, 2, 0) as <int>;
+
+        Button update_button {
+          styles [
+            "pill",
+            "suggested-action"
+          ]
+
+          hexpand: bind $invert_boolean(template.wide) as <bool>;
+          label: _("Update");
+          clicked => $update_cb(template);
+        }
+
+        Button {
+          styles [
+            "destructive-action",
+            "circular",
+          ]
+
+          width-request: bind $choose(template.wide, 45, -1) as <int>;
+          hexpand: bind $invert_boolean(template.wide) as <bool>;
+          has-tooltip: bind template.wide as <bool>;
+          tooltip-text: _("Uninstall Application");
+          sensitive: bind $invert_boolean($is_zero(template.entry-group as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>;
+          clicked => $remove_cb(template);
+
+          child: Box {
+            halign: center;
+            hexpand: true;
+
+            Label {
+              visible: bind $invert_boolean(template.wide) as <bool>;
+              label: _("Remove");
+            }
+
+            Image {
+              visible: bind template.wide as <bool>;
+              icon-name: "user-trash-symbolic";
+            }
+          };
+        }
+      };
+    }
+
+    StackPage empty {
+      name: "empty";
+      child: Adw.Bin {};
+    }
   }
 }


### PR DESCRIPTION
GNOME and KDE do not support multiple apps with the same app ID, and so launching specific refs requires the Flatpak CLI, so supporting this in Bazaar does not make much sense.