### PR TITLE
Ensure runtime remote before bundle install

### DIFF
--- a/src/bz-bundle-install-dialog.blp
+++ b/src/bz-bundle-install-dialog.blp
@@ -178,11 +178,12 @@ template $BzBundleInstallDialog: Adw.BreakpointBin {
 
                   Label {
                     label: _(
-                      "Installing this app requires adding a new software source. Other apps from this source will show up in Bazaar.\n\nOnly add this source if you're sure you trust it."
+                      "Installing this app may require adding a new software source. Other apps from this source will show up in Bazaar.\n\nOnly add this source if you're sure you trust it."
                     );
                     wrap: true;
                     wrap-mode: word_char;
                     halign: start;
+                    margin-bottom: 6;
 
                     styles [
                       "body",

--- a/src/bz-flatpak-instance.c
+++ b/src/bz-flatpak-instance.c
@@ -161,6 +161,12 @@ BZ_DEFINE_DATA (
 static DexFuture *
 list_repositories_fiber (ListReposData *data);
 
+static DexFuture *
+ensure_runtime_remote_fiber (BzFlatpakInstance   *self,
+                             FlatpakInstallation *installation,
+                             const char          *bundle_path,
+                             GCancellable        *cancellable);
+
 BZ_DEFINE_DATA (
     retrieve_refs_for_remote,
     RetrieveRefsForRemote,
@@ -997,7 +1003,8 @@ bz_flatpak_repo_new_from_url (const char   *url,
   name = g_path_get_basename (url);
   {
     char *dot = strrchr (name, '.');
-    if (dot != NULL) *dot = '\0';
+    if (dot != NULL)
+      *dot = '\0';
   }
 
   message = soup_message_new (SOUP_METHOD_GET, url);
@@ -2136,11 +2143,12 @@ list_repositories_fiber (ListReposData *data)
 }
 
 static DexFuture *
-ensure_runtime_remote (BzFlatpakInstance   *self,
-                       FlatpakInstallation *installation,
-                       const char          *bundle_path,
-                       GCancellable        *cancellable)
+ensure_runtime_remote_fiber (BzFlatpakInstance   *self,
+                             FlatpakInstallation *installation,
+                             const char          *bundle_path,
+                             GCancellable        *cancellable)
 {
+  g_autoptr (GError) local_error          = NULL;
   g_autoptr (GFile) bundle_file           = NULL;
   g_autoptr (FlatpakBundleRef) bundle_ref = NULL;
   g_autofree char *runtime_repo_url       = NULL;
@@ -2152,7 +2160,6 @@ ensure_runtime_remote (BzFlatpakInstance   *self,
   g_autoptr (GKeyFile) key_file           = NULL;
   g_autofree char *gpg_key_base64         = NULL;
   g_autoptr (GBytes) gpg_key_bytes        = NULL;
-  g_autoptr (GError) local_error          = NULL;
 
   bundle_file = g_file_new_for_path (bundle_path);
   bundle_ref  = flatpak_bundle_ref_new (bundle_file, NULL);
@@ -2166,7 +2173,8 @@ ensure_runtime_remote (BzFlatpakInstance   *self,
   remote_name = g_path_get_basename (runtime_repo_url);
   {
     char *dot = strrchr (remote_name, '.');
-    if (dot != NULL) *dot = '\0';
+    if (dot != NULL)
+      *dot = '\0';
   }
 
   {
@@ -2185,7 +2193,7 @@ ensure_runtime_remote (BzFlatpakInstance   *self,
       &local_error);
   if (local_error != NULL)
     {
-      g_warning ("ensure_runtime_remote: failed to fetch %s: %s",
+      g_warning ("failed to fetch %s: %s",
                  runtime_repo_url, local_error->message);
       return dex_future_new_true ();
     }
@@ -2202,13 +2210,13 @@ ensure_runtime_remote (BzFlatpakInstance   *self,
   {
     gsize   gpg_key_len  = 0;
     guchar *gpg_key_data = g_base64_decode (gpg_key_base64, &gpg_key_len);
-    gpg_key_bytes = g_bytes_new_take (gpg_key_data, gpg_key_len);
+    gpg_key_bytes        = g_bytes_new_take (gpg_key_data, gpg_key_len);
   }
 
   remote = flatpak_remote_new_from_file (remote_name, bytes, &local_error);
   if (remote == NULL)
     {
-      g_warning ("ensure_runtime_remote: failed to parse flatpakrepo from %s: %s",
+      g_warning ("failed to parse flatpakrepo from %s: %s",
                  runtime_repo_url, local_error->message);
       return dex_future_new_true ();
     }
@@ -2219,7 +2227,7 @@ ensure_runtime_remote (BzFlatpakInstance   *self,
   if (!flatpak_installation_add_remote (
           installation, remote, TRUE, cancellable, &local_error))
     {
-      g_warning ("ensure_runtime_remote: failed to add remote '%s': %s",
+      g_warning ("failed to add remote '%s': %s",
                  remote_name, local_error->message);
       g_clear_error (&local_error);
     }
@@ -2256,8 +2264,8 @@ transaction_fiber (TransactionData *data)
           const char          *bundle_path  = NULL;
           FlatpakInstallation *installation = NULL;
 
-          entry        = g_ptr_array_index (installations, i);
-          bundle_path  = bz_flatpak_entry_get_bundle_path (entry);
+          entry       = g_ptr_array_index (installations, i);
+          bundle_path = bz_flatpak_entry_get_bundle_path (entry);
 
           if (bundle_path == NULL)
             continue;
@@ -2267,9 +2275,9 @@ transaction_fiber (TransactionData *data)
                              : self->system_interactive;
 
           if (bundle_path != NULL && installation != NULL)
-              dex_await (
-                  ensure_runtime_remote (self, installation, bundle_path, cancellable),
-                  NULL);
+            dex_await (
+                ensure_runtime_remote_fiber (self, installation, bundle_path, cancellable),
+                NULL);
         }
 
       for (guint i = 0; i < installations->len; i++)

--- a/src/bz-flatpak-instance.c
+++ b/src/bz-flatpak-instance.c
@@ -981,6 +981,7 @@ bz_flatpak_repo_new_from_url (const char   *url,
   BzFlatpakRepo *repo              = NULL;
   g_autoptr (GError) local_error   = NULL;
   gboolean         result          = FALSE;
+  g_autofree char *name            = NULL;
   g_autofree char *title           = NULL;
   g_autofree char *repo_url        = NULL;
   g_autofree char *homepage        = NULL;
@@ -992,6 +993,12 @@ bz_flatpak_repo_new_from_url (const char   *url,
   g_autofree char *filter          = NULL;
   g_autoptr (GError) bool_error    = NULL;
   gboolean gpg_verify              = FALSE;
+
+  name = g_path_get_basename (url);
+  {
+    char *dot = strrchr (name, '.');
+    if (dot != NULL) *dot = '\0';
+  }
 
   message = soup_message_new (SOUP_METHOD_GET, url);
   output  = g_memory_output_stream_new_resizable ();
@@ -1032,6 +1039,7 @@ bz_flatpak_repo_new_from_url (const char   *url,
     }
 
   repo = g_object_new (BZ_TYPE_FLATPAK_REPO,
+                       "name", name,
                        "title", title,
                        "url", repo_url,
                        "homepage", homepage,
@@ -2128,6 +2136,98 @@ list_repositories_fiber (ListReposData *data)
 }
 
 static DexFuture *
+ensure_runtime_remote (BzFlatpakInstance   *self,
+                       FlatpakInstallation *installation,
+                       const char          *bundle_path,
+                       GCancellable        *cancellable)
+{
+  g_autoptr (GFile) bundle_file           = NULL;
+  g_autoptr (FlatpakBundleRef) bundle_ref = NULL;
+  g_autofree char *runtime_repo_url       = NULL;
+  g_autoptr (SoupMessage) message         = NULL;
+  g_autoptr (GOutputStream) output        = NULL;
+  g_autoptr (GBytes) bytes                = NULL;
+  g_autoptr (FlatpakRemote) remote        = NULL;
+  g_autofree char *remote_name            = NULL;
+  g_autoptr (GKeyFile) key_file           = NULL;
+  g_autofree char *gpg_key_base64         = NULL;
+  g_autoptr (GBytes) gpg_key_bytes        = NULL;
+  g_autoptr (GError) local_error          = NULL;
+
+  bundle_file = g_file_new_for_path (bundle_path);
+  bundle_ref  = flatpak_bundle_ref_new (bundle_file, NULL);
+  if (bundle_ref == NULL)
+    return dex_future_new_true ();
+
+  runtime_repo_url = flatpak_bundle_ref_get_runtime_repo_url (bundle_ref);
+  if (runtime_repo_url == NULL)
+    return dex_future_new_true ();
+
+  remote_name = g_path_get_basename (runtime_repo_url);
+  {
+    char *dot = strrchr (remote_name, '.');
+    if (dot != NULL) *dot = '\0';
+  }
+
+  {
+    g_autoptr (FlatpakRemote) existing = NULL;
+
+    existing = flatpak_installation_get_remote_by_name (
+        installation, remote_name, cancellable, NULL);
+    if (existing != NULL)
+      return dex_future_new_true ();
+  }
+
+  message = soup_message_new (SOUP_METHOD_GET, runtime_repo_url);
+  output  = g_memory_output_stream_new_resizable ();
+  dex_await (
+      bz_send_with_global_http_session_then_splice_into (message, output),
+      &local_error);
+  if (local_error != NULL)
+    {
+      g_warning ("ensure_runtime_remote: failed to fetch %s: %s",
+                 runtime_repo_url, local_error->message);
+      return dex_future_new_true ();
+    }
+
+  bytes    = g_memory_output_stream_steal_as_bytes (G_MEMORY_OUTPUT_STREAM (output));
+  key_file = g_key_file_new ();
+  if (!g_key_file_load_from_bytes (key_file, bytes, G_KEY_FILE_NONE, NULL))
+    return dex_future_new_true ();
+
+  gpg_key_base64 = g_key_file_get_string (key_file, "Flatpak Repo", "GPGKey", NULL);
+  if (gpg_key_base64 == NULL)
+    return dex_future_new_true ();
+
+  {
+    gsize   gpg_key_len  = 0;
+    guchar *gpg_key_data = g_base64_decode (gpg_key_base64, &gpg_key_len);
+    gpg_key_bytes = g_bytes_new_take (gpg_key_data, gpg_key_len);
+  }
+
+  remote = flatpak_remote_new_from_file (remote_name, bytes, &local_error);
+  if (remote == NULL)
+    {
+      g_warning ("ensure_runtime_remote: failed to parse flatpakrepo from %s: %s",
+                 runtime_repo_url, local_error->message);
+      return dex_future_new_true ();
+    }
+
+  flatpak_remote_set_gpg_verify (remote, TRUE);
+  flatpak_remote_set_gpg_key (remote, gpg_key_bytes);
+
+  if (!flatpak_installation_add_remote (
+          installation, remote, TRUE, cancellable, &local_error))
+    {
+      g_warning ("ensure_runtime_remote: failed to add remote '%s': %s",
+                 remote_name, local_error->message);
+      g_clear_error (&local_error);
+    }
+
+  return dex_future_new_true ();
+}
+
+static DexFuture *
 transaction_fiber (TransactionData *data)
 {
   g_autoptr (BzFlatpakInstance) self = NULL;
@@ -2150,6 +2250,28 @@ transaction_fiber (TransactionData *data)
 
   if (installations != NULL)
     {
+      for (guint i = 0; i < installations->len; i++)
+        {
+          BzFlatpakEntry      *entry        = NULL;
+          const char          *bundle_path  = NULL;
+          FlatpakInstallation *installation = NULL;
+
+          entry        = g_ptr_array_index (installations, i);
+          bundle_path  = bz_flatpak_entry_get_bundle_path (entry);
+
+          if (bundle_path == NULL)
+            continue;
+
+          installation = bz_flatpak_entry_is_user (entry)
+                             ? self->user_interactive
+                             : self->system_interactive;
+
+          if (bundle_path != NULL && installation != NULL)
+              dex_await (
+                  ensure_runtime_remote (self, installation, bundle_path, cancellable),
+                  NULL);
+        }
+
       for (guint i = 0; i < installations->len; i++)
         {
           BzFlatpakEntry  *entry                     = NULL;


### PR DESCRIPTION
Bundle installs would fail if the runtime remote was not already added beforehand. Now it gets added automatically if need be (like how already said so in the UI).

`flatpak_remote_new_from_file` does not set GPG verification correctly for some reason... So i had to do it manually. 

The URL below provides a bundle with `gnome-nightly` for the runtimes remote:
https://gitlab.gnome.org/GNOME/gnome-text-editor/-/jobs/6530959/artifacts/download?file_type=archive

Make sure you don't have `gnome-nightly` already when testing.