### PR TITLE
Limit search bar max length

### DIFF
--- a/src/bz-library-page.blp
+++ b/src/bz-library-page.blp
@@ -28,6 +28,7 @@ template $BzLibraryPage: Adw.Bin {
 
           Text search_bar {
             hexpand: true;
+            max-length: 50;
             placeholder-text: _("Search installed apps");
             notify::text => $search_text_changed(template);
           }

--- a/src/bz-search-page.blp
+++ b/src/bz-search-page.blp
@@ -54,6 +54,7 @@ template $BzSearchPage: Adw.Bin {
 
             Text search_bar {
               hexpand: true;
+              max-length: 50;
               placeholder-text: _("Search Apps, Games, Software");
             }
 


### PR DESCRIPTION
pasting in a long string would greatly lag or even crash the app.