### PR TITLE
Fix both app icon and its fallback showing at the same time

### DIFF
--- a/src/bz-installed-tile.blp
+++ b/src/bz-installed-tile.blp
@@ -30,7 +30,7 @@ template $BzInstalledTile: $BzListTile {
       width-request: 64;
       pixel-size: 64;
       icon-name: "application-x-executable";
-      visible: bind $is_null(template.group as <$BzEntryGroup>.ui-entry as <$BzResult>.object as <$BzEntry>.icon-paintable) as <bool>;
+      visible: bind icon_picture.visible inverted;
       styles ["icon-dropshadow"]
     }
 


### PR DESCRIPTION
When loading the app without cache, both widgets would briefly appear at the same time when the installed tile was added, causing the app to overflow on mobile repeatedly.