### PR TITLE
chore: build python-babel from tarball

### DIFF
--- a/build-aux/flatpak/io.github.kolunmi.Bazaar.json
+++ b/build-aux/flatpak/io.github.kolunmi.Bazaar.json
@@ -205,25 +205,27 @@
                                 }
                             ]
                         },
-			{
-			    "name": "python3-babel",
-			    "buildsystem": "simple",
-			    "cleanup": ["*"],
-			    "build-commands": [
-				"pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} babel"
-			    ],
-			    "sources": [
-				{
-				    "type": "file",
-				    "url": "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl",
-				    "sha256": "e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35",
-				     "x-checker-data": {
-					"type": "pypi",
-					"name": "babel"
-				    }
-				}
-			    ]
-			},
+                        {
+                            "name": "python3-babel",
+                            "buildsystem": "simple",
+                            "cleanup": [
+                                "*"
+                            ],
+                            "build-commands": [
+                                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} --no-build-isolation babel"
+                            ],
+                            "sources": [
+                                {
+                                    "type": "file",
+                                    "url": "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz",
+                                    "sha256": "b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d",
+                                    "x-checker-data": {
+                                        "type": "pypi",
+                                        "name": "babel"
+                                    }
+                                }
+                            ]
+                        },
                         {
                             "name": "polkit",
                             "buildsystem": "meson",


### PR DESCRIPTION
This needs the --no-build-isolation flag so we can use setuptools from the runtime for the build.

Follow-up of a9b0232cfe.

Fixes build failure here
```
  × installing build dependencies for babel did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      Looking in links: file:///run/build/python3-babel
      ERROR: Could not find a version that satisfies the requirement setuptools>=40.8.0 (from versions: none)
      ERROR: No matching distribution found for setuptools>=40.8.0
      [end of output]
```
https://github.com/flathub/io.github.kolunmi.Bazaar/pull/117
https://github.com/flathub-infra/vorarbeiter/actions/runs/24113632488/job/70353295680