### PR TITLE
Fix transaction level error reporting

### DIFF
--- a/src/bz-bundle-install-dialog.c
+++ b/src/bz-bundle-install-dialog.c
@@ -538,6 +538,8 @@ install_fiber (GWeakRef *wr)
   g_autoptr (GError) local_error              = NULL;
   g_autoptr (BzTransaction) transaction       = NULL;
   g_autoptr (BzTransactionManager) ts_manager = NULL;
+  gboolean            success                 = FALSE;
+  g_autofree char    *error_message           = NULL;
 
   bz_weak_get_or_return_reject (self, wr);
 
@@ -557,10 +559,18 @@ install_fiber (GWeakRef *wr)
           ts_manager, transaction),
       &local_error);
 
+  g_object_get (transaction,
+                "success", &success,
+                "error", &error_message,
+                NULL);
+
   g_clear_handle_id (&self->pulse_source_id, g_source_remove);
-  if (local_error != NULL)
+  if (local_error != NULL || !success)
     {
-      adw_status_page_set_description (self->error_status, local_error->message);
+      const char *description = local_error != NULL
+                                    ? local_error->message
+                                    : error_message;
+      adw_status_page_set_description (self->error_status, description);
       gtk_stack_set_visible_child_name (self->main_stack, "error");
     }
   else

--- a/src/bz-transaction-manager.c
+++ b/src/bz-transaction-manager.c
@@ -627,12 +627,12 @@ transaction_fiber (QueuedScheduleData *data)
   BzTransaction *transaction            = data->transaction;
   DexPromise    *promise                = data->promise;
   g_autoptr (GError) local_error        = NULL;
-  gboolean result                       = FALSE;
   g_autoptr (GListStore) store          = NULL;
   g_autoptr (DexChannel) channel        = NULL;
   g_autoptr (DexFuture) future          = NULL;
   g_autoptr (GHashTable) op_set         = NULL;
   g_autoptr (GHashTable) pending_set    = NULL;
+  g_autoptr (GHashTable) errored        = NULL;
   GHashTableIter iter                   = { 0 };
 
   bz_weak_get_or_return_reject (self, data->self);
@@ -758,9 +758,20 @@ transaction_fiber (QueuedScheduleData *data)
       bz_transaction_error_out_task (transaction, payload, "Cancelled");
     }
 
-  result = dex_await (g_steal_pointer (&future), &local_error);
-  if (!result)
+  errored = dex_await_boxed (g_steal_pointer (&future), &local_error);
+  if (local_error != NULL)
     return dex_future_new_for_error (g_steal_pointer (&local_error));
+
+  if (errored != NULL && g_hash_table_size (errored) > 0)
+    {
+      GHashTableIter  errored_iter = { 0 };
+      gpointer        key          = NULL;
+      gpointer        val          = NULL;
+
+      g_hash_table_iter_init (&errored_iter, errored);
+      g_hash_table_iter_next (&errored_iter, &key, &val);
+      return dex_future_new_for_error (g_error_copy ((GError *) val));
+    }
 
   return dex_future_new_true ();
 }
@@ -789,9 +800,9 @@ transaction_finally (DexFuture          *future,
       transaction,
       "status", status,
       "progress", 1.0,
-      "finished", TRUE,
       "success", value != NULL,
       "error", local_error != NULL ? local_error->message : NULL,
+      "finished", TRUE,
       NULL);
 
   self->current_progress = 1.0;

--- a/src/bz-transaction.c
+++ b/src/bz-transaction.c
@@ -698,7 +698,11 @@ finish (BzTransactionPrivate *priv)
       bz_transaction_entry_tracker_set_pending (tracker, FALSE);
       if (bz_transaction_entry_tracker_get_status (tracker) == BZ_TRANSACTION_ENTRY_STATUS_CANCELLED)
         continue;
-      bz_transaction_entry_tracker_set_status (tracker, BZ_TRANSACTION_ENTRY_STATUS_DONE);
+      bz_transaction_entry_tracker_set_status (
+          tracker,
+          priv->success
+              ? BZ_TRANSACTION_ENTRY_STATUS_DONE
+              : BZ_TRANSACTION_ENTRY_STATUS_CANCELLED);
     }
 }
 


### PR DESCRIPTION
Most errors are specific to a job, but there are also transaction level errors, most easily seen when not entering a password in a polkit prompt. These were seemingly ignored before, as they were returned as an error hashmap. Now this hashmap gets properly read and set as an error, and the transaction gets also marked as cancelled.

This fixes the issue where the bundle install dialog reports the app as installed when the user did not provide their password, even though the installation did not actually complete.