### PR TITLE
fix(ci): don't use sha for cache-key

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -27,13 +27,13 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.variant.runner }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         submodules: recursive
-    - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+    - uses: flatpak/flatpak-github-actions/flatpak-builder@92ae9851ad316786193b1fd3f40c4b51eb5cb101 # v6.6
       with:
         bundle: Bazaar.flatpak
         manifest-path: build-aux/flatpak/io.github.kolunmi.Bazaar.json
-        cache-key: flatpak-builder-${{ github.sha }}
+        cache-key: flatpak-builder-046f9ec
         arch: ${{ matrix.variant.arch }}
         verbose: true


### PR DESCRIPTION
This results in an always changing cache key otherwise and so the cache will never be actually used.

This decreases CI build time from 6 minutes to roughly 2 minutes
https://github.com/renner0e/bazaar/actions/runs/23212674647/job/67465344018