### PR TITLE
Don't show the incorrect total size for update tasks

### DIFF
--- a/src/bz-transaction-tile.blp
+++ b/src/bz-transaction-tile.blp
@@ -84,7 +84,7 @@ template $BzTransactionTile: $BzListTile {
                       xalign: 0;
                       ellipsize: end;
                       single-line-mode: true;
-                      label: bind $format_download_progress(template.item as <$BzTransactionTask>.last-progress as <$BzBackendTransactionOpProgressPayload>.progress, template.item as <$BzTransactionTask>.op as <$BzBackendTransactionOpPayload>.download-size) as <string>;
+                      label: bind $format_download_progress(template.item as <$BzTransactionTask>.last-progress as <$BzBackendTransactionOpProgressPayload>.bytes-transferred, template.item as <$BzTransactionTask>.op as <$BzBackendTransactionOpPayload>.download-size) as <string>;
                     }
                   };
                 }

--- a/src/bz-transaction-tile.c
+++ b/src/bz-transaction-tile.c
@@ -109,14 +109,21 @@ format_removal_size (gpointer object,
 
 static char *
 format_download_progress (gpointer object,
-                          double   progress,
+                          guint64  bytes_transferred,
                           guint64  total_size)
 {
-  guint64          downloaded     = (guint64) (progress * total_size);
-  g_autofree char *downloaded_str = g_format_size (downloaded);
-  g_autofree char *total_str      = g_format_size (total_size);
+  g_autofree char *downloaded_str = NULL;
+  g_autofree char *total_str      = NULL;
 
-  return g_strdup_printf ("%s / %s", downloaded_str, total_str);
+  downloaded_str = g_format_size (bytes_transferred);
+
+  if (total_size == (guint64) -1)
+    return g_strdup_printf ("%s", downloaded_str);
+  else
+    {
+      total_str = g_format_size (total_size);
+      return g_strdup_printf ("%s / %s", downloaded_str, total_str);
+    }
 }
 
 static gboolean

--- a/src/bz-transaction.c
+++ b/src/bz-transaction.c
@@ -594,6 +594,9 @@ bz_transaction_add_task (BzTransaction                 *self,
     {
       GListModel *current_ops = NULL;
 
+      if (bz_transaction_entry_tracker_get_kind (tracker) == BZ_TRANSACTION_ENTRY_KIND_UPDATE)
+        bz_backend_transaction_op_payload_set_download_size (payload, (guint64) -1);
+
       current_ops = bz_transaction_entry_tracker_get_current_ops (tracker);
       g_list_store_append (G_LIST_STORE (current_ops), task);
       g_object_notify (G_OBJECT (tracker), "current-ops");


### PR DESCRIPTION
Since it's not possible to see the total size of delta updates before they are finished, it's better to not show the total amount at all instead of showing the full app download size.