### PR TITLE
Add support for previewing metainfo files

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -88,6 +88,7 @@ src/bz-license-dialog.h
 src/bz-login-page.blp
 src/bz-login-page.c
 src/bz-login-page.h
+src/bz-metainfo-preview.c
 src/bz-preferences-dialog.blp
 src/bz-preferences-dialog.c
 src/bz-progress-bar.blp

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -28,9 +28,9 @@
 #include <glib/gi18n.h>
 #include <malloc.h>
 
-#include "bz-appstream-parser.h"
 #include "bz-application-map-factory.h"
 #include "bz-application.h"
+#include "bz-appstream-parser.h"
 #include "bz-auth-state.h"
 #include "bz-backend-notification.h"
 #include "bz-content-provider.h"
@@ -434,7 +434,6 @@ bz_application_command_line (GApplication            *app,
   g_auto (GStrv) locations            = NULL;
   gboolean preview_metainfo           = FALSE;
 
-
   GOptionEntry main_entries[] = {
     { "help", 0, 0, G_OPTION_ARG_NONE, &help, "Print help" },
     { "no-window", 0, 0, G_OPTION_ARG_NONE, &no_window, "Ensure the service is running without creating a new window" },
@@ -547,16 +546,17 @@ bz_application_command_line (GApplication            *app,
     command_line_open_location (self, cmdline, locations[0]);
 
   if (preview_metainfo)
-      {
-        g_autoptr (DexFuture) future = NULL;
-        future = bz_metainfo_preview_pick_files ();
-        future = dex_future_then (
-            g_steal_pointer (&future),
-            (DexFutureCallback) preview_metainfo_then,
-            bz_track_weak (self),
-            bz_weak_release);
-        dex_future_disown (g_steal_pointer (&future));
-      }
+    {
+      g_autoptr (DexFuture) future = NULL;
+
+      future = bz_metainfo_preview_pick_files ();
+      future = dex_future_then (
+          g_steal_pointer (&future),
+          (DexFutureCallback) preview_metainfo_then,
+          bz_track_weak (self),
+          bz_weak_release);
+      dex_future_disown (g_steal_pointer (&future));
+    }
 
   return EXIT_SUCCESS;
 }
@@ -1994,7 +1994,8 @@ fiber_replace_entry (BzApplication *self,
       unique_id == NULL ||
       unique_id_checksum == NULL)
     return;
-  user = bz_flatpak_entry_is_user (BZ_FLATPAK_ENTRY (entry));
+
+  user           = bz_flatpak_entry_is_user (BZ_FLATPAK_ENTRY (entry));
   name_to_addons = user ? self->usr_name_to_addons : self->sys_name_to_addons;
 
   installed = g_hash_table_contains (self->installed_set, unique_id);
@@ -2027,12 +2028,12 @@ fiber_replace_entry (BzApplication *self,
 
   if (bz_entry_is_of_kinds (entry, BZ_ENTRY_KIND_APPLICATION))
     {
-      gboolean      ignore_eol              = FALSE;
-      const char   *runtime_name            = NULL;
-      BzEntry      *eol_runtime             = NULL;
-      BzEntryGroup *group                   = NULL;
-      GHashTable   *ref_to_addon_group_ids  = NULL;
-      GPtrArray    *pending                 = NULL;
+      gboolean      ignore_eol             = FALSE;
+      const char   *runtime_name           = NULL;
+      BzEntry      *eol_runtime            = NULL;
+      BzEntryGroup *group                  = NULL;
+      GHashTable   *ref_to_addon_group_ids = NULL;
+      GPtrArray    *pending                = NULL;
 
       if (self->ignore_eol_set != NULL)
         ignore_eol = g_hash_table_contains (self->ignore_eol_set, id);
@@ -2043,9 +2044,10 @@ fiber_replace_entry (BzApplication *self,
 
       group = ensure_group_and_add (self, id, entry, eol_runtime, ignore_eol, installed);
 
-      ref_to_addon_group_ids = user
-          ? self->usr_ref_to_addon_group_ids
-          : self->sys_ref_to_addon_group_ids;
+      ref_to_addon_group_ids =
+          user
+              ? self->usr_ref_to_addon_group_ids
+              : self->sys_ref_to_addon_group_ids;
       pending = g_hash_table_lookup (ref_to_addon_group_ids, id);
       if (pending != NULL)
         {
@@ -2086,8 +2088,8 @@ fiber_replace_entry (BzApplication *self,
       if (extension_of_what != NULL &&
           g_str_has_prefix (extension_of_what, "app/"))
         {
-          g_auto (GStrv) parts     = NULL;
-          BzEntryGroup  *app_group = NULL;
+          g_auto (GStrv) parts    = NULL;
+          BzEntryGroup *app_group = NULL;
 
           ensure_group_and_add (self, id, entry, NULL, FALSE, installed);
 
@@ -2099,10 +2101,11 @@ fiber_replace_entry (BzApplication *self,
                 bz_entry_group_append_addon_group_id (app_group, id);
               else
                 {
-                  GHashTable *ref_to_addon_group_ids = user
-                      ? self->usr_ref_to_addon_group_ids
-                      : self->sys_ref_to_addon_group_ids;
-                  GPtrArray  *pending                = NULL;
+                  GHashTable *ref_to_addon_group_ids =
+                      user
+                          ? self->usr_ref_to_addon_group_ids
+                          : self->sys_ref_to_addon_group_ids;
+                  GPtrArray *pending = NULL;
 
                   pending = g_hash_table_lookup (ref_to_addon_group_ids, parts[1]);
                   if (pending == NULL)
@@ -3016,7 +3019,7 @@ init_service_struct (BzApplication *self,
   self->usr_name_to_addons = g_hash_table_new_full (
       g_str_hash, g_str_equal, g_free, (GDestroyNotify) g_ptr_array_unref);
   self->sys_ref_to_addon_group_ids = g_hash_table_new_full (
-    g_str_hash, g_str_equal, g_free, (GDestroyNotify) g_ptr_array_unref);
+      g_str_hash, g_str_equal, g_free, (GDestroyNotify) g_ptr_array_unref);
   self->usr_ref_to_addon_group_ids = g_hash_table_new_full (
       g_str_hash, g_str_equal, g_free, (GDestroyNotify) g_ptr_array_unref);
 
@@ -3217,12 +3220,12 @@ static DexFuture *
 preview_metainfo_then (DexFuture *future,
                        GWeakRef  *wr)
 {
-  g_autoptr (BzApplication) self   = NULL;
-  g_autoptr (GError) local_error   = NULL;
-  const GValue         *value      = NULL;
-  BzMetainfoPickResult *result     = NULL;
-  g_autoptr (BzEntry) entry        = NULL;
-  GtkWindow            *window     = NULL;
+  g_autoptr (BzApplication) self = NULL;
+  g_autoptr (GError) local_error = NULL;
+  const GValue         *value    = NULL;
+  BzMetainfoPickResult *result   = NULL;
+  g_autoptr (BzEntry) entry      = NULL;
+  GtkWindow *window              = NULL;
 
   bz_weak_get_or_return_reject (self, wr);
 

--- a/src/bz-application.c
+++ b/src/bz-application.c
@@ -28,6 +28,7 @@
 #include <glib/gi18n.h>
 #include <malloc.h>
 
+#include "bz-appstream-parser.h"
 #include "bz-application-map-factory.h"
 #include "bz-application.h"
 #include "bz-auth-state.h"
@@ -50,6 +51,7 @@
 #include "bz-io.h"
 #include "bz-login-page.h"
 #include "bz-malcontent-service.h"
+#include "bz-metainfo-preview.h"
 #include "bz-newline-parser.h"
 #include "bz-parser.h"
 #include "bz-preferences-dialog.h"
@@ -306,6 +308,10 @@ static void
 open_generic_id (BzApplication *self,
                  const char    *generic_id);
 
+static DexFuture *
+preview_metainfo_then (DexFuture *future,
+                       GWeakRef  *wr);
+
 static gpointer
 map_strings_to_files (GtkStringObject *string,
                       gpointer         data);
@@ -426,6 +432,8 @@ bz_application_command_line (GApplication            *app,
   g_auto (GStrv) blocklists_strv      = NULL;
   g_auto (GStrv) content_configs_strv = NULL;
   g_auto (GStrv) locations            = NULL;
+  gboolean preview_metainfo           = FALSE;
+
 
   GOptionEntry main_entries[] = {
     { "help", 0, 0, G_OPTION_ARG_NONE, &help, "Print help" },
@@ -434,6 +442,7 @@ bz_application_command_line (GApplication            *app,
     { "extra-curated-config", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &content_configs_strv, "Add an extra yaml file with which to configure the app browser" },
     /* Here for backwards compat */
     { "extra-content-config", 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &content_configs_strv, "Add an extra yaml file with which to configure the app browser (backwards compat)" },
+    { "preview-metainfo", 0, 0, G_OPTION_ARG_NONE, &preview_metainfo, "Preview a metainfo file by selecting it via file dialog" },
     { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &locations, "flatpakref file to open" },
     { NULL }
   };
@@ -531,11 +540,23 @@ bz_application_command_line (GApplication            *app,
       dex_future_disown (g_steal_pointer (&init));
     }
 
-  if (!no_window)
+  if (!no_window && !preview_metainfo)
     new_window (self);
 
   if (locations != NULL && *locations != NULL)
     command_line_open_location (self, cmdline, locations[0]);
+
+  if (preview_metainfo)
+      {
+        g_autoptr (DexFuture) future = NULL;
+        future = bz_metainfo_preview_pick_files ();
+        future = dex_future_then (
+            g_steal_pointer (&future),
+            (DexFutureCallback) preview_metainfo_then,
+            bz_track_weak (self),
+            bz_weak_release);
+        dex_future_disown (g_steal_pointer (&future));
+      }
 
   return EXIT_SUCCESS;
 }
@@ -3190,6 +3211,45 @@ open_generic_id (BzApplication *self,
       message = g_strdup_printf ("ID '%s' was not found", generic_id);
       bz_show_error_for_widget (GTK_WIDGET (window), _ ("Could not find app"), message);
     }
+}
+
+static DexFuture *
+preview_metainfo_then (DexFuture *future,
+                       GWeakRef  *wr)
+{
+  g_autoptr (BzApplication) self   = NULL;
+  g_autoptr (GError) local_error   = NULL;
+  const GValue         *value      = NULL;
+  BzMetainfoPickResult *result     = NULL;
+  g_autoptr (BzEntry) entry        = NULL;
+  GtkWindow            *window     = NULL;
+
+  bz_weak_get_or_return_reject (self, wr);
+
+  value = dex_future_get_value (future, &local_error);
+  if (value == NULL)
+    return dex_future_new_true ();
+
+  result = g_value_get_boxed (value);
+  window = gtk_application_get_active_window (GTK_APPLICATION (self));
+  if (window == NULL)
+    window = new_window (self);
+
+  entry = bz_appstream_parser_entry_from_metainfo (
+      result->metainfo_file,
+      result->icon_file,
+      &local_error);
+  if (entry == NULL)
+    {
+      bz_show_error_for_widget (GTK_WIDGET (window),
+                                _ ("Failed to load metainfo"),
+                                local_error->message);
+      return dex_future_new_true ();
+    }
+
+  bz_window_show_entry (BZ_WINDOW (window), entry);
+
+  return dex_future_new_true ();
 }
 
 static gpointer

--- a/src/bz-appstream-parser.c
+++ b/src/bz-appstream-parser.c
@@ -14,6 +14,7 @@
 #include "bz-release.h"
 #include "bz-url.h"
 #include "bz-verification-status.h"
+#include "bz-flatpak-entry.h"
 
 static guint
 parse_control_value (const char *value)
@@ -122,7 +123,7 @@ find_screenshot (GPtrArray  *images,
 
       if (match_highest)
         {
-          if (pixels > best_res)
+          if (best_url == NULL || pixels > best_res)
             {
               best_url = url;
               best_res = pixels;
@@ -131,7 +132,7 @@ find_screenshot (GPtrArray  *images,
       else
         {
           gint diff = ABS ((gint) pixels - (gint) target_pixels);
-          if (diff < best_diff)
+          if (best_url == NULL || diff < best_diff)
             {
               best_url  = url;
               best_diff = diff;
@@ -715,4 +716,72 @@ bz_appstream_parser_populate_entry (BzEntry     *entry,
       NULL);
 
   return TRUE;
+}
+
+BzEntry *
+bz_appstream_parser_entry_from_metainfo (GFile   *metainfo_file,
+                                         GFile   *icon_file,
+                                         GError **error)
+{
+  g_autoptr (AsMetadata) mdata  = as_metadata_new ();
+  AsComponent *component        = NULL;
+  g_autofree char *xml_contents = NULL;
+  g_autofree char *xml_path     = NULL;
+  g_autofree char *xml_dir      = NULL;
+  g_autofree char *module_dir   = NULL;
+  g_autofree char *checksum     = NULL;
+  gsize xml_length              = 0;
+  g_autoptr (BzEntry) entry     = NULL;
+
+  g_return_val_if_fail (G_IS_FILE (metainfo_file), NULL);
+
+  xml_path = g_file_get_path (metainfo_file);
+
+  if (!g_file_get_contents (xml_path, &xml_contents, &xml_length, error))
+    return NULL;
+
+  as_metadata_parse_data (mdata, xml_contents, xml_length, AS_FORMAT_KIND_XML, error);
+  if (*error != NULL)
+    return NULL;
+
+  component = as_metadata_get_component (mdata);
+  if (component == NULL)
+    {
+      g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
+                   "No component found in metainfo file");
+      return NULL;
+    }
+
+  xml_dir    = g_path_get_dirname (xml_path);
+  module_dir = bz_dup_module_dir ();
+  checksum   = g_compute_checksum_for_string (G_CHECKSUM_MD5, xml_path, -1);
+
+  entry = BZ_ENTRY (g_object_new (BZ_TYPE_FLATPAK_ENTRY, NULL));
+
+  bz_appstream_parser_populate_entry (
+      entry, component,
+      xml_dir,
+      "local-preview",
+      module_dir,
+      checksum,
+      as_component_get_id (component),
+      BZ_ENTRY_KIND_APPLICATION,
+      NULL);
+
+  g_object_set (entry, "remote-repo-name", "local-preview", NULL);
+
+  if (icon_file != NULL)
+    {
+      g_autoptr (GFile) cache_into = NULL;
+
+      cache_into = g_file_new_build_filename (
+          module_dir, checksum, "icon-paintable.png", NULL);
+
+      g_object_set (
+          entry,
+          "icon-paintable", GDK_PAINTABLE (bz_async_texture_new_lazy (icon_file, cache_into)),
+          NULL);
+    }
+
+  return g_steal_pointer (&entry);
 }

--- a/src/bz-appstream-parser.h
+++ b/src/bz-appstream-parser.h
@@ -36,4 +36,9 @@ gboolean bz_appstream_parser_populate_entry (BzEntry     *entry,
                                              guint        kinds,
                                              GError     **error);
 
+BzEntry *
+bz_appstream_parser_entry_from_metainfo (GFile   *metainfo_file,
+                                         GFile   *icon_file,
+                                         GError **error);
+
 G_END_DECLS

--- a/src/bz-full-view.blp
+++ b/src/bz-full-view.blp
@@ -129,7 +129,16 @@ template $BzFullView: Adw.Bin {
 
                   Adw.Banner {
                     title: _("Installing .flatpak bundles is not yet supported");
-                    revealed: bind template.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.is-bundle as <bool>;
+                    visible: bind template.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.is-bundle as <bool>;
+                    revealed: true;
+                  }
+
+                  Adw.Banner {
+                    title: _("This is a local preview, some details may differ from the published listing");
+                    visible: bind $metainfo_banner_visible(template.ui-entry as <$BzResult>.object as <$BzFlatpakEntry>.remote-repo-name) as <bool>;
+                    revealed: true;
+                    button-label: _("Preview Store Appearance");
+                    button-clicked => $preview_other_metainfo_cb(template);
                   }
 
                   Adw.Clamp {

--- a/src/bz-full-view.c
+++ b/src/bz-full-view.c
@@ -41,6 +41,7 @@
 #include "bz-hardware-support-dialog.h"
 #include "bz-install-controls.h"
 #include "bz-license-dialog.h"
+#include "bz-metainfo-preview.h"
 #include "bz-releases-list.h"
 #include "bz-safety-calculator.h"
 #include "bz-safety-dialog.h"
@@ -54,6 +55,7 @@
 #include "bz-tag-list.h"
 #include "bz-template-callbacks.h"
 #include "bz-util.h"
+#include "bz-window.h"
 
 struct _BzFullView
 {
@@ -577,6 +579,24 @@ get_description_toggle_text (gpointer object,
   return g_strdup (active ? _ ("Show Less") : _ ("Show More"));
 }
 
+static gboolean
+metainfo_banner_visible (gpointer    object,
+                         const char *remote_name)
+{
+  return g_strcmp0 (remote_name, "local-preview") == 0;
+}
+
+static void
+preview_other_metainfo_cb (BzFullView *self,
+                           AdwBanner  *banner)
+{
+  GtkWidget *window = NULL;
+
+  window = GTK_WIDGET (gtk_widget_get_root (GTK_WIDGET (self)));
+  bz_window_push_page (BZ_WINDOW (window),
+                       create_entry_group_preview_page (self->group));
+}
+
 static void
 copy_id_cb (BzFullView *self,
             GtkButton  *button)
@@ -723,6 +743,8 @@ bz_full_view_class_init (BzFullViewClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, unbind_app_tile_cb);
   gtk_widget_class_bind_template_callback (widget_class, get_description_max_height);
   gtk_widget_class_bind_template_callback (widget_class, get_description_toggle_text);
+  gtk_widget_class_bind_template_callback (widget_class, metainfo_banner_visible);
+  gtk_widget_class_bind_template_callback (widget_class, preview_other_metainfo_cb);
   gtk_widget_class_bind_template_callback (widget_class, copy_id_cb);
   gtk_widget_class_bind_template_callback (widget_class, debug_id_inspect_cb);
 }

--- a/src/bz-metainfo-preview.c
+++ b/src/bz-metainfo-preview.c
@@ -1,0 +1,235 @@
+/* bz-metainfo-preview.c
+ *
+ * Copyright 2026 Alexander Vanhee
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+
+#include "bz-entry-group.h"
+#include "bz-featured-carousel.h"
+#include "bz-metainfo-preview.h"
+#include "bz-rich-app-tile.h"
+#include "bz-util.h"
+
+BZ_DEFINE_DATA (
+    pick_files,
+    PickFiles,
+    {
+      DexPromise *promise;
+      GFile      *metainfo_file;
+    },
+    BZ_RELEASE_DATA (promise, dex_unref);
+    BZ_RELEASE_DATA (metainfo_file, g_object_unref))
+
+static void
+on_icon_chosen (GtkFileDialog *dialog,
+                GAsyncResult  *result,
+                PickFilesData *data);
+
+static void
+on_metainfo_chosen (GtkFileDialog *dialog,
+                    GAsyncResult  *result,
+                    DexPromise    *promise);
+
+static BzMetainfoPickResult *
+bz_metainfo_pick_result_copy (BzMetainfoPickResult *result);
+
+GType
+bz_metainfo_pick_result_get_type (void)
+{
+  static GType type = 0;
+
+  if (type == 0)
+    type = g_boxed_type_register_static (
+        "BzMetainfoPickResult",
+        (GBoxedCopyFunc) bz_metainfo_pick_result_copy,
+        (GBoxedFreeFunc) bz_metainfo_pick_result_free);
+  return type;
+}
+
+void
+bz_metainfo_pick_result_free (BzMetainfoPickResult *result)
+{
+  g_clear_object (&result->metainfo_file);
+  g_clear_object (&result->icon_file);
+  g_free (result);
+}
+
+DexFuture *
+bz_metainfo_preview_pick_files (void)
+{
+  g_autoptr (DexPromise) promise   = dex_promise_new ();
+  g_autoptr (GtkFileDialog) dialog = NULL;
+  g_autoptr (GtkFileFilter) filter = NULL;
+  g_autoptr (GListStore) filters   = NULL;
+
+  dialog = gtk_file_dialog_new ();
+  gtk_file_dialog_set_title (dialog, _ ("Select Metainfo File"));
+
+  filter = gtk_file_filter_new ();
+  gtk_file_filter_set_name (filter, _ ("Metainfo Files"));
+  gtk_file_filter_add_pattern (filter, "*.metainfo.xml*");
+  gtk_file_filter_add_pattern (filter, "*.appdata.xml*");
+
+  filters = g_list_store_new (GTK_TYPE_FILE_FILTER);
+  g_list_store_append (filters, filter);
+  gtk_file_dialog_set_filters (dialog, G_LIST_MODEL (filters));
+
+  gtk_file_dialog_open (
+      dialog, NULL, NULL,
+      (GAsyncReadyCallback) on_metainfo_chosen,
+      dex_ref (promise));
+
+  return DEX_FUTURE (g_steal_pointer (&promise));
+}
+
+static BzMetainfoPickResult *
+bz_metainfo_pick_result_copy (BzMetainfoPickResult *result)
+{
+  BzMetainfoPickResult *copy = NULL;
+
+  copy                = g_new0 (BzMetainfoPickResult, 1);
+  copy->metainfo_file = result->metainfo_file ? g_object_ref (result->metainfo_file) : NULL;
+  copy->icon_file     = result->icon_file ? g_object_ref (result->icon_file) : NULL;
+
+  return copy;
+}
+
+static void
+on_metainfo_chosen (GtkFileDialog *dialog,
+                    GAsyncResult  *result,
+                    DexPromise    *promise)
+{
+  g_autoptr (DexPromise) owned_promise  = promise;
+  g_autoptr (GError) local_error        = NULL;
+  g_autoptr (GFile) metainfo_file       = NULL;
+  g_autoptr (GtkFileDialog) icon_dialog = NULL;
+  g_autoptr (GtkFileFilter) filter      = NULL;
+  g_autoptr (GListStore) filters        = NULL;
+  PickFilesData *data                   = NULL;
+
+  metainfo_file = gtk_file_dialog_open_finish (dialog, result, &local_error);
+
+  if (metainfo_file == NULL)
+    {
+      dex_promise_reject (owned_promise, g_steal_pointer (&local_error));
+      return;
+    }
+
+  data                = pick_files_data_new ();
+  data->promise       = g_steal_pointer (&owned_promise);
+  data->metainfo_file = g_steal_pointer (&metainfo_file);
+
+  icon_dialog = gtk_file_dialog_new ();
+  gtk_file_dialog_set_title (icon_dialog, _ ("Select Icon (Optional)"));
+
+  filter = gtk_file_filter_new ();
+  gtk_file_filter_set_name (filter, _ ("Image Files"));
+  gtk_file_filter_add_pattern (filter, "*.png");
+  gtk_file_filter_add_pattern (filter, "*.svg");
+  gtk_file_filter_add_pattern (filter, "*.jpg");
+  gtk_file_filter_add_pattern (filter, "*.jpeg");
+
+  filters = g_list_store_new (GTK_TYPE_FILE_FILTER);
+  g_list_store_append (filters, filter);
+  gtk_file_dialog_set_filters (icon_dialog, G_LIST_MODEL (filters));
+
+  gtk_file_dialog_open (
+      icon_dialog, NULL, NULL,
+      (GAsyncReadyCallback) on_icon_chosen,
+      data);
+}
+
+static void
+on_icon_chosen (GtkFileDialog *dialog,
+                GAsyncResult  *result,
+                PickFilesData *data)
+{
+  g_autoptr (PickFilesData) owned_data = data;
+  g_autoptr (GFile) icon_file          = NULL;
+  BzMetainfoPickResult *pick           = NULL;
+  GValue                value          = G_VALUE_INIT;
+
+  icon_file = gtk_file_dialog_open_finish (dialog, result, NULL);
+
+  pick                = g_new0 (BzMetainfoPickResult, 1);
+  pick->metainfo_file = g_object_ref (owned_data->metainfo_file);
+  pick->icon_file     = g_steal_pointer (&icon_file);
+
+  g_value_init (&value, bz_metainfo_pick_result_get_type ());
+  g_value_take_boxed (&value, pick);
+  dex_promise_resolve (owned_data->promise, &value);
+  g_value_unset (&value);
+}
+
+AdwNavigationPage *
+create_entry_group_preview_page (BzEntryGroup *group)
+{
+  AdwNavigationPage  *page           = NULL;
+  GtkWidget          *toolbar_view   = NULL;
+  AdwHeaderBar       *header_bar     = NULL;
+  GtkBox             *box            = NULL;
+  BzFeaturedCarousel *carousel       = NULL;
+  BzRichAppTile      *tile           = NULL;
+  GtkWidget          *carousel_clamp = NULL;
+  GtkWidget          *tile_clamp     = NULL;
+  GtkWidget          *scroll         = NULL;
+  g_autoptr (GListStore) store       = NULL;
+
+  store = g_list_store_new (BZ_TYPE_ENTRY_GROUP);
+  g_list_store_append (store, group);
+
+  carousel = bz_featured_carousel_new ();
+  bz_featured_carousel_set_model (carousel, G_LIST_MODEL (store));
+  gtk_widget_set_can_target (GTK_WIDGET (carousel), FALSE);
+
+  carousel_clamp = adw_clamp_new ();
+  adw_clamp_set_maximum_size (ADW_CLAMP (carousel_clamp), 1500);
+  adw_clamp_set_tightening_threshold (ADW_CLAMP (carousel_clamp), 1400);
+  adw_clamp_set_child (ADW_CLAMP (carousel_clamp), GTK_WIDGET (carousel));
+
+  tile = BZ_RICH_APP_TILE (bz_rich_app_tile_new ());
+  bz_rich_app_tile_set_group (tile, group);
+
+  tile_clamp = adw_clamp_new ();
+  adw_clamp_set_maximum_size (ADW_CLAMP (tile_clamp), 350);
+  adw_clamp_set_child (ADW_CLAMP (tile_clamp), GTK_WIDGET (tile));
+
+  box = GTK_BOX (gtk_box_new (GTK_ORIENTATION_VERTICAL, 12));
+  gtk_widget_set_margin_top (GTK_WIDGET (box), 24);
+  gtk_widget_set_margin_bottom (GTK_WIDGET (box), 24);
+  gtk_widget_set_margin_start (GTK_WIDGET (box), 24);
+  gtk_widget_set_margin_end (GTK_WIDGET (box), 24);
+  gtk_box_append (box, GTK_WIDGET (carousel_clamp));
+  gtk_box_append (box, GTK_WIDGET (tile_clamp));
+
+  scroll = gtk_scrolled_window_new ();
+  gtk_scrolled_window_set_child (GTK_SCROLLED_WINDOW (scroll), GTK_WIDGET (box));
+  gtk_widget_set_vexpand (scroll, TRUE);
+
+  header_bar   = ADW_HEADER_BAR (adw_header_bar_new ());
+  toolbar_view = adw_toolbar_view_new ();
+  adw_toolbar_view_add_top_bar (ADW_TOOLBAR_VIEW (toolbar_view), GTK_WIDGET (header_bar));
+  adw_toolbar_view_set_content (ADW_TOOLBAR_VIEW (toolbar_view), scroll);
+
+  page = adw_navigation_page_new (toolbar_view, _ ("Preview"));
+
+  return page;
+}

--- a/src/bz-metainfo-preview.c
+++ b/src/bz-metainfo-preview.c
@@ -165,7 +165,6 @@ on_icon_chosen (GtkFileDialog *dialog,
   g_autoptr (PickFilesData) owned_data = data;
   g_autoptr (GFile) icon_file          = NULL;
   BzMetainfoPickResult *pick           = NULL;
-  GValue                value          = G_VALUE_INIT;
 
   icon_file = gtk_file_dialog_open_finish (dialog, result, NULL);
 
@@ -173,10 +172,10 @@ on_icon_chosen (GtkFileDialog *dialog,
   pick->metainfo_file = g_object_ref (owned_data->metainfo_file);
   pick->icon_file     = g_steal_pointer (&icon_file);
 
-  g_value_init (&value, bz_metainfo_pick_result_get_type ());
-  g_value_take_boxed (&value, pick);
-  dex_promise_resolve (owned_data->promise, &value);
-  g_value_unset (&value);
+  dex_promise_resolve_boxed (
+      owned_data->promise,
+      bz_metainfo_pick_result_get_type (),
+      g_steal_pointer (&pick));
 }
 
 AdwNavigationPage *

--- a/src/bz-metainfo-preview.h
+++ b/src/bz-metainfo-preview.h
@@ -1,0 +1,50 @@
+/* bz-metainfo-preview.h
+ *
+ * Copyright 2026 Alexander Vanhee
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#pragma once
+
+#include <adwaita.h>
+#include <gio/gio.h>
+#include <gtk/gtk.h>
+#include <libdex.h>
+
+#include "bz-entry-group.h"
+
+G_BEGIN_DECLS
+
+typedef struct
+{
+  GFile *metainfo_file;
+  GFile *icon_file;
+} BzMetainfoPickResult;
+
+void
+bz_metainfo_pick_result_free (BzMetainfoPickResult *result);
+
+GType
+bz_metainfo_pick_result_get_type (void);
+
+DexFuture *
+bz_metainfo_preview_pick_files (void);
+
+AdwNavigationPage *
+create_entry_group_preview_page (BzEntryGroup *group);
+
+G_END_DECLS

--- a/src/meson.build
+++ b/src/meson.build
@@ -122,6 +122,7 @@ bz_sources = files(
   'bz-login-page.c',
   'bz-lozenge.c',
   'bz-malcontent-service.c',
+  'bz-metainfo-preview.c',
   'bz-newline-parser.c',
   'bz-parser.c',
   'bz-preferences-dialog.c',


### PR DESCRIPTION
Adds a command-line argument that opens two file selection dialogs, allowing the user to choose a metainfo file and optionally an icon file. It then displays a mock app page, including a banner with a button that leads to a basic page showcasing widgets elements that have their branding.

This should make it easier for developers to design their metainfo file based on how it will appear in Bazaar.

The file dialog approach was chosen because I couldn’t figure out a way to pass two different files into the sandbox via launch commands. It’s also a bit more user friendly, I guess.

`flatpak run io.github.kolunmi.Bazaar --preview-metainfo`

<img width="2362" height="1876" alt="image" src="https://github.com/user-attachments/assets/79c68c62-f08a-4886-a9fb-d5b711e2ffc8" />
<img width="2348" height="2060" alt="image" src="https://github.com/user-attachments/assets/0ac2ab17-a51e-46b5-bc01-fb9adb609be8" />
