### PR TITLE
Move app of the day title to above the carousel

### DIFF
--- a/src/bz-featured-carousel.c
+++ b/src/bz-featured-carousel.c
@@ -33,7 +33,6 @@ struct _BzFeaturedCarousel
   GtkBox parent_instance;
 
   GListModel *model;
-  gboolean    is_aotd;
 
   guint   rotation_timer_source;
   GTimer *time_since_manual_rotate;
@@ -50,7 +49,6 @@ enum
 {
   PROP_0,
   PROP_MODEL,
-  PROP_IS_AOTD,
   LAST_PROP
 };
 
@@ -224,9 +222,6 @@ bz_featured_carousel_get_property (GObject    *object,
     case PROP_MODEL:
       g_value_set_object (value, bz_featured_carousel_get_model (self));
       break;
-    case PROP_IS_AOTD:
-      g_value_set_boolean (value, bz_featured_carousel_get_is_aotd (self));
-      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -248,9 +243,6 @@ bz_featured_carousel_set_property (GObject      *object,
     case PROP_MODEL:
       bz_featured_carousel_set_model (self, g_value_get_object (value));
       break;
-    case PROP_IS_AOTD:
-      bz_featured_carousel_set_is_aotd (self, g_value_get_boolean (value));
-      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -265,8 +257,6 @@ on_create_widget (BzFeaturedCarousel *self,
   BzFeaturedTile *tile = NULL;
 
   tile = bz_featured_tile_new (group);
-
-  g_object_bind_property (self, "is-aotd", tile, "is-aotd", G_BINDING_SYNC_CREATE);
 
   gtk_widget_set_hexpand (GTK_WIDGET (tile), TRUE);
   gtk_widget_set_vexpand (GTK_WIDGET (tile), TRUE);
@@ -303,11 +293,6 @@ bz_featured_carousel_class_init (BzFeaturedCarouselClass *klass)
       g_param_spec_object ("model", NULL, NULL,
                            G_TYPE_LIST_MODEL,
                            G_PARAM_READWRITE | G_PARAM_EXPLICIT_NOTIFY | G_PARAM_STATIC_STRINGS);
-
-  props[PROP_IS_AOTD] =
-      g_param_spec_boolean ("is-aotd", NULL, NULL,
-                            FALSE,
-                            G_PARAM_READWRITE | G_PARAM_EXPLICIT_NOTIFY | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class, LAST_PROP, props);
 
@@ -373,23 +358,3 @@ bz_featured_carousel_set_model (BzFeaturedCarousel *self,
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_MODEL]);
 }
 
-gboolean
-bz_featured_carousel_get_is_aotd (BzFeaturedCarousel *self)
-{
-  g_return_val_if_fail (BZ_IS_FEATURED_CAROUSEL (self), FALSE);
-  return self->is_aotd;
-}
-
-void
-bz_featured_carousel_set_is_aotd (BzFeaturedCarousel *self,
-                                  gboolean            is_aotd)
-{
-  g_return_if_fail (BZ_IS_FEATURED_CAROUSEL (self));
-
-  if (self->is_aotd == is_aotd)
-    return;
-
-  self->is_aotd = is_aotd;
-
-  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_IS_AOTD]);
-}

--- a/src/bz-featured-carousel.h
+++ b/src/bz-featured-carousel.h
@@ -35,9 +35,4 @@ GListModel *bz_featured_carousel_get_model (BzFeaturedCarousel *self);
 void bz_featured_carousel_set_model (BzFeaturedCarousel *self,
                                      GListModel         *model);
 
-gboolean bz_featured_carousel_get_is_aotd (BzFeaturedCarousel *self);
-
-void bz_featured_carousel_set_is_aotd (BzFeaturedCarousel *self,
-                                       gboolean            is_aotd);
-
 G_END_DECLS

--- a/src/bz-featured-tile.blp
+++ b/src/bz-featured-tile.blp
@@ -69,35 +69,7 @@ template $BzFeaturedTile: Button {
                 "caption",
               ]
             }
-
-            Box {
-              spacing: 4;
-              halign: center;
-              margin-top: 4;
-
-              visible: bind template.is-aotd;
-
-              Image {
-                icon-name: "starred-symbolic";
-                pixel-size: 12;
-              }
-
-              Label {
-                ellipsize: end;
-                xalign: 0.5;
-                lines: 1;
-                justify: center;
-                label: _("App of the Day");
-                wrap: true;
-                wrap-mode: word_char;
-
-                styles [
-                  "caption",
-                ]
-              }
-            }
           }
