### PR TITLE
LibraryPage: automatically scroll to top of content on page switch

### DIFF
--- a/src/bz-library-page.c
+++ b/src/bz-library-page.c
@@ -618,7 +618,13 @@ set_page (BzLibraryPage *self)
   else if (n_apps > 0 && n_filtered == 0)
     adw_view_stack_set_visible_child_name (self->stack, "no-results");
   else
-    adw_view_stack_set_visible_child_name (self->stack, "content");
+    {
+      GtkAdjustment *adjustment = NULL;
+
+      adw_view_stack_set_visible_child_name (self->stack, "content");
+      adjustment = gtk_scrolled_window_get_vadjustment (self->scroll);
+      gtk_adjustment_set_value (adjustment, gtk_adjustment_get_lower (adjustment));
+    }
 }
 
 static gboolean


### PR DESCRIPTION
This solves an issue where removing an app would cause cause focus to shift to the beginning of the installed list, which was a bit disorienting. This ensures consistent behavior where the user can immediately see the ongoing progress of the transaction.