### PR TITLE
Add lingering cache to async textures

### DIFF
--- a/src/bz-async-texture.c
+++ b/src/bz-async-texture.c
@@ -38,130 +38,35 @@
 #include "bz-io.h"
 #include "bz-util.h"
 
-typedef struct
-{
-  GdkTexture *texture;
-  guint       linger_source_id;
-  gsize       refcount;
-} TextureCacheEntry;
+BZ_DEFINE_DATA (
+    cache_entry,
+    CacheEntry,
+    {
+      GdkTexture *texture;
+      DexFuture  *linger_timeout;
+    },
+    BZ_RELEASE_DATA (texture, g_object_unref);
+    BZ_RELEASE_DATA (linger_timeout, dex_unref));
 
 static GMutex      texture_cache_mutex = { 0 };
 static GHashTable *texture_cache       = NULL;
 
 static void
-texture_cache_ensure (void)
-{
-  if (texture_cache == NULL)
-    texture_cache = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
-}
+texture_cache_ensure (void);
 
-static gboolean
-linger_timeout_cb (char *uri)
-{
-  TextureCacheEntry *entry = NULL;
-
-  g_mutex_lock (&texture_cache_mutex);
-  texture_cache_ensure ();
-
-  entry = g_hash_table_lookup (texture_cache, uri);
-  if (entry != NULL)
-    {
-      if (entry->refcount == 0)
-        {
-          g_clear_object (&entry->texture);
-          g_hash_table_remove (texture_cache, uri);
-          g_slice_free (TextureCacheEntry, entry);
-          g_debug ("Texture cache: evicted '%s' after linger (table size: %u)\n",
-                   uri, g_hash_table_size (texture_cache));
-        }
-      else
-        entry->linger_source_id = 0;
-    }
-
-  g_mutex_unlock (&texture_cache_mutex);
-  return G_SOURCE_REMOVE;
-}
+static DexFuture *
+linger_timeout_finally (DexFuture *future,
+                        char      *uri);
 
 static GdkTexture *
-texture_cache_acquire (const char *uri)
-{
-  TextureCacheEntry *entry = NULL;
-  GdkTexture        *tex   = NULL;
-
-  g_mutex_lock (&texture_cache_mutex);
-  texture_cache_ensure ();
-
-  entry = g_hash_table_lookup (texture_cache, uri);
-  if (entry != NULL && entry->texture != NULL)
-    {
-      entry->refcount++;
-      if (entry->linger_source_id != 0)
-        {
-          g_source_remove (entry->linger_source_id);
-          entry->linger_source_id = 0;
-        }
-      tex = g_object_ref (entry->texture);
-    }
-
-  g_mutex_unlock (&texture_cache_mutex);
-  return tex;
-}
+texture_cache_acquire (const char *uri);
 
 static void
 texture_cache_store (const char *uri,
-                     GdkTexture *texture)
-{
-  TextureCacheEntry *entry = NULL;
-
-  g_mutex_lock (&texture_cache_mutex);
-  texture_cache_ensure ();
-
-  entry = g_hash_table_lookup (texture_cache, uri);
-  if (entry == NULL)
-    {
-      entry = g_slice_new0 (TextureCacheEntry);
-      g_hash_table_insert (texture_cache, g_strdup (uri), entry);
-    }
-
-  if (entry->texture != texture)
-    {
-      g_clear_object (&entry->texture);
-      entry->texture = g_object_ref (texture);
-    }
-  entry->refcount++;
-
-  g_mutex_unlock (&texture_cache_mutex);
-}
+                     GdkTexture *texture);
 
 static void
