### PR TITLE
Bring back the separate add-ons for non compact widths

### DIFF
--- a/src/bz-installed-tile.blp
+++ b/src/bz-installed-tile.blp
@@ -93,16 +93,26 @@ template $BzInstalledTile: $BzListTile {
       hexpand: true;
       halign: end;
 
+      Button addons_button {
+        styles [
+          "flat"
+        ]
+
+        tooltip-text: _("Manage Add-Ons");
+        visible: bind $logical_and($invert_boolean(template.compact) as <bool>, $invert_boolean($is_zero(template.group as <$BzEntryGroup>.n-addons as <int>) as <bool>) as <bool>) as <bool>;
+        valign: center;
+        icon-name: "application-x-addon-symbolic";
+
+        clicked => $install_addons_cb() swapped;
+      }
+
       Button permissions_button {
         styles [
           "flat"
         ]
 
-        has-tooltip: true;
         tooltip-text: _("Manage Permissions");
-        visible: bind $logical_and($is_zero(template.group as <$BzEntryGroup>.n-addons as <int>) as <bool>, $invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable) as <bool>) as <bool> ) as <bool>;
-        width-request: 32;
-        height-request: 32;
+        visible: bind $logical_and($invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable) as <bool>) as <bool>, $logical_or($invert_boolean(template.compact) as <bool>, $is_zero(template.group as <$BzEntryGroup>.n-addons as <int>) as <bool>) as <bool>) as <bool>;
         valign: center;
         icon-name: "sliders-horizontal-symbolic";
 
@@ -110,9 +120,8 @@ template $BzInstalledTile: $BzListTile {
       }
 
       MenuButton {
-        visible: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.n-addons as <int>) as <bool>) as <bool>;
+        visible: bind $logical_and(template.compact, $invert_boolean($is_zero(template.group as <$BzEntryGroup>.n-addons as <int>) as <bool>) as <bool>) as <bool>;
         icon-name: "view-more-horizontal-symbolic";
-        has-tooltip: true;
         tooltip-text: _("Show Other Options…");
         menu-model: menu;
         valign: center;
@@ -127,11 +136,7 @@ template $BzInstalledTile: $BzListTile {
           "flat",
         ]
 
-        has-tooltip: true;
         tooltip-text: _("Remove");
-
-        width-request: 32;
-        height-request: 32;
         valign: center;
         icon-name: "user-trash-symbolic";
         visible: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable) as <bool>) as <bool>;

--- a/src/bz-installed-tile.c
+++ b/src/bz-installed-tile.c
@@ -28,12 +28,15 @@
 #include "bz-installed-tile.h"
 #include "bz-library-page.h"
 #include "bz-state-info.h"
