### PR TITLE
Make runtime titles not have double versions

### DIFF
--- a/src/bz-flatpak-entry.c
+++ b/src/bz-flatpak-entry.c
@@ -614,8 +614,10 @@ bz_flatpak_entry_new_for_ref (FlatpakRef    *ref,
 
       if (g_once_init_enter_pointer (&version_regex))
         {
-          GRegex *re = NULL;
-          re =  g_regex_new (VERSION_SUFFIX_REGEX, 0, 0, NULL); // GNOME runtimes have the flatpak version at the end whilst others don't.
+          g_autoptr (GRegex) re = NULL;
+
+          /* GNOME runtimes have the flatpak version at the end whilst others don't. */
+          re = g_regex_new (VERSION_SUFFIX_REGEX, 0, 0, NULL);
           g_once_init_leave_pointer (&version_regex, g_steal_pointer (&re));
         }
       stripped_title = g_regex_replace (version_regex, title, -1, 0, "", 0, NULL);


### PR DESCRIPTION
For some reason, some GNOME runtime titles included a version number like "49" at the end, while the actual version was something different like 50. This caused the old algorithm to combine both values and return "49 50". To fix this, we now remove the version number from the title entirely and append the correct version value.