### PR TITLE
fix(just): build before bundle

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -19,13 +19,14 @@ build-flatpak $manifest=manifest $branch=branch:
     set -xeuo pipefail
     flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
-    FLATPAK_BUILDER_DIR=$(realpath ".flatpak-builder")
+    FLATPAK_BUILDER_DIR="$(realpath ".flatpak-builder")"
     BUILDER_ARGS+=(--default-branch="${branch}")
     BUILDER_ARGS+=(--state-dir="${FLATPAK_BUILDER_DIR}/flatpak-builder")
     BUILDER_ARGS+=("--user")
     BUILDER_ARGS+=("--ccache")
     BUILDER_ARGS+=("--force-clean")
     BUILDER_ARGS+=("--install")
+    BUILDER_ARGS+=("--disable-updates")
     BUILDER_ARGS+=("--disable-rofiles-fuse")
     BUILDER_ARGS+=("${FLATPAK_BUILDER_DIR}/build-dir")
     BUILDER_ARGS+=("${manifest}")
@@ -36,7 +37,12 @@ build-flatpak $manifest=manifest $branch=branch:
         flatpak run org.flatpak.Builder "${BUILDER_ARGS[@]}"
     fi
 
-build-flatpak-bundle $appid=appid:
+build-flatpak-bundle $appid=appid: build-flatpak
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    FLATPAK_BUILDER_DIR="$(realpath ".flatpak-builder")"
+
     flatpak build-export repo "${FLATPAK_BUILDER_DIR}/build-dir"
     flatpak build-bundle repo "${appid}".flatpak "${appid}"
 
@@ -79,5 +85,3 @@ fix:
     done
     echo "Checking syntax: Justfile"
     {{ just }} --unstable --fmt -f Justfile || { exit 1; }
-
-update-flatpak:


### PR DESCRIPTION
build-bundle is gonna fail when you don't build beforehand, we can use disable-updates here which makes iterative building so much faster because we don't update git sources anymore each time.