### PR TITLE
Add "Since" label to world map for context

### DIFF
--- a/src/bz-stats-dialog.blp
+++ b/src/bz-stats-dialog.blp
@@ -55,10 +55,25 @@ template $BzStatsDialog: Adw.Dialog {
           title: _("World");
           icon-name: "globe-symbolic";
 
-          child: $BzWorldMap world_map {
+          child: Box {
+            orientation: vertical;
+            margin-top:10;
+            margin-bottom: 10;
+
+            $BzWorldMap world_map {
               model: bind template.country-model;
-              margin-top:10;
-              margin-bottom: 10;
+              vexpand: true;
+            }
+
+            Label {
+              label: _("Since 4/15/2024");
+              halign: center;
+
+              styles [
+                "dimmed",
+                "caption"
+              ]
+            }
           };
         }
       }


### PR DESCRIPTION
This mirrors what Flathub is doing.

<img width="922" height="794" alt="image" src="https://github.com/user-attachments/assets/2e66beda-8a93-4220-be96-fb62644d60ea" />
