### PR TITLE
Avoid the EOL abbreviation

### DIFF
--- a/src/bz-preferences-dialog.blp
+++ b/src/bz-preferences-dialog.blp
@@ -46,7 +46,7 @@ template $BzPreferencesDialog: Adw.PreferencesDialog {
       }
 
       Adw.SwitchRow hide_eol_switch {
-        title: _("Hide EOL Apps");
+        title: _("Hide End-of-Life Apps");
         subtitle: _("Hide apps which are no longer supported by their developers");
       }
     }

--- a/src/bz-search-filter-popover.blp
+++ b/src/bz-search-filter-popover.blp
@@ -49,6 +49,7 @@ template $BzSearchFilterPopover: Gtk.Popover {
           label: _("Non-_EOL");
           clicked => $on_filter_button_clicked();
           use-underline: true;
+          tooltip-text: _("Filter out End-of-Life apps");
         }
       }
 


### PR DESCRIPTION
We can't really do that in the search filter popover though, so I added a tooltip at least.