### PR TITLE
(UX) Show open button on search tile after install

### DIFF
--- a/src/bz-rich-app-tile.blp
+++ b/src/bz-rich-app-tile.blp
@@ -160,8 +160,8 @@ template $BzRichAppTile: $BzListTile {
         }
 
         Button {
-          visible: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable) as <bool>) as <bool>;
-          sensitive: bind $invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>;
+          visible: bind $logical_and($invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable) as <bool>) as <bool>, template.removable-at-start) as <bool>;
+          sensitive: bind $logical_and($invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>, template.removable-at-start) as <bool>;
 
           styles [
             "circular"
@@ -172,6 +172,19 @@ template $BzRichAppTile: $BzListTile {
           tooltip-text: _("Uninstall");
           valign: center;
           clicked => $remove_button_clicked_cb(template);
+        }
+
+        Button {
+          visible: bind $logical_and($invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable) as <bool>) as <bool>, $invert_boolean(template.removable-at-start) as <bool>) as <bool>;
+          sensitive: bind $logical_and($invert_boolean($is_zero(template.group as <$BzEntryGroup>.removable-and-available) as <bool>) as <bool>, $invert_boolean(template.removable-at-start) as <bool>) as <bool>;
+
+          styles [
+            "medium-pill",
+          ]
+
+          label: _("Open");
+          valign: center;
+          clicked => $run_button_clicked_cb(template);
         }
       }
     }

--- a/src/bz-rich-app-tile.c
+++ b/src/bz-rich-app-tile.c
@@ -32,6 +32,7 @@ struct _BzRichAppTile
   BzEntryGroup *group;
   BzEntry      *ui_entry;
   DexFuture    *ui_entry_resolve;
+  gboolean      removable_at_start;
 
   GtkWidget *picture_box;
 };
@@ -43,11 +44,11 @@ enum
   PROP_0,
   PROP_GROUP,
   PROP_UI_ENTRY,
+  PROP_REMOVABLE_AT_START,
   LAST_PROP
 };
 
 static GParamSpec *props[LAST_PROP] = { 0 };
-
 
 static void update_ui_entry (BzRichAppTile *self);
 
@@ -122,6 +123,9 @@ bz_rich_app_tile_get_property (GObject    *object,
     case PROP_UI_ENTRY:
       g_value_set_object (value, self->ui_entry);
       break;
+    case PROP_REMOVABLE_AT_START:
+      g_value_set_boolean (value, self->removable_at_start);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -140,6 +144,7 @@ bz_rich_app_tile_set_property (GObject      *object,
       bz_rich_app_tile_set_group (self, g_value_get_object (value));
       break;
     case PROP_UI_ENTRY:
+    case PROP_REMOVABLE_AT_START:
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -191,6 +196,14 @@ remove_button_clicked_cb (BzRichAppTile *self,
 }
 
 static void
+run_button_clicked_cb (BzRichAppTile *self,
+                       GtkButton     *button)
+{
+  gtk_widget_activate_action (GTK_WIDGET (self), "window.launch-group", "s",
+                              bz_entry_group_get_id (self->group));
+}
+
+static void
 bz_rich_app_tile_class_init (BzRichAppTileClass *klass)
 {
   GObjectClass   *object_class = G_OBJECT_CLASS (klass);
@@ -214,6 +227,13 @@ bz_rich_app_tile_class_init (BzRichAppTileClass *klass)
           BZ_TYPE_ENTRY,
           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
+  props[PROP_REMOVABLE_AT_START] =
+      g_param_spec_boolean (
+          "removable-at-start",
+          NULL, NULL,
+          FALSE,
+          G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
+
   g_object_class_install_properties (object_class, LAST_PROP, props);
 
   g_type_ensure (BZ_TYPE_LIST_TILE);
@@ -227,6 +247,7 @@ bz_rich_app_tile_class_init (BzRichAppTileClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, logical_and);
   gtk_widget_class_bind_template_callback (widget_class, install_button_clicked_cb);
   gtk_widget_class_bind_template_callback (widget_class, remove_button_clicked_cb);
+  gtk_widget_class_bind_template_callback (widget_class, run_button_clicked_cb);
   gtk_widget_class_bind_template_child (widget_class, BzRichAppTile, picture_box);
 
   gtk_widget_class_set_accessible_role (widget_class, GTK_ACCESSIBLE_ROLE_BUTTON);
@@ -255,9 +276,10 @@ void
 bz_rich_app_tile_set_group (BzRichAppTile *self,
                             BzEntryGroup  *group)
 {
-  const char *title = NULL;
-  gboolean verified = FALSE;
-  g_autofree char *label = NULL;
+  const char      *title              = NULL;
+  gboolean         verified           = FALSE;
+  gboolean         removable_at_start = FALSE;
+  g_autofree char *label              = NULL;
 
   g_return_if_fail (BZ_IS_RICH_APP_TILE (self));
 
@@ -267,12 +289,19 @@ bz_rich_app_tile_set_group (BzRichAppTile *self,
     {
       self->group = g_object_ref (group);
 
-      title = bz_entry_group_get_title (self->group);
+      title    = bz_entry_group_get_title (self->group);
       verified = bz_entry_group_get_is_verified (self->group);
+
+      removable_at_start = bz_entry_group_get_removable (self->group) != 0;
+      if (self->removable_at_start != removable_at_start)
+        {
+          self->removable_at_start = removable_at_start;
+          g_object_notify_by_pspec (G_OBJECT (self), props[PROP_REMOVABLE_AT_START]);
+        }
 
       if (verified)
         {
-          label = g_strdup_printf ("%s, %s", title, _("Verified"));
+          label = g_strdup_printf ("%s, %s", title, _ ("Verified"));
           gtk_accessible_update_property (GTK_ACCESSIBLE (self),
                                           GTK_ACCESSIBLE_PROPERTY_LABEL, label,
                                           -1);


### PR DESCRIPTION
Users are probably more interested in running the app they just installed than removing it, so it now shows an "Open" button until the search is changed or something.

<img width="1732" height="1576" alt="Screenshot From 2026-03-22 21-36-59" src="https://github.com/user-attachments/assets/7e31dacd-73e3-4cac-8a58-e5df72c391e7" />