+#include "bz-window.h"
 
 struct _BzInstalledTile
 {
   BzListTile parent_instance;
 
   BzEntryGroup *group;
+  gboolean      compact;
+  GBinding     *compact_binding;
 
   GtkPicture *icon_picture;
   GtkImage   *fallback_icon;
@@ -48,6 +51,7 @@ enum
 {
   PROP_0,
   PROP_GROUP,
+  PROP_COMPACT,
   LAST_PROP
 };
 
@@ -58,9 +62,34 @@ bz_installed_tile_dispose (GObject *object)
 {
   BzInstalledTile *self = BZ_INSTALLED_TILE (object);
 
+  g_clear_pointer (&self->compact_binding, g_binding_unbind);
   g_clear_object (&self->group);
 
   G_OBJECT_CLASS (bz_installed_tile_parent_class)->dispose (object);
+}
+
+static void
+bz_installed_tile_map (GtkWidget *widget)
+{
+  BzInstalledTile *self   = BZ_INSTALLED_TILE (widget);
+  GtkWidget       *window = NULL;
+
+  GTK_WIDGET_CLASS (bz_installed_tile_parent_class)->map (widget);
+
+  window = gtk_widget_get_ancestor (widget, BZ_TYPE_WINDOW);
+  if (window != NULL && self->compact_binding == NULL)
+    self->compact_binding = g_object_bind_property (window, "compact",
+                                                    self, "compact",
+                                                    G_BINDING_SYNC_CREATE);
+}
+
+static void
+bz_installed_tile_unmap (GtkWidget *widget)
+{
+  BzInstalledTile *self = BZ_INSTALLED_TILE (widget);
+  g_clear_pointer (&self->compact_binding, g_binding_unbind);
+
+  GTK_WIDGET_CLASS (bz_installed_tile_parent_class)->unmap (widget);
 }
 
 static void
@@ -75,6 +104,9 @@ bz_installed_tile_get_property (GObject    *object,
     {
     case PROP_GROUP:
       g_value_set_object (value, bz_installed_tile_get_group (self));
+      break;
+    case PROP_COMPACT:
+      g_value_set_boolean (value, self->compact);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -93,6 +125,10 @@ bz_installed_tile_set_property (GObject      *object,
     {
     case PROP_GROUP:
       bz_installed_tile_set_group (self, g_value_get_object (value));
+      break;
+    case PROP_COMPACT:
+      self->compact = g_value_get_boolean (value);
+      g_object_notify_by_pspec (G_OBJECT (self), props[PROP_COMPACT]);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -126,6 +162,14 @@ logical_and (gpointer object,
              gboolean b)
 {
   return a && b;
+}
+
+static gboolean
+logical_or (gpointer object,
+            gboolean a,
+            gboolean b)
+{
+  return a || b;
 }
 
 static char *
@@ -232,12 +276,21 @@ bz_installed_tile_class_init (BzInstalledTileClass *klass)
   object_class->dispose      = bz_installed_tile_dispose;
   object_class->get_property = bz_installed_tile_get_property;
   object_class->set_property = bz_installed_tile_set_property;
+  widget_class->map          = bz_installed_tile_map;
+  widget_class->unmap        = bz_installed_tile_unmap;
 
   props[PROP_GROUP] =
       g_param_spec_object (
           "group",
           NULL, NULL,
           BZ_TYPE_ENTRY_GROUP,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
+
+  props[PROP_COMPACT] =
+      g_param_spec_boolean (
+          "compact",
+          NULL, NULL,
+          FALSE,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
   g_object_class_install_properties (object_class, LAST_PROP, props);
@@ -255,6 +308,7 @@ bz_installed_tile_class_init (BzInstalledTileClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, is_null);
   gtk_widget_class_bind_template_callback (widget_class, is_zero);
   gtk_widget_class_bind_template_callback (widget_class, logical_and);
+  gtk_widget_class_bind_template_callback (widget_class, logical_or);
   gtk_widget_class_bind_template_callback (widget_class, format_description);
   gtk_widget_class_bind_template_callback (widget_class, support_cb);
   gtk_widget_class_bind_template_callback (widget_class, install_addons_cb);

--- a/src/bz-window.c
+++ b/src/bz-window.c
@@ -76,6 +76,7 @@ enum
   PROP_0,
 
   PROP_STATE,
+  PROP_COMPACT,
 
   LAST_PROP
 };
@@ -166,6 +167,9 @@ bz_window_get_property (GObject    *object,
     {
     case PROP_STATE:
       g_value_set_object (value, self->state);
+      break;
+    case PROP_COMPACT:
+      g_value_set_boolean (value, self->breakpoint_applied);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -313,6 +317,7 @@ breakpoint_apply_cb (BzWindow      *self,
   self->breakpoint_applied = TRUE;
 
   gtk_widget_add_css_class (GTK_WIDGET (self), "narrow");
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_COMPACT]);
 }
 
 static void
@@ -322,6 +327,7 @@ breakpoint_unapply_cb (BzWindow      *self,
   self->breakpoint_applied = FALSE;
 
   gtk_widget_remove_css_class (GTK_WIDGET (self), "narrow");
+  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_COMPACT]);
 }
 
 static void
@@ -681,6 +687,12 @@ bz_window_class_init (BzWindowClass *klass)
           NULL, NULL,
           BZ_TYPE_STATE_INFO,
           G_PARAM_READABLE);
+
+  props[PROP_COMPACT] =
+      g_param_spec_boolean (
+          "compact",
+          NULL, NULL, FALSE,
+          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS | G_PARAM_EXPLICIT_NOTIFY);
 
   g_object_class_install_properties (object_class, LAST_PROP, props);
 


### PR DESCRIPTION
I always wanted to have it behave like this, but its a real hassle to bind from outside a ListItem and I also did not want to add breakpoints to each tile for performance reasons.

<img width="1518" height="1412" alt="image" src="https://github.com/user-attachments/assets/7cabbec3-bf11-403a-bd87-54e8bbf4edde" />

<img width="932" height="1412" alt="image" src="https://github.com/user-attachments/assets/15ef7896-fa5b-40b7-9e05-3211d7e20b92" />