-texture_cache_release (const char *uri)
-{
-  TextureCacheEntry *entry = NULL;
-
-  g_mutex_lock (&texture_cache_mutex);
-  texture_cache_ensure ();
-
-  entry = g_hash_table_lookup (texture_cache, uri);
-  if (entry == NULL)
-    {
-      g_mutex_unlock (&texture_cache_mutex);
-      return;
-    }
-
-  if (entry->refcount > 0)
-    entry->refcount--;
-
-  if (entry->refcount == 0 && entry->linger_source_id == 0 && entry->texture != NULL)
-    {
-      entry->linger_source_id = g_timeout_add_seconds_full (
-          G_PRIORITY_DEFAULT,
-          TEXTURE_LINGER_SECONDS,
-          (GSourceFunc) linger_timeout_cb,
-          g_strdup (uri), g_free);
-    }
-
-  g_mutex_unlock (&texture_cache_mutex);
-}
+texture_cache_release (const char *uri);
 
 BZ_DEFINE_DATA (
     load,
@@ -626,12 +531,13 @@ maybe_load (BzAsyncTexture *self)
 
   if (!self->cache_acquired)
     {
-      GdkTexture *cached = NULL;
-      cached             = texture_cache_acquire (self->source_uri);
+      g_autoptr (GdkTexture) cached = NULL;
+
+      cached = texture_cache_acquire (self->source_uri);
       if (cached != NULL)
         {
           g_clear_object (&self->paintable);
-          self->paintable      = GDK_PAINTABLE (cached);
+          self->paintable      = (GdkPaintable *) g_object_ref (cached);
           self->cache_acquired = TRUE;
 
           g_idle_add_full (
@@ -1053,10 +959,11 @@ load_finally (DexFuture *future,
   if (dex_future_is_resolved (future))
     {
       GdkTexture *texture = NULL;
-      texture = g_value_dup_object (dex_future_get_value (future, NULL));
+
+      texture = g_value_get_object (dex_future_get_value (future, NULL));
 
       g_clear_object (&self->paintable);
-      self->paintable = GDK_PAINTABLE (texture);
+      self->paintable = g_object_ref (GDK_PAINTABLE (texture));
 
       if (!self->cache_acquired)
         {
@@ -1125,4 +1032,87 @@ idle_notify (BzAsyncTexture *self)
   gdk_paintable_invalidate_size (GDK_PAINTABLE (self));
 
   return G_SOURCE_REMOVE;
+}
+
+static void
+texture_cache_ensure (void)
+{
+  if (texture_cache == NULL)
+    texture_cache = g_hash_table_new_full (
+        g_str_hash, g_str_equal,
+        g_free, cache_entry_data_unref);
+}
+
+static DexFuture *
+linger_timeout_finally (DexFuture *future,
+                        char      *uri)
+{
+  g_mutex_lock (&texture_cache_mutex);
+  texture_cache_ensure ();
+
+  g_hash_table_remove (texture_cache, uri);
+  g_debug ("Texture cache: evicted '%s' after linger (table size: %u)",
+           uri, g_hash_table_size (texture_cache));
+
+  g_mutex_unlock (&texture_cache_mutex);
+  return dex_future_new_true ();
+}
+
+static GdkTexture *
+texture_cache_acquire (const char *uri)
+{
+  g_autoptr (GMutexLocker) locker = NULL;
+  CacheEntryData *data            = NULL;
+
+  locker = g_mutex_locker_new (&texture_cache_mutex);
+  texture_cache_ensure ();
+
+  data = g_hash_table_lookup (texture_cache, uri);
+  if (data != NULL)
+    return g_object_ref (data->texture);
+  else
+    return NULL;
+}
+
+static void
+texture_cache_store (const char *uri,
+                     GdkTexture *texture)
+{
+  g_autoptr (CacheEntryData) data = NULL;
+
+  g_mutex_lock (&texture_cache_mutex);
+  texture_cache_ensure ();
+
+  data          = cache_entry_data_new ();
+  data->texture = g_object_ref (texture);
+
+  g_hash_table_replace (
+      texture_cache,
+      g_strdup (uri),
+      cache_entry_data_ref (data));
+
+  g_mutex_unlock (&texture_cache_mutex);
+}
+
+static void
+texture_cache_release (const char *uri)
+{
+  g_autoptr (GMutexLocker) locker = NULL;
+  CacheEntryData *data            = NULL;
+  g_autoptr (DexFuture) future    = NULL;
+
+  locker = g_mutex_locker_new (&texture_cache_mutex);
+  texture_cache_ensure ();
+
+  data = g_hash_table_lookup (texture_cache, uri);
+  if (data == NULL)
+    return;
+
+  dex_clear (&data->linger_timeout);
+  future = dex_timeout_new_seconds (TEXTURE_LINGER_SECONDS);
+  future = dex_future_finally (
+      future,
+      (DexFutureCallback) linger_timeout_finally,
+      g_strdup (uri), g_free);
+  data->linger_timeout = dex_ref (future);
 }


### PR DESCRIPTION
Adds a hashmap containing references to loaded GdkTexture objects, keyed by source URIs. Used for deduplication of loads, but primarily to prevent textures from blinking when an BzAsyncTexture for the same URI is destroyed and recreated like half a second later.