-
         }
       }
       $BzScreenshot screenshot {

--- a/src/bz-featured-tile.c
+++ b/src/bz-featured-tile.c
@@ -166,7 +166,6 @@ struct _BzFeaturedTile
 
   BzEntryGroup *group;
   gboolean      narrow_mode;
-  gboolean      is_aotd;
   guint         refresh_id;
 
   BzGroupTileCssWatcher *css;
@@ -192,7 +191,6 @@ enum
   PROP_FIRST_SCREENSHOT,
   PROP_HAS_SCREENSHOT,
   PROP_NARROW,
-  PROP_IS_AOTD,
   LAST_PROP
 };
 
@@ -381,9 +379,6 @@ bz_featured_tile_get_property (GObject    *object,
     case PROP_NARROW:
       g_value_set_boolean (value, self->narrow_mode);
       break;
-    case PROP_IS_AOTD:
-      g_value_set_boolean (value, bz_featured_tile_get_is_aotd (self));
-      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -404,9 +399,6 @@ bz_featured_tile_set_property (GObject      *object,
     {
     case PROP_GROUP:
       bz_featured_tile_set_group (self, g_value_get_object (value));
-      break;
-    case PROP_IS_AOTD:
-      bz_featured_tile_set_is_aotd (self, g_value_get_boolean (value));
       break;
     case PROP_FIRST_SCREENSHOT:
     case PROP_HAS_SCREENSHOT:
@@ -449,11 +441,6 @@ bz_featured_tile_class_init (BzFeaturedTileClass *klass)
       g_param_spec_boolean ("narrow", NULL, NULL,
                             FALSE,
                             G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
-
-  props[PROP_IS_AOTD] =
-      g_param_spec_boolean ("is-aotd", NULL, NULL,
-                            FALSE,
-                            G_PARAM_READWRITE | G_PARAM_EXPLICIT_NOTIFY | G_PARAM_STATIC_STRINGS);
 
   g_object_class_install_properties (object_class, LAST_PROP, props);
 
@@ -535,22 +522,3 @@ bz_featured_tile_set_group (BzFeaturedTile *self,
   g_object_notify_by_pspec (G_OBJECT (self), props[PROP_GROUP]);
 }
 
-gboolean
-bz_featured_tile_get_is_aotd (BzFeaturedTile *self)
-{
-  g_return_val_if_fail (BZ_IS_FEATURED_TILE (self), FALSE);
-  return self->is_aotd;
-}
-
-void
-bz_featured_tile_set_is_aotd (BzFeaturedTile *self,
-                              gboolean        is_aotd)
-{
-  g_return_if_fail (BZ_IS_FEATURED_TILE (self));
-
-  if (self->is_aotd == is_aotd)
-    return;
-
-  self->is_aotd = is_aotd;
-  g_object_notify_by_pspec (G_OBJECT (self), props[PROP_IS_AOTD]);
-}

--- a/src/bz-featured-tile.h
+++ b/src/bz-featured-tile.h
@@ -36,9 +36,4 @@ BzEntryGroup *bz_featured_tile_get_group (BzFeaturedTile *self);
 void bz_featured_tile_set_group (BzFeaturedTile *self,
                                  BzEntryGroup   *group);
 
-gboolean bz_featured_tile_get_is_aotd (BzFeaturedTile *self);
-
-void bz_featured_tile_set_is_aotd (BzFeaturedTile *self,
-                                   gboolean        is_aotd);
-
 G_END_DECLS

--- a/src/bz-flathub-page.blp
+++ b/src/bz-flathub-page.blp
@@ -188,13 +188,23 @@ template $BzFlathubPage: Adw.Bin {
                       category: bind $get_category_by_name_cb(template.state as <$BzStateInfo>.flathub as <$BzFlathubState>.categories, "office") as <$BzFlathubCategory>;
                     }
 
-                    $BzFeaturedCarousel {
+                    Label {
+                      styles [
+                        "title-1",
+                      ]
+                      xalign: 0.0;
+                      hexpand: true;
+                      margin-start: 3;
+                      margin-end: 3;
+                      ellipsize: end;
+                      label: _("App of the Day");
+                    }
 
+                    $BzFeaturedCarousel {
                       styles [
                         "flathub-page-section",
                       ]
 
-                      margin-top: 16;
                       margin-bottom: 8;
                       hexpand: true;
 
@@ -203,8 +213,6 @@ template $BzFlathubPage: Adw.Bin {
                         size: 1;
                         model: bind template.state as <$BzStateInfo>.flathub as <$BzFlathubState>.apps_of_the_day_week;
                       };
-
-                      is-aotd: true;
                     }
 
                     $BzFlathubCategorySection section_graphics {


### PR DESCRIPTION
It did not look too hot in the top left, so I moved it outside the widget.

<img width="2590" height="1808" alt="image" src="https://github.com/user-attachments/assets/9f04b15d-b424-4678-83fd-589a8bef35fb" />


Top left one for reference:
<img width="1992" height="1650" alt="Screenshot From 2026-04-12 19-07-57" src="https://github.com/user-attachments/assets/7f815c5d-d268-45d2-b1eb-1907998dd221" />
