### PR TITLE
Disable zoom for screenshot carousel when compact

### DIFF
--- a/src/bz-screenshots-carousel.blp
+++ b/src/bz-screenshots-carousel.blp
@@ -31,7 +31,7 @@ template $BzScreenshotsCarousel: Gtk.Widget {
         allow-mouse-drag: true;
         allow-overshoot: true;
         allow-scroll-wheel: true;
-        allow-raise: true;
+        allow-raise: bind $invert_boolean(template.compact) as <bool>;
 
         create-widget => $on_create_widget(template);
         remove-widget => $on_remove_widget(template);

--- a/src/bz-screenshots-carousel.c
+++ b/src/bz-screenshots-carousel.c
@@ -32,6 +32,7 @@
 
 #include "bz-decorated-screenshot.h"
 #include "bz-screenshots-carousel.h"
+#include "bz-template-callbacks.h"
 
 #define LIGHT_CLASS          "screenshot-carousel-light"
 #define DARK_CLASS           "screenshot-carousel-dark"
@@ -445,6 +446,8 @@ bz_screenshots_carousel_class_init (BzScreenshotsCarouselClass *klass)
                     G_TYPE_UINT);
 
   gtk_widget_class_set_template_from_resource (widget_class, "/io/github/kolunmi/Bazaar/bz-screenshots-carousel.ui");
+  bz_widget_class_bind_all_util_callbacks (widget_class);
+
   gtk_widget_class_bind_template_child (widget_class, BzScreenshotsCarousel, carousel);
   gtk_widget_class_bind_template_child (widget_class, BzScreenshotsCarousel, prev_button);
   gtk_widget_class_bind_template_child (widget_class, BzScreenshotsCarousel, prev_button_revealer);


### PR DESCRIPTION
The effect looked really glitchy when it doesn't have space to animate.