### PR TITLE
Make exported desktop search provider app icon sizes adjustable

### DIFF
--- a/src/bz-entry.c
+++ b/src/bz-entry.c
@@ -2343,6 +2343,7 @@ GIcon *
 bz_load_mini_icon_sync (const char *unique_id_checksum,
                         const char *path)
 {
+  guint            icon_size             = 0;
   g_autofree char *main_cache            = NULL;
   g_autoptr (GString) mini_icon_basename = NULL;
   g_autofree char *mini_icon_path        = NULL;
@@ -2356,9 +2357,11 @@ bz_load_mini_icon_sync (const char *unique_id_checksum,
   g_autoptr (GFile) mini_icon_file       = NULL;
   g_autoptr (GIcon) mini_icon            = NULL;
 
+  icon_size = bz_get_desktop_search_provider_icon_size ();
+
   main_cache         = bz_dup_module_dir ();
   mini_icon_basename = g_string_new (unique_id_checksum);
-  g_string_append (mini_icon_basename, "-24x24.png");
+  g_string_append_printf (mini_icon_basename, "-%ux%u.png", icon_size, icon_size);
   mini_icon_path = g_build_filename (main_cache, mini_icon_basename->str, NULL);
 
   if (g_file_test (mini_icon_path, G_FILE_TEST_EXISTS))
@@ -2369,11 +2372,12 @@ bz_load_mini_icon_sync (const char *unique_id_checksum,
   width      = cairo_image_surface_get_width (surface_in);
   height     = cairo_image_surface_get_height (surface_in);
 
-  /* 24x24 for the gnome-shell search provider */
-  surface_out = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, 24, 24);
+  surface_out = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, icon_size, icon_size);
   cairo       = cairo_create (surface_out);
 
-  cairo_scale (cairo, 24.0 / (double) width, 24.0 / (double) height);
+  cairo_scale (cairo,
+               (double) icon_size / (double) width,
+               (double) icon_size / (double) height);
   cairo_set_source_surface (cairo, surface_in, 0, 0);
   cairo_paint (cairo);
   cairo_restore (cairo);

--- a/src/bz-env.c
+++ b/src/bz-env.c
@@ -110,3 +110,46 @@ bz_get_n_download_workers (void)
 
   return n_dl_workers;
 }
+
+guint
+bz_get_desktop_search_provider_icon_size (void)
+{
+  static guint64 icon_size = 0;
+
+  if (g_once_init_enter (&icon_size))
+    {
+      const char *envvar = NULL;
+      guint64     value  = 0;
+
+      /* default 24x24 for the gnome-shell search provider */
+      value = 24;
+
+      envvar = g_getenv ("BAZAAR_DESKTOP_SEARCH_PROVIDER_ICON_SIZE");
+      if (envvar != NULL)
+        {
+          g_autoptr (GError) local_error = NULL;
+          g_autoptr (GVariant) variant   = NULL;
+
+          variant = g_variant_parse (
+              G_VARIANT_TYPE_UINT64, envvar,
+              NULL, NULL, &local_error);
+          if (variant != NULL)
+            {
+              guint64 parse_result = 0;
+
+              parse_result = g_variant_get_uint64 (variant);
+              if (parse_result == 0 || parse_result > 256)
+                g_warning ("BAZAAR_DESKTOP_SEARCH_PROVIDER_ICON_SIZE must be "
+                           "greater than 0 but no greater than 256");
+              else
+                value = parse_result;
+            }
+          else
+            g_warning ("BAZAAR_DESKTOP_SEARCH_PROVIDER_ICON_SIZE is invalid: %s", local_error->message);
+        }
+
+      g_once_init_leave (&icon_size, value);
+    }
+
+  return (guint) icon_size;
+}

--- a/src/bz-env.h
+++ b/src/bz-env.h
@@ -30,4 +30,7 @@ bz_get_dex_stack_size (void);
 guint64
 bz_get_n_download_workers (void);
 
+guint
+bz_get_desktop_search_provider_icon_size (void);
+
 G_END_DECLS


### PR DESCRIPTION
Added a new environment variable `BAZAAR_DESKTOP_SEARCH_PROVIDER_ICON_SIZE` which may be read as an unsigned integer from 1 to 256 to specify the square pixel size of icons sent to the desktop search provider. This should be configured to be a higher value than its default value of 24x24 when on KDE, as krunner paints result icons as much larger than gnome-shell does. This way, the images will not appear blurry as they have historically on KDE.

@renner0e :eyes: 