### PR TITLE
Fix half filled columns for "On the Go" section

### DIFF
--- a/src/bz-flathub-page.blp
+++ b/src/bz-flathub-page.blp
@@ -457,7 +457,7 @@ template $BzFlathubPage: Adw.Bin {
       };
 
       Adw.Breakpoint {
-        condition ("max-width: 1150sp")
+        condition ("max-width: 1250sp")
 
         setters {
           otg_list.max-children-per-line: 2;
@@ -498,7 +498,7 @@ template $BzFlathubPage: Adw.Bin {
     };
 
     Adw.Breakpoint {
-      condition ("max-width: 900px")
+      condition ("max-width: 970sp")
 
       setters {
         section_toggles_box.width-request: -1;


### PR DESCRIPTION
This seemed to have been messed up by not using "sp" and the app tiles layout changes